### PR TITLE
:seedling: chore: update references to documentation site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing Guidelines
 
-Please check our Contributing Guide [here](https://docs.rancher-turtles.com/docs/contributing/intro).
+Please check our Contributing Guide [here](https://turtles.docs.rancher.com/docs/contributing/intro).

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Currently, this project has the following functionality:
 
 ## Installation & Usage
 
-Rancher Turtles is deployed using a Helm Chart. For instructions, see the [getting started guide](https://docs.rancher-turtles.com/docs/category/getting-started).
+Rancher Turtles is deployed using a Helm Chart. For instructions, see the [getting started guide](https://turtles.docs.rancher.com/docs/category/getting-started).
 
 ## Documentation
 
-Configuration steps, the quickstart guide and the architecture for this project can be found in our [documentation](https://docs.rancher-turtles.com/).
+Configuration steps, the quickstart guide and the architecture for this project can be found in our [documentation](https://turtles.docs.rancher.com).
 
 ## How to contribute?
 

--- a/charts/rancher-turtles/README.md
+++ b/charts/rancher-turtles/README.md
@@ -2,4 +2,4 @@
 
 This chart installs the Rancher Turtles operator and optionally the Cluster API Operator using Helm.
 
-Checkout the [documentation](https://docs.rancher-turtles.com) for further information.
+Checkout the [documentation](https://turtles.docs.rancher.com) for further information.

--- a/charts/rancher-turtles/app-readme.md
+++ b/charts/rancher-turtles/app-readme.md
@@ -2,4 +2,4 @@
 
 Rancher Turtles brings enhanced integration of Cluster API with Rancher.
 
-For more information, including a getting started guide, see the [official documentation](https://docs.rancher-turtles.com).
+For more information, including a getting started guide, see the [official documentation](https://turtles.docs.rancher.com).


### PR DESCRIPTION
### Blocked until https://github.com/rancher/turtles-docs/pull/70 is merged.

**What this PR does / why we need it**:

Documentation is now available at turtles.docs.rancher.com and this PR updates any references to the old URL.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**This is waiting for https://github.com/rancher/turtles-docs/pull/70 to be merged**, when the new site will become available and the old one deprecated.

**Checklist**:

- [x] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
