### PR TITLE
chore: add tags to eks resources

### DIFF
--- a/test/testenv/eksctl_provider.go
+++ b/test/testenv/eksctl_provider.go
@@ -71,6 +71,8 @@ func (k *EKSClusterProvider) Create(ctx context.Context) {
 			k.region,
 			"--kubeconfig",
 			tempFile.Name(),
+			"--tags",
+			"team=highlander,purpose=e2e",
 		},
 	}, createClusterRes)
 	Expect(createClusterRes.Error).NotTo(HaveOccurred(), "Failed to create cluster using eksctl: %s", createClusterRes.Stderr)


### PR DESCRIPTION
**What this PR does / why we need it**:

This change adds tags to the resources created by eksctl for the following reasons:

- identify which team owns the resources
- aid automatic clean-up of the resources

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] adds or updates e2e tests
