### PR TITLE
🌱 Bump go version in dependabot workflow 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: Run CI checks
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+  workflow_dispatch:
 
 jobs:
   ci:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main", "release-*" ]
   pull_request:
     branches: [ "main" ]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
   schedule:
     - cron: '45 15 * * *'
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,6 +2,7 @@ name: dependabot
 
 on:
   pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
     branches:
       - dependabot/**
   push:
@@ -20,7 +21,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # tag=v3.5.0
       with:
-        go-version: '=1.20.7'
+        go-version: 1.22.0
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3.3.0

--- a/.github/workflows/e2e-short.yaml
+++ b/.github/workflows/e2e-short.yaml
@@ -2,6 +2,7 @@ name: Run short e2e tests
 
 on:
   pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   e2e:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,7 +2,7 @@ name: golangci-lint
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 # Remove all permissions from GITHUB_TOKEN except metadata.
 permissions: {}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 # Remove all permissions from GITHUB_TOKEN except metadata.
 permissions: {}

--- a/.github/workflows/pr-md-link-check.yaml
+++ b/.github/workflows/pr-md-link-check.yaml
@@ -2,7 +2,7 @@ name: PR check Markdown links
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
     paths:
       - '**.md'
 

--- a/.github/workflows/pr_size_labeler.yml
+++ b/.github/workflows/pr_size_labeler.yml
@@ -1,6 +1,8 @@
 name: PR Size Labeler
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   labeler:

--- a/.github/workflows/pr_type.yaml
+++ b/.github/workflows/pr_type.yaml
@@ -2,12 +2,7 @@ name: PR Type
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
-      - unlabeled
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   check_pull_request_type:

--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -1,6 +1,8 @@
 name: Lint and Test Charts
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 env:
   TAG: v0.0.1

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ "main", "release-*" ]
   pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
     branches: [ "main" ]
   schedule:
     - cron: '37 1 * * *'


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This is a followup on #408, bumping used go version to 1.22, and updating event handlers on all required jobs to always run on dependabot PRs when a push occurs. This is needed to mitigate the issue when the last commit does not trigger changes - https://github.com/orgs/community/discussions/62346

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
![IMG_0307](https://github.com/rancher/turtles/assets/32226600/a1430665-b14f-4ff9-9889-be1260cd353b)

**Special notes for your reviewer**:

**Checklist**:

<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
