### PR TITLE
Fix nightly release CI job

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -99,7 +99,7 @@ jobs:
       actions: read
       id-token: write
       packages: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.9.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
     with:
       digest: ${{ needs.build.outputs.digest }}
       image: ${{ format('{0}-{1}', vars[inputs.image], inputs.arch) }}

--- a/.github/workflows/release_sign/action.yaml
+++ b/.github/workflows/release_sign/action.yaml
@@ -43,7 +43,7 @@ runs:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
-    - uses: sigstore/cosign-installer@v3.1.2
+    - uses: sigstore/cosign-installer@v3.4.0
     - name: Sign manifests
       shell: bash
       env:


### PR DESCRIPTION
Nightly release [jobs](https://github.com/rancher/turtles/actions/runs/8515988902) failing due to the [bug](https://github.com/slsa-framework/slsa-github-generator/issues/1163) in the version of slsa-GH generator used (v1.9.0) and this patch updates it to new version: v1.10.0

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
