### PR TITLE
🐛 Fix repo name in release-workflow.yml GH workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           image: ${{ format('{0}-{1}', vars[inputs.image], inputs.arch) }}
           digest: ${{ needs.build.outputs.digest }}
-          identity: https://github.com/${{ inputs.org }}/rancher-turtles/.github/workflows/release-workflow.yml@${{ github.ref }}
+          identity: https://github.com/${{ inputs.org }}/turtles/.github/workflows/release-workflow.yml@${{ github.ref }}
           oids-issuer: https://token.actions.githubusercontent.com
           registry: ${{ inputs.secret_registry && secrets[inputs.registry] || inputs.registry }}
           username: ${{ inputs.secret_registry && secrets[inputs.username] || inputs.username }}


### PR DESCRIPTION
**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
[Nightly test release](https://github.com/rancher/turtles/actions/runs/8417796108) GH action is failing while[ signing image with cosign](https://github.com/rancher/turtles/actions/runs/8417796108/job/23047003714#step:3:293) since the  
`--certificate-identity` points to `rancher/rancher-turtles` instead of `rancher/turtles` after recent repo move and this PR tries to fix that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
