### PR TITLE
[Bug] fix missing conditional for CAPI Operator dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ hack/crd/bases/*
 
 # act
 .secrets
+
+# helm
+**/Chart.lock

--- a/charts/rancher-turtles/Chart.yaml
+++ b/charts/rancher-turtles/Chart.yaml
@@ -15,6 +15,7 @@ dependencies:
   - name: cluster-api-operator
     version: v0.9.1
     repository: https://kubernetes-sigs.github.io/cluster-api-operator
+    condition: cluster-api-operator.enabled
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: Rancher Turtles - the Cluster API Extension


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR implements a missing dependencies in the Chart file; the values.yaml implements a boolean field called `cluster-api-operator` that will instruct helm to install or not install the CAPI Operator. 

**Checklist**:

None needed.
