### PR TITLE
chore: Update image URLs in chart templates

### DIFF
--- a/charts/rancher-turtles/templates/core-provider.yaml
+++ b/charts/rancher-turtles/templates/core-provider.yaml
@@ -41,11 +41,11 @@ spec:
     selector: {{ index .Values "cluster-api-operator" "cluster-api" "core" "fetchConfig" "selector" }}
     {{- end }}
 {{- end }}
-{{- if index .Values "cluster-api-operator" "cluster-api" "core" "image" }}
+{{- if index .Values "cluster-api-operator" "cluster-api" "core" "imageUrl" }}
   deployment:
     containers:
       - name: manager
-        image: {{ index .Values "cluster-api-operator" "cluster-api" "core" "image" }}
+        imageUrl: {{ index .Values "cluster-api-operator" "cluster-api" "core" "imageUrl" }}
 {{- end }}
 ---
 apiVersion: v1

--- a/charts/rancher-turtles/templates/rke2-bootstrap.yaml
+++ b/charts/rancher-turtles/templates/rke2-bootstrap.yaml
@@ -40,10 +40,10 @@ spec:
     selector: {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "bootstrap" "fetchConfig" "selector" }}
     {{- end }}
 {{- end }}
-{{- if index .Values "cluster-api-operator" "cluster-api" "rke2" "bootstrap" "image" }}
+{{- if index .Values "cluster-api-operator" "cluster-api" "rke2" "bootstrap" "imageUrl" }}
   deployment:
     containers:
       - name: manager
-        image: {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "bootstrap" "image" }}
+        imageUrl: {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "bootstrap" "imageUrl" }}
 {{- end }}
 {{- end }}

--- a/charts/rancher-turtles/templates/rke2-controlplane.yaml
+++ b/charts/rancher-turtles/templates/rke2-controlplane.yaml
@@ -40,10 +40,10 @@ spec:
     selector: {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "controlPlane" "fetchConfig" "selector" }}
     {{- end }}
 {{- end }}
-{{- if index .Values "cluster-api-operator" "cluster-api" "rke2" "controlPlane" "image" }}
+{{- if index .Values "cluster-api-operator" "cluster-api" "rke2" "controlPlane" "imageUrl" }}
   deployment:
     containers:
       - name: manager
-        image: {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "controlPlane" "image" }}
+        imageUrl: {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "controlPlane" "imageUrl" }}
 {{- end }}
 {{- end }}

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -49,7 +49,7 @@ cluster-api-operator:
       defaultName: capi-env-variables
     core:
       namespace: capi-system
-      image: ""
+      imageUrl: ""
       fetchConfig:
         url: ""
         selector: ""
@@ -58,13 +58,13 @@ cluster-api-operator:
       version: ""
       bootstrap:
         namespace: rke2-bootstrap-system
-        image: ""
+        imageUrl: ""
         fetchConfig:
           url: ""
           selector: ""
       controlPlane:
         namespace: rke2-control-plane-system
-        image: ""
+        imageUrl: ""
         fetchConfig:
           url: ""
           selector: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates image URLs in cluster-api-operator in core-provider, rke2-bootstrap, and rke2-controlplane templates

<!-- Enter a description of the change and why this change is needed -->
Fixes #532 

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
