### PR TITLE
fix: install aws-iam-authenticator

### DIFF
--- a/.github/workflows/run-e2e-suite.yaml
+++ b/.github/workflows/run-e2e-suite.yaml
@@ -58,6 +58,13 @@ jobs:
           tar -xzf eksctl_$PLATFORM.tar.gz -C /tmp && rm eksctl_$PLATFORM.tar.gz
 
           sudo mv /tmp/eksctl /usr/local/bin
+      - name: Install aws-iam-authenticator
+        run: |
+          curl -L -o aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.14/aws-iam-authenticator_0.6.14_linux_amd64
+          chmod +x ./aws-iam-authenticator
+          sudo mv ./aws-iam-authenticator /usr/local/bin
+
+          aws-iam-authenticator version
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

A [recent run](https://github.com/rancher/turtles/actions/runs/8436973843) of the e2e tests failed because the aws-iam-authenticator wasn't installed.  This change adds installation to the workflow.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
