### PR TITLE
🌱 Use calico as alternative to kindnet in e2e tests, and start testing helm chart proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ SKIP_RESOURCE_CLEANUP ?= false
 USE_EXISTING_CLUSTER ?= false
 USE_EKS ?= true
 ISOLATED_MODE ?= false
+CNI ?= calico # alternatively: kindnet
 GINKGO_NOCOLOR ?= false
 GINKGO_LABEL_FILTER ?= short
 GINKGO_TESTS ?= $(ROOT_DIR)/$(TEST_DIR)/e2e/suites/...
@@ -524,7 +525,8 @@ test-e2e: $(GINKGO) $(HELM) $(CLUSTERCTL) kubectl e2e-image ## Run the end-to-en
 	    -e2e.skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) \
 		-e2e.use-existing-cluster=$(USE_EXISTING_CLUSTER) \
 		-e2e.isolated-mode=$(ISOLATED_MODE) \
-		-e2e.use-eks=$(USE_EKS)
+		-e2e.use-eks=$(USE_EKS) \
+		-e2e.cni=$(CNI)
 
 .PHONY: e2e-image
 e2e-image: ## Build the image for e2e tests

--- a/Makefile
+++ b/Makefile
@@ -485,6 +485,9 @@ $(RELEASE_DIR):
 $(CHART_RELEASE_DIR):
 	mkdir -p $(CHART_RELEASE_DIR)/templates
 
+clean-chart-release-dir:
+	rm -rf $(CHART_RELEASE_DIR)
+
 $(CHART_PACKAGE_DIR):
 	mkdir -p $(CHART_PACKAGE_DIR)
 
@@ -493,7 +496,7 @@ release: clean-release $(RELEASE_DIR)  ## Builds and push container images using
 	$(MAKE) release-chart
 
 .PHONY: build-chart
-build-chart: $(HELM) $(KUSTOMIZE) $(RELEASE_DIR) $(CHART_RELEASE_DIR) $(CHART_PACKAGE_DIR) ## Builds the chart to publish with a release
+build-chart: $(HELM) $(KUSTOMIZE) clean-chart-release-dir $(RELEASE_DIR) $(CHART_RELEASE_DIR) $(CHART_PACKAGE_DIR) ## Builds the chart to publish with a release
 	$(KUSTOMIZE) build ./config/chart > $(CHART_DIR)/templates/rancher-turtles-components.yaml
 	cp -rf $(CHART_DIR)/* $(CHART_RELEASE_DIR)
 	sed -i'' -e 's@image: .*@image: '"$(CONTROLLER_IMG)"'@' $(CHART_RELEASE_DIR)/values.yaml

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -74,6 +74,12 @@ var (
 
 	//go:embed data/cluster-templates/vsphere-kubeadm.yaml
 	CAPIvSphereKubeadm []byte
+
+	//go:embed data/cluster-templates/cni-calico.yaml
+	CalicoCNI []byte
+
+	//go:embed data/cluster-templates/cni-kindnet.yaml
+	KindnetCNI []byte
 )
 
 const (

--- a/test/e2e/data/capi-operator/capa-variables.yaml
+++ b/test/e2e/data/capi-operator/capa-variables.yaml
@@ -3,12 +3,16 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: capa-system
+  annotations:
+    "helm.sh/resource-policy": keep
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: full-variables
   namespace: capa-system
+  annotations:
+    "helm.sh/resource-policy": keep
 type: Opaque
 stringData:
   AWS_B64ENCODED_CREDENTIALS: "{{ .AWSEncodedCredentials }}"

--- a/test/e2e/data/capi-operator/capi-providers.yaml
+++ b/test/e2e/data/capi-operator/capi-providers.yaml
@@ -3,12 +3,16 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: capd-system
+  annotations:
+    "helm.sh/resource-policy": keep
 ---
 apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: CAPIProvider
 metadata:
   name: docker
   namespace: capd-system
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   name: docker
   type: infrastructure
@@ -19,12 +23,16 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: capi-kubeadm-bootstrap-system
+  annotations:
+    "helm.sh/resource-policy": keep
 ---
 apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: CAPIProvider
 metadata:
   name: kubeadm-bootstrap
   namespace: capi-kubeadm-bootstrap-system
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   name: kubeadm
   type: bootstrap
@@ -36,15 +44,30 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: capi-kubeadm-control-plane-system
+  annotations:
+    "helm.sh/resource-policy": keep
 ---
 apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: CAPIProvider
 metadata:
   name: kubeadm-control-plane
   namespace: capi-kubeadm-control-plane-system
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   name: kubeadm
   type: controlPlane
   version: v1.4.6
   configSecret:
     name: variables
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: helm
+  namespace: capd-system
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  type: addon
+  name: helm

--- a/test/e2e/data/capi-operator/capv-provider.yaml
+++ b/test/e2e/data/capi-operator/capv-provider.yaml
@@ -4,6 +4,8 @@ kind: CAPIProvider
 metadata:
   name: vsphere
   namespace: capv-system
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   name: vsphere
   type: infrastructure

--- a/test/e2e/data/capi-operator/capv-variables.yaml
+++ b/test/e2e/data/capi-operator/capv-variables.yaml
@@ -3,12 +3,16 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: capv-system
+  annotations:
+    "helm.sh/resource-policy": keep
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: vsphere-variables
   namespace: capv-system
+  annotations:
+    "helm.sh/resource-policy": keep
 type: Opaque
 stringData:
   VSPHERE_USERNAME: "${VSPHERE_USERNAME}"

--- a/test/e2e/data/capi-operator/capz-identity-secret.yaml
+++ b/test/e2e/data/capi-operator/capz-identity-secret.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: capz-system
+  annotations:
+    "helm.sh/resource-policy": keep
 ---
 apiVersion: v1
 stringData:
@@ -11,4 +13,6 @@ kind: Secret
 metadata:
   name: cluster-identity-secret
   namespace: capz-system
+  annotations:
+    "helm.sh/resource-policy": keep
 type: Opaque

--- a/test/e2e/data/capi-operator/full-providers.yaml
+++ b/test/e2e/data/capi-operator/full-providers.yaml
@@ -4,6 +4,8 @@ kind: CAPIProvider
 metadata:
   name: aws
   namespace: capa-system
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   type: infrastructure
   name: aws
@@ -22,6 +24,8 @@ kind: CAPIProvider
 metadata:
   name: azure
   namespace: capz-system
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   type: infrastructure
   name: azure

--- a/test/e2e/data/cluster-templates/cni-calico.yaml
+++ b/test/e2e/data/cluster-templates/cni-calico.yaml
@@ -1,0 +1,28 @@
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cluster-calico-cni
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  clusterSelector:
+    matchLabels:
+      calico: "true"
+  releaseName: calico
+  repoURL: https://docs.tigera.io/calico/charts
+  chartName: tigera-operator
+  namespace: kube-system
+  valuesTemplate: |
+    installation:
+      cni:
+        type: Calico
+        ipam:
+          type: HostLocal
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: None
+          natOutgoing: Enabled
+          nodeSelector: all(){{end}}

--- a/test/e2e/data/cluster-templates/cni-kindnet.yaml
+++ b/test/e2e/data/cluster-templates/cni-kindnet.yaml
@@ -1,0 +1,137 @@
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: ${CLUSTER_NAME}-crs-0
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: ${CLUSTER_NAME}-crs-0
+  resources:
+  - kind: ConfigMap
+    name: cni-${CLUSTER_NAME}-crs-0
+  strategy: ApplyOnce
+---
+apiVersion: v1
+data:
+  kindnet.yaml: |
+    # kindnetd networking manifest
+    ---
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: kindnet
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - list
+          - watch
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+        verbs:
+          - get
+    ---
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: kindnet
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: kindnet
+    subjects:
+      - kind: ServiceAccount
+        name: kindnet
+        namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: kindnet
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: kindnet
+      namespace: kube-system
+      labels:
+        tier: node
+        app: kindnet
+        k8s-app: kindnet
+    spec:
+      selector:
+        matchLabels:
+          app: kindnet
+      template:
+        metadata:
+          labels:
+            tier: node
+            app: kindnet
+            k8s-app: kindnet
+        spec:
+          hostNetwork: true
+          tolerations:
+            - operator: Exists
+              effect: NoSchedule
+          serviceAccountName: kindnet
+          containers:
+            - name: kindnet-cni
+              image: kindest/kindnetd:v20230511-dc714da8
+              env:
+                - name: HOST_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                - name: POD_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.podIP
+                - name: POD_SUBNET
+                  value: '10.1.0.0/16'
+              volumeMounts:
+                - name: cni-cfg
+                  mountPath: /etc/cni/net.d
+                - name: xtables-lock
+                  mountPath: /run/xtables.lock
+                  readOnly: false
+                - name: lib-modules
+                  mountPath: /lib/modules
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "50Mi"
+                limits:
+                  cpu: "100m"
+                  memory: "50Mi"
+              securityContext:
+                privileged: false
+                capabilities:
+                  add: ["NET_RAW", "NET_ADMIN"]
+          volumes:
+            - name: cni-bin
+              hostPath:
+                path: /opt/cni/bin
+                type: DirectoryOrCreate
+            - name: cni-cfg
+              hostPath:
+                path: /etc/cni/net.d
+                type: DirectoryOrCreate
+            - name: xtables-lock
+              hostPath:
+                path: /run/xtables.lock
+                type: FileOrCreate
+            - name: lib-modules
+              hostPath:
+                path: /lib/modules
+kind: ConfigMap
+metadata:
+  name: cni-${CLUSTER_NAME}-crs-0

--- a/test/e2e/data/cluster-templates/docker-kubeadm.yaml
+++ b/test/e2e/data/cluster-templates/docker-kubeadm.yaml
@@ -12,22 +12,18 @@ spec:
       controlPlane: true
     fd3:
       controlPlane: true
-    fd4:
-      controlPlane: false
-    fd5:
-      controlPlane: false
-    fd6:
-      controlPlane: false
-    fd7:
-      controlPlane: false
-    fd8:
-      controlPlane: false
+    fd4: {}
+    fd5: {}
+    fd6: {}
+    fd7: {}
+    fd8: {}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
     cni: ${CLUSTER_NAME}-crs-0
+    calico: "true"
   name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:
@@ -145,139 +141,3 @@ spec:
         kind: DockerMachineTemplate
         name: ${CLUSTER_NAME}-md-0
       version: ${KUBERNETES_VERSION}
----
-apiVersion: addons.cluster.x-k8s.io/v1beta1
-kind: ClusterResourceSet
-metadata:
-  name: ${CLUSTER_NAME}-crs-0
-spec:
-  clusterSelector:
-    matchLabels:
-      cni: ${CLUSTER_NAME}-crs-0
-  resources:
-  - kind: ConfigMap
-    name: cni-${CLUSTER_NAME}-crs-0
-  strategy: ApplyOnce
----
-apiVersion: v1
-data:
-  kindnet.yaml: |
-    # kindnetd networking manifest
-    ---
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: kindnet
-    rules:
-      - apiGroups:
-          - ""
-        resources:
-          - nodes
-        verbs:
-          - list
-          - watch
-          - patch
-      - apiGroups:
-          - ""
-        resources:
-          - configmaps
-        verbs:
-          - get
-    ---
-    kind: ClusterRoleBinding
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: kindnet
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: kindnet
-    subjects:
-      - kind: ServiceAccount
-        name: kindnet
-        namespace: kube-system
-    ---
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: kindnet
-      namespace: kube-system
-    ---
-    apiVersion: apps/v1
-    kind: DaemonSet
-    metadata:
-      name: kindnet
-      namespace: kube-system
-      labels:
-        tier: node
-        app: kindnet
-        k8s-app: kindnet
-    spec:
-      selector:
-        matchLabels:
-          app: kindnet
-      template:
-        metadata:
-          labels:
-            tier: node
-            app: kindnet
-            k8s-app: kindnet
-        spec:
-          hostNetwork: true
-          tolerations:
-            - operator: Exists
-              effect: NoSchedule
-          serviceAccountName: kindnet
-          containers:
-            - name: kindnet-cni
-              image: kindest/kindnetd:v20230511-dc714da8
-              env:
-                - name: HOST_IP
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: status.hostIP
-                - name: POD_IP
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: status.podIP
-                - name: POD_SUBNET
-                  value: '10.1.0.0/16'
-              volumeMounts:
-                - name: cni-cfg
-                  mountPath: /etc/cni/net.d
-                - name: xtables-lock
-                  mountPath: /run/xtables.lock
-                  readOnly: false
-                - name: lib-modules
-                  mountPath: /lib/modules
-                  readOnly: true
-              resources:
-                requests:
-                  cpu: "100m"
-                  memory: "50Mi"
-                limits:
-                  cpu: "100m"
-                  memory: "50Mi"
-              securityContext:
-                privileged: false
-                capabilities:
-                  add: ["NET_RAW", "NET_ADMIN"]
-          volumes:
-            - name: cni-bin
-              hostPath:
-                path: /opt/cni/bin
-                type: DirectoryOrCreate
-            - name: cni-cfg
-              hostPath:
-                path: /etc/cni/net.d
-                type: DirectoryOrCreate
-            - name: xtables-lock
-              hostPath:
-                path: /run/xtables.lock
-                type: FileOrCreate
-            - name: lib-modules
-              hostPath:
-                path: /lib/modules
-kind: ConfigMap
-metadata:
-  name: cni-${CLUSTER_NAME}-crs-0

--- a/test/e2e/flags.go
+++ b/test/e2e/flags.go
@@ -54,6 +54,9 @@ type FlagValues struct {
 
 	// ClusterctlBinaryPath is the path to the clusterctl binary to use.
 	ClusterctlBinaryPath string
+
+	// CNI for the cluster to use. Values include calico or kindnet.
+	CNI string
 }
 
 // InitFlags is used to specify the standard flags for the e2e tests.
@@ -68,4 +71,5 @@ func InitFlags(values *FlagValues) {
 	flag.StringVar(&values.ClusterctlBinaryPath, "e2e.clusterctl-binary-path", "helm", "path to the clusterctl binary")
 	flag.StringVar(&values.ChartPath, "e2e.chart-path", "", "path to the operator chart")
 	flag.BoolVar(&values.IsolatedMode, "e2e.isolated-mode", false, "if true, the test will run without ngrok and exposing the cluster to the internet. This setup will only work with CAPD or other providers that run in the same network as the bootstrap cluster.")
+	flag.StringVar(&values.CNI, "e2e.cni", "calico", "specify CNI solution for the cluster. Allowed values: calico, kindnet")
 }

--- a/test/e2e/specs/import_gitops.go
+++ b/test/e2e/specs/import_gitops.go
@@ -58,6 +58,8 @@ type CreateUsingGitOpsSpecInput struct {
 	ClusterName                 string
 	AdditionalTemplateVariables map[string]string
 
+	CNITemplate []byte
+
 	CAPIClusterCreateWaitName string
 	DeleteClusterWaitName     string
 
@@ -183,6 +185,16 @@ func CreateUsingGitOpsSpec(ctx context.Context, inputGetter func() CreateUsingGi
 			OutputFilePath:                clusterPath,
 			AddtionalEnvironmentVariables: additionalVars,
 		})).To(Succeed())
+
+		if input.CNITemplate != nil {
+			cniPath := filepath.Join(clustersDir, fmt.Sprintf("%s-cni.yaml", input.ClusterName))
+			Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+				Getter:                        input.E2EConfig.GetVariable,
+				Template:                      input.CNITemplate,
+				OutputFilePath:                cniPath,
+				AddtionalEnvironmentVariables: additionalVars,
+			})).To(Succeed())
+		}
 
 		fleetPath := filepath.Join(clustersDir, "fleet.yaml")
 		turtlesframework.FleetCreateFleetFile(ctx, turtlesframework.FleetCreateFleetFileInput{

--- a/test/e2e/specs/import_gitops_mgmtv3.go
+++ b/test/e2e/specs/import_gitops_mgmtv3.go
@@ -58,6 +58,8 @@ type CreateMgmtV3UsingGitOpsSpecInput struct {
 	ClusterName                 string
 	AdditionalTemplateVariables map[string]string
 
+	CNITemplate []byte
+
 	CAPIClusterCreateWaitName string
 	DeleteClusterWaitName     string
 
@@ -188,6 +190,16 @@ func CreateMgmtV3UsingGitOpsSpec(ctx context.Context, inputGetter func() CreateM
 			OutputFilePath:                clusterPath,
 			AddtionalEnvironmentVariables: additionalVars,
 		})).To(Succeed())
+
+		if input.CNITemplate != nil {
+			cniPath := filepath.Join(clustersDir, fmt.Sprintf("%s-cni.yaml", input.ClusterName))
+			Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+				Getter:                        input.E2EConfig.GetVariable,
+				Template:                      input.CNITemplate,
+				OutputFilePath:                cniPath,
+				AddtionalEnvironmentVariables: additionalVars,
+			})).To(Succeed())
+		}
 
 		fleetPath := filepath.Join(clustersDir, "fleet.yaml")
 		turtlesframework.FleetCreateFleetFile(ctx, turtlesframework.FleetCreateFleetFileInput{

--- a/test/e2e/suites/embedded-capi-disabled/embedded_capi_disabled_test.go
+++ b/test/e2e/suites/embedded-capi-disabled/embedded_capi_disabled_test.go
@@ -37,6 +37,10 @@ var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster functionality shoul
 	})
 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
+		cni := e2e.KindnetCNI
+		if flagVals.CNI == "calico" {
+			cni = e2e.CalicoCNI
+		}
 		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                 e2eConfig,
 			BootstrapClusterProxy:     setupClusterResult.BootstrapClusterProxy,
@@ -45,7 +49,7 @@ var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster functionality shoul
 			ArtifactFolder:            flagVals.ArtifactFolder,
 			ClusterTemplate:           e2e.CAPIAwsEKSMMP,
 			ClusterName:               "highlander-e2e-cluster1",
-			CNITemplate:               e2e.CalicoCNI,
+			CNITemplate:               cni,
 			ControlPlaneMachineCount:  ptr.To[int](1),
 			WorkerMachineCount:        ptr.To[int](1),
 			GitAddr:                   giteaResult.GitAddress,

--- a/test/e2e/suites/embedded-capi-disabled/embedded_capi_disabled_test.go
+++ b/test/e2e/suites/embedded-capi-disabled/embedded_capi_disabled_test.go
@@ -45,6 +45,7 @@ var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster functionality shoul
 			ArtifactFolder:            flagVals.ArtifactFolder,
 			ClusterTemplate:           e2e.CAPIAwsEKSMMP,
 			ClusterName:               "highlander-e2e-cluster1",
+			CNITemplate:               e2e.CalicoCNI,
 			ControlPlaneMachineCount:  ptr.To[int](1),
 			WorkerMachineCount:        ptr.To[int](1),
 			GitAddr:                   giteaResult.GitAddress,

--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -48,6 +48,7 @@ var _ = Describe("[Docker] [Kubeadm] Create and delete CAPI cluster functionalit
 			ArtifactFolder:            flagVals.ArtifactFolder,
 			ClusterTemplate:           e2e.CAPIDockerKubeadm,
 			ClusterName:               "highlander-e2e-cluster1",
+			CNITemplate:               e2e.CalicoCNI,
 			ControlPlaneMachineCount:  ptr.To[int](1),
 			WorkerMachineCount:        ptr.To[int](1),
 			GitAddr:                   giteaResult.GitAddress,

--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -40,6 +40,10 @@ var _ = Describe("[Docker] [Kubeadm] Create and delete CAPI cluster functionalit
 	})
 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
+		cni := e2e.KindnetCNI
+		if flagVals.CNI == "calico" {
+			cni = e2e.CalicoCNI
+		}
 		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                 e2eConfig,
 			BootstrapClusterProxy:     setupClusterResult.BootstrapClusterProxy,
@@ -48,7 +52,7 @@ var _ = Describe("[Docker] [Kubeadm] Create and delete CAPI cluster functionalit
 			ArtifactFolder:            flagVals.ArtifactFolder,
 			ClusterTemplate:           e2e.CAPIDockerKubeadm,
 			ClusterName:               "highlander-e2e-cluster1",
-			CNITemplate:               e2e.CalicoCNI,
+			CNITemplate:               cni,
 			ControlPlaneMachineCount:  ptr.To[int](1),
 			WorkerMachineCount:        ptr.To[int](1),
 			GitAddr:                   giteaResult.GitAddress,

--- a/test/e2e/suites/managementv3/managementv3_test.go
+++ b/test/e2e/suites/managementv3/managementv3_test.go
@@ -36,6 +36,10 @@ var _ = Describe("[Docker] [Kubeadm] - [management.cattle.io/v3] Create and dele
 	})
 
 	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+		cni := e2e.KindnetCNI
+		if flagVals.CNI == "calico" {
+			cni = e2e.CalicoCNI
+		}
 		return specs.CreateMgmtV3UsingGitOpsSpecInput{
 			E2EConfig:                      e2eConfig,
 			BootstrapClusterProxy:          setupClusterResult.BootstrapClusterProxy,
@@ -44,7 +48,7 @@ var _ = Describe("[Docker] [Kubeadm] - [management.cattle.io/v3] Create and dele
 			ArtifactFolder:                 flagVals.ArtifactFolder,
 			ClusterTemplate:                e2e.CAPIDockerKubeadm,
 			ClusterName:                    "highlander-e2e-clusterv3-1",
-			CNITemplate:                    e2e.CalicoCNI,
+			CNITemplate:                    cni,
 			ControlPlaneMachineCount:       ptr.To[int](1),
 			WorkerMachineCount:             ptr.To[int](1),
 			GitAddr:                        giteaResult.GitAddress,

--- a/test/e2e/suites/managementv3/managementv3_test.go
+++ b/test/e2e/suites/managementv3/managementv3_test.go
@@ -44,6 +44,7 @@ var _ = Describe("[Docker] [Kubeadm] - [management.cattle.io/v3] Create and dele
 			ArtifactFolder:                 flagVals.ArtifactFolder,
 			ClusterTemplate:                e2e.CAPIDockerKubeadm,
 			ClusterName:                    "highlander-e2e-clusterv3-1",
+			CNITemplate:                    e2e.CalicoCNI,
 			ControlPlaneMachineCount:       ptr.To[int](1),
 			WorkerMachineCount:             ptr.To[int](1),
 			GitAddr:                        giteaResult.GitAddress,

--- a/test/testenv/cleanup.go
+++ b/test/testenv/cleanup.go
@@ -74,7 +74,7 @@ func CollectArtifacts(ctx context.Context, kubeconfigPath, name string, args ...
 		return fmt.Errorf("Unable to collect artifacts: kubeconfig path is empty")
 	}
 
-	aargs := append([]string{"crust-gather", "collect", "--kubeconfig", kubeconfigPath, "-f", name}, args...)
+	aargs := append([]string{"crust-gather", "collect", "-v", "ERROR", "--kubeconfig", kubeconfigPath, "-f", name}, args...)
 	for _, secret := range secrets {
 		aargs = append(aargs, "-s", secret)
 	}

--- a/test/testenv/turtles.go
+++ b/test/testenv/turtles.go
@@ -23,11 +23,14 @@ import (
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	opframework "sigs.k8s.io/cluster-api-operator/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	turtlesframework "github.com/rancher/turtles/test/framework"
+	turtlesv1 "github.com/rancher-sandbox/rancher-turtles/api/v1alpha1"
+	turtlesframework "github.com/rancher-sandbox/rancher-turtles/test/framework"
 )
 
 type DeployRancherTurtlesInput struct {
@@ -129,6 +132,25 @@ func DeployRancherTurtles(ctx context.Context, input DeployRancherTurtlesInput) 
 		Getter: input.BootstrapClusterProxy.GetClient(),
 		Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
 			Name:      "capd-controller-manager",
+			Namespace: "capd-system",
+		}},
+	}, input.WaitDeploymentsReadyInterval...)
+
+	key := client.ObjectKey{
+		Namespace: "capd-system",
+		Name:      "helm",
+	}
+	if err := input.BootstrapClusterProxy.GetClient().Get(ctx, key, &turtlesv1.CAPIProvider{}); apierrors.IsNotFound(err) {
+		return
+	}
+
+	Expect(err).ToNot(HaveOccurred())
+
+	By("Waiting for CAPI helm provider deployment to be available")
+	framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
+		Getter: input.BootstrapClusterProxy.GetClient(),
+		Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Name:      "caaph-controller-manager",
 			Namespace: "capd-system",
 		}},
 	}, input.WaitDeploymentsReadyInterval...)

--- a/test/testenv/turtles.go
+++ b/test/testenv/turtles.go
@@ -29,8 +29,8 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	turtlesv1 "github.com/rancher-sandbox/rancher-turtles/api/v1alpha1"
-	turtlesframework "github.com/rancher-sandbox/rancher-turtles/test/framework"
+	turtlesv1 "github.com/rancher/turtles/api/v1alpha1"
+	turtlesframework "github.com/rancher/turtles/test/framework"
 )
 
 type DeployRancherTurtlesInput struct {


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This PR provides alternative to kindnet network setup with calico. In my environment it is needed to make the local tests pass.

Additionally this introduces tests for helm addon provider as means for installing Calico CNI in the child cluster.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
