### PR TITLE
Add v1->v3 cluster migration

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -46,6 +46,7 @@ projects = {
             "go.mod",
             "go.sum",
             "internal",
+            "features",
         ],
         "kustomize_dir": "config/default",
         "label": "turtles"

--- a/internal/controllers/helpers.go
+++ b/internal/controllers/helpers.go
@@ -49,6 +49,7 @@ const (
 	ownedLabelName            = "cluster-api.cattle.io/owned"
 	capiClusterOwner          = "cluster-api.cattle.io/capi-cluster-owner"
 	capiClusterOwnerNamespace = "cluster-api.cattle.io/capi-cluster-owner-ns"
+	v1ClusterMigrated         = "cluster-api.cattle.io/migrated"
 
 	defaultRequeueDuration = 1 * time.Minute
 )


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This PR allows migrating from V1->V3 cluster without reimporting the clusters. Rancher already creates a V3 cluster for every V1 cluster. V3 cluster controller will check that V1 cluster includes a migrated annotation or exists at all for a given v3 cluster if the annotation is present, the reconciliation will continue as expected.
Users are required to set proper labels on the existing V3 cluster before migrating, this will be described in the ADR and rancher turtles docs.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
