### PR TITLE
fix: git add files in dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -31,4 +31,5 @@ jobs:
       run: |
         git config --local user.email "49699333+dependabot[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
+        git add .
         git commit -m "Update generated code"


### PR DESCRIPTION
**What this PR does / why we need it**:

Dependabot CI checks are failing on some PRs after replacing the no longer supported action with manual steps [example](https://github.com/rancher/turtles/actions/runs/9249544453/job/25447774389). Looks like this is because the Action we were using sets a default `git add .` [here](https://github.com/EndBug/add-and-commit?tab=readme-ov-file#inputs) and it is missing now, so the commit returns error code 1 when there are no changes to commit. This PR simply adds a `git add .` which hopefully is enough to mimic the removed action's behavior.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
