### PR TITLE
Update README.md for Helm Chart Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Currently, this project has the following functionality:
 
 ## Installation & Usage
 
-Rancher Turtles is deployed using a Helm Chart. For instructions, see the [getting started guide](https://turtles.docs.rancher.com/docs/category/getting-started).
+Rancher Turtles is deployed using a Helm Chart. For instructions, see the [getting started guide](https://turtles.docs.rancher.com/getting-started/install-rancher-turtles/using_helm).
 
 ## Documentation
 


### PR DESCRIPTION


<!--
Label the PR with the kind of change this for:

kind/documentation
-->

**What this PR does / why we need it**:

Installation & Usage is pointing to a broken page for deployed as a Helm Chart. Believe this is the page that is meant to be linked
