### PR TITLE
Enable addon provider fleet as experimental

### DIFF
--- a/api/v1alpha1/capiprovider_types.go
+++ b/api/v1alpha1/capiprovider_types.go
@@ -30,7 +30,7 @@ const (
 // CAPIProviderSpec defines the desired state of CAPIProvider.
 // +kubebuilder:validation:XValidation:message="CAPI Provider version should be in the semver format prefixed with 'v'. Example: v1.9.3",rule="!has(self.version) || self.version.matches(r\"\"\"^v([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-]+)?$\"\"\")"
 // +kubebuilder:validation:XValidation:message="Config secret namespace is always equal to the resource namespace and should not be set.",rule="!has(self.configSecret) || !has(self.configSecret.__namespace__)"
-// +kubebuilder:validation:XValidation:message="Either fetchConfig or name should be set.",rule="has(self.fetchConfig.url) || has(self.fetchConfig.selector) ||  has(self.name)"
+// +kubebuilder:validation:XValidation:message="One of fetchConfig url or selector should be set.",rule="!has(self.fetchConfig) || [has(self.fetchConfig.url), has(self.fetchConfig.selector)].exists_one(e, e)"
 //
 //nolint:lll
 type CAPIProviderSpec struct {
@@ -127,6 +127,7 @@ type CAPIProviderStatus struct {
 // +kubebuilder:printcolumn:name="ProviderName",type="string",JSONPath=".spec.name"
 // +kubebuilder:printcolumn:name="InstalledVersion",type="string",JSONPath=".status.installedVersion"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:validation:XValidation:message="CAPI Provider type should always be set.",rule="has(self.spec.type)"
 type CAPIProvider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/rancher-turtles/questions.yml
+++ b/charts/rancher-turtles/questions.yml
@@ -64,3 +64,9 @@ questions:
     type: boolean
     label: Propagate CAPI Labels
     group: "Rancher Turtles Features Settings"
+  - variable: rancherTurtles.features.addon-provider-fleet.enabled
+    default: false
+    description: "(Experimental) Enable Fleet Addon Provider functionality in Rancher Turtles"
+    type: boolean
+    label: Seamless integration with Fleet and CAPI
+    group: "Rancher Turtles Features Settings"

--- a/charts/rancher-turtles/templates/addon-provider-fleet.yaml
+++ b/charts/rancher-turtles/templates/addon-provider-fleet.yaml
@@ -1,0 +1,12 @@
+{{- if index .Values "rancherTurtles" "features" "addon-provider-fleet" "enabled" }}
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: fleet
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
+  annotations:
+    "helm.sh/hook": "post-install, post-upgrade"
+    "helm.sh/hook-weight": "2"
+spec:
+  type: addon
+{{- end }}

--- a/charts/rancher-turtles/templates/clusterctl-config.yaml
+++ b/charts/rancher-turtles/templates/clusterctl-config.yaml
@@ -47,4 +47,9 @@ data:
     - name:         "rke2"
       url:          "https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/v0.3.0/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
+
+    # Addon providers
+    - name:         "fleet"
+      url:          "https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/latest/addon-components.yaml"
+      type:         "AddonProvider"
 {{- end }}

--- a/charts/rancher-turtles/templates/rancher-turtles-components.yaml
+++ b/charts/rancher-turtles/templates/rancher-turtles-components.yaml
@@ -1619,8 +1619,9 @@ spec:
             - message: Config secret namespace is always equal to the resource namespace
                 and should not be set.
               rule: '!has(self.configSecret) || !has(self.configSecret.__namespace__)'
-            - message: Either fetchConfig or name should be set.
-              rule: has(self.fetchConfig.url) || has(self.fetchConfig.selector) ||  has(self.name)
+            - message: One of fetchConfig url or selector should be set.
+              rule: '!has(self.fetchConfig) || [has(self.fetchConfig.url), has(self.fetchConfig.selector)].exists_one(e,
+                e)'
           status:
             default: {}
             description: CAPIProviderStatus defines the observed state of CAPIProvider.
@@ -1700,6 +1701,9 @@ spec:
                 type: object
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: CAPI Provider type should always be set.
+          rule: has(self.spec.type)
     served: true
     storage: true
     subresources:

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -22,6 +22,8 @@ rancherTurtles:
       enabled: true
     etcd-snapshot-restore:
       enabled: false
+    addon-provider-fleet:
+      enabled: false
 cluster-api-operator:
   enabled: true
   cert-manager:

--- a/config/crd/bases/turtles-capi.cattle.io_capiproviders.yaml
+++ b/config/crd/bases/turtles-capi.cattle.io_capiproviders.yaml
@@ -1619,8 +1619,9 @@ spec:
             - message: Config secret namespace is always equal to the resource namespace
                 and should not be set.
               rule: '!has(self.configSecret) || !has(self.configSecret.__namespace__)'
-            - message: Either fetchConfig or name should be set.
-              rule: has(self.fetchConfig.url) || has(self.fetchConfig.selector) ||  has(self.name)
+            - message: One of fetchConfig url or selector should be set.
+              rule: '!has(self.fetchConfig) || [has(self.fetchConfig.url), has(self.fetchConfig.selector)].exists_one(e,
+                e)'
           status:
             default: {}
             description: CAPIProviderStatus defines the observed state of CAPIProvider.
@@ -1700,6 +1701,9 @@ spec:
                 type: object
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: CAPI Provider type should always be set.
+          rule: has(self.spec.type)
     served: true
     storage: true
     subresources:

--- a/test/e2e/suites/import-gitops/suite_test.go
+++ b/test/e2e/suites/import-gitops/suite_test.go
@@ -223,6 +223,8 @@ var _ = BeforeSuite(func() {
 			rtInput.AdditionalValues["rancherTurtles.imagePullPolicy"] = "Never"
 		}
 
+		rtInput.AdditionalValues["rancherTurtles.features.addon-provider-fleet.enabled"] = "true"
+
 		testenv.UpgradeRancherTurtles(ctx, upgradeInput)
 	} else {
 		rtInput := testenv.DeployRancherTurtlesInput{


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This change introduces CAAPF as experimental feature in turtles, bringing automatic Fleet cluster management per CAPI cluster, and tight ClusterClass integration with ClusterGroups.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
