### PR TITLE
:seedling: cover cluster reimport after running e2e

### DIFF
--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -33,7 +33,6 @@ import (
 )
 
 var _ = Describe("[Docker] [Kubeadm] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.ShortTestLabel), func() {
-
 	BeforeEach(func() {
 		SetClient(setupClusterResult.BootstrapClusterProxy.GetClient())
 		SetContext(ctx)
@@ -55,6 +54,7 @@ var _ = Describe("[Docker] [Kubeadm] Create and delete CAPI cluster functionalit
 			SkipCleanup:               false,
 			SkipDeletionTest:          false,
 			LabelNamespace:            true,
+			TestClusterReimport:       true,
 			RancherServerURL:          hostName,
 			CAPIClusterCreateWaitName: "wait-rancher",
 			DeleteClusterWaitName:     "wait-controllers",

--- a/test/e2e/suites/managementv3/managementv3_test.go
+++ b/test/e2e/suites/managementv3/managementv3_test.go
@@ -51,6 +51,7 @@ var _ = Describe("[Docker] [Kubeadm] - [management.cattle.io/v3] Create and dele
 			SkipCleanup:                    false,
 			SkipDeletionTest:               false,
 			LabelNamespace:                 true,
+			TestClusterReimport:            true,
 			RancherServerURL:               hostName,
 			CAPIClusterCreateWaitName:      "wait-rancher",
 			DeleteClusterWaitName:          "wait-controllers",


### PR DESCRIPTION
**What this PR does / why we need it**:

This change adds a re-import check after running the existing `import_gitops` suite. The validation sits behind a condition passed as input `TestClusterReimport` which is proposed to only be enabled on CAPD tests to limit the effect on running time, which is already considerably long. This is also the reason why the new re-import validation is added to an existing test suite and not as a new one.

Both controller types are supported for now (v1 and v3 clusters) until we move completely to only v3.

To simplify and reduce code duplication, the validation on the Rancher cluster resource is now part of a `validateRancherCluster` function which is called during the "normal" test and then again after re-import.

The process of re-import is as follows:
- Rancher cluster is removed, which causes the CAPI cluster to be annotated: `imported=true`.
- Validate that the cluster is no longer imported and annotation is properly set.
- Retrieve CAPI cluster annotations and remove `imported=true`.
- Validate annotation is removed and wait for Rancher cluster to appear.
- Re-run the existing tests on Rancher cluster (agent deployed, cluster ready, etc.).

**Which issue(s) this PR fixes**:
Fixes #266 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
