### PR TITLE
feat: add label propagation

### DIFF
--- a/charts/rancher-turtles/questions.yml
+++ b/charts/rancher-turtles/questions.yml
@@ -58,3 +58,9 @@ questions:
     description: "Flag to enable or disable installation of the RKE2 provider for Cluster API. By default this is enabled."
     label: "Enable RKE2 Provider"
     type: boolean
+  - variable: rancherTurtles.features.propagate-labels.enabled
+    default: false
+    description: "(Experimental) Specify that the labels from CAPI should be propagated to Rancher"
+    type: boolean
+    label: Propagate CAPI Labels
+    group: "Rancher Turtles Features Settings"

--- a/charts/rancher-turtles/templates/deployment.yaml
+++ b/charts/rancher-turtles/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - args:
         - --leader-elect
-        - --feature-gates=managementv3-cluster={{ index .Values "rancherTurtles" "features" "managementv3-cluster" "enabled"}},rancher-kube-secret-patch={{ index .Values "rancherTurtles" "features" "rancher-kubeconfigs" "label"}}
+        - --feature-gates=propagate-labels={{ index .Values "rancherTurtles" "features" "propagate-labels" "enabled"}},managementv3-cluster={{ index .Values "rancherTurtles" "features" "managementv3-cluster" "enabled"}},rancher-kube-secret-patch={{ index .Values "rancherTurtles" "features" "rancher-kubeconfigs" "label"}}
         {{- range .Values.rancherTurtles.managerArguments }}
         - {{ . }}
         {{- end }}  

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -18,6 +18,8 @@ rancherTurtles:
       label: true
     managementv3-cluster:
       enabled: false
+    propagate-labels:
+      enabled: false
 cluster-api-operator:
   enabled: true
   cert-manager:

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -28,6 +28,10 @@ const (
 
 	// ManagementV3Cluster is used to enable the management.cattle.io/v3 cluster resource.
 	ManagementV3Cluster featuregate.Feature = "managementv3-cluster" //nolint:gosec
+
+	// PropagateLabels is used to enable copying the labels from the CAPI cluster
+	// to the Rancher cluster.
+	PropagateLabels featuregate.Feature = "propagate-labels"
 )
 
 func init() {
@@ -37,4 +41,5 @@ func init() {
 var defaultGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	RancherKubeSecretPatch: {Default: false, PreRelease: featuregate.Beta},
 	ManagementV3Cluster:    {Default: false, PreRelease: featuregate.Beta},
+	PropagateLabels:        {Default: false, PreRelease: featuregate.Beta},
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This change adds an experimental feature that when enabled will copy the labels from the CAPI Cluster to the created Rancher Cluster resource.

By copying the labels it allows "cluster groups" to be easily used to automatically deploy applications to CAPI created clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #461 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
