### PR TITLE
🐛 [WIP] B64 encode gcp credentials for credentials sync

### DIFF
--- a/internal/sync/secret_mapper_sync.go
+++ b/internal/sync/secret_mapper_sync.go
@@ -84,7 +84,7 @@ var (
 			{to: "VSPHERE_USERNAME", from: Raw{source: "vmwarevsphere-username"}},
 		},
 		"gcp": {
-			{to: "GCP_B64ENCODED_CREDENTIALS", from: Raw{source: "googlecredentialConfig-authEncodedJson"}},
+			{to: "GCP_B64ENCODED_CREDENTIALS", from: B64{source: "googlecredentialConfig-authEncodedJson"}},
 		},
 		"digitalocean": {
 			{to: "DIGITALOCEAN_ACCESS_TOKEN", from: Raw{source: "digitaloceancredentialConfig-accessToken"}},


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Rancher credentials for GCP are not encoded as b64 (TODO: needs to be verified, therefore WIP for now). We need to encode this once in the credentials syncing and second time by specifying the data in the `stringData` field.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #510 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
