### PR TITLE
:seedling: chore: cover uninstall in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ GINGKO_VER := $(call get_go_version,github.com/onsi/ginkgo/v2)
 GINKGO := $(abspath $(TOOLS_BIN_DIR)/$(GINKGO_BIN)-$(GINGKO_VER))
 GINKGO_PKG := github.com/onsi/ginkgo/v2/ginkgo
 
-HELM_VER := v3.8.1
+HELM_VER := v3.14.0
 HELM_BIN := helm
 HELM := $(TOOLS_BIN_DIR)/$(HELM_BIN)-$(HELM_VER)
 

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -23,6 +23,7 @@ intervals:
   default/wait-vsphere-delete: ["20m", "30s"]
   default/wait-gitea-service: ["5m", "30s"]
   default/wait-gitea-uninstall: ["10m", "30s"]
+  default/wait-turtles-uninstall: ["10m", "30s"]
 
 variables:
   RANCHER_VERSION: "v2.8.1"

--- a/test/e2e/suites/import-gitops/suite_test.go
+++ b/test/e2e/suites/import-gitops/suite_test.go
@@ -326,6 +326,13 @@ var _ = AfterSuite(func() {
 		DeleteWaitInterval:    e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea-uninstall"),
 	})
 
+	testenv.UninstallRancherTurtles(ctx, testenv.UninstallRancherTurtlesInput{
+		BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+		HelmBinaryPath:        flagVals.HelmBinaryPath,
+		Namespace:             turtlesframework.DefaultRancherTurtlesNamespace,
+		DeleteWaitInterval:    e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-turtles-uninstall"),
+	})
+
 	testenv.CleanupTestCluster(ctx, testenv.CleanupTestClusterInput{
 		SetupTestClusterResult: *setupClusterResult,
 		SkipCleanup:            flagVals.SkipCleanup,


### PR DESCRIPTION
**What this PR does / why we need it**:

After running the `import-gitops` test suite, we verify that `helm uninstall` works on Turtles. This also upgrades Helm to `v3.14.0`, as `v3.8.1` was failing to detect the `--cascade` flag.

**Which issue(s) this PR fixes**:
Fixes #410 

**Special notes for your reviewer**:

The uninstall of Turtles may fail unexpectedly due to a problem with the CAPI Operator Helm chart and CRDs being deleted in such a way that doesn't guarantee the order and may end up in a deadlock caused by a finalizer that is never removed.

**Note**: perhaps we should wait to have this sorted out before merging this change and having the uninstall step as part of the E2E tests.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
