### PR TITLE
🌱 Cleanup v1 cluster before creating v3 clusters on upgrade

### DIFF
--- a/.github/workflows/e2e-short.yaml
+++ b/.github/workflows/e2e-short.yaml
@@ -8,6 +8,23 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
+      - name: Cleanup space
+        run: |
+          sudo apt-get remove -y '^aspnetcore-.*' || echo "::warning::The command [sudo apt-get remove -y '^aspnetcore-.*'] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y '^dotnet-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^dotnet-.*' --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y '^llvm-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^llvm-.*' --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y 'php.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y 'php.*' --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y '^mongodb-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mongodb-.*' --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y '^mysql-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mysql-.*' --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing || echo "::warning::The command [sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y google-cloud-sdk --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-sdk --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y google-cloud-cli --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-cli --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get autoremove -y || echo "::warning::The command [sudo apt-get autoremove -y] failed to complete successfully. Proceeding..."
+          sudo apt-get clean || echo "::warning::The command [sudo apt-get clean] failed to complete successfully. Proceeding..."
+          sudo docker image prune --all --force || true
+          sudo swapoff -a || true
+          sudo rm -f /mnt/swapfile || true
+          free -h
       - name: Checkout
         uses: actions/checkout@v4.1.3
         with:

--- a/charts/rancher-turtles/questions.yml
+++ b/charts/rancher-turtles/questions.yml
@@ -53,6 +53,12 @@ questions:
     type: boolean
     label: Use management v3 cluster manifest
     group: "Rancher Turtles Features Settings"
+  - variable: rancherTurtles.features.managementv3-cluster-migration.enabled
+    default: false
+    description: "(Experimental) Automatically migrate provisioning clusters to management clusters on upgrade"
+    type: boolean
+    label: Use newly provisioned management cluster manifest, replacing provisioning cluster manifest.
+    group: "Rancher Turtles Features Settings"
   - variable: cluster-api-operator.cluster-api.rke2.enabled
     default: "true"
     description: "Flag to enable or disable installation of the RKE2 provider for Cluster API. By default this is enabled."

--- a/charts/rancher-turtles/templates/post-upgrade-job.yaml
+++ b/charts/rancher-turtles/templates/post-upgrade-job.yaml
@@ -1,0 +1,67 @@
+{{- if and (index .Values "rancherTurtles" "features" "managementv3-cluster" "enabled") (index .Values "rancherTurtles" "features" "managementv3-cluster-migration" "enabled") }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: post-upgrade-job
+  namespace: rancher-turtles-system
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "1"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: post-upgrade-job-delete-clusters
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "1"
+rules:
+- apiGroups:
+  - provisioning.cattle.io
+  resources:
+  - clusters
+  verbs:
+  - list
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: post-upgrade-job-delete-clusters
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "1"
+subjects:
+  - kind: ServiceAccount
+    name: post-upgrade-job
+    namespace: rancher-turtles-system
+roleRef:
+  kind: ClusterRole
+  name: post-upgrade-job-delete-clusters
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: post-upgrade-delete-clusters
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "2"
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: post-upgrade-job
+      containers:
+        - name: post-upgrade-delete-clusters
+          image: {{ index .Values "rancherTurtles" "features" "rancher-webhook" "kubectlImage" }}
+          args:
+          - delete
+          - clusters.provisioning.cattle.io
+          - --selector=cluster-api.cattle.io/owned
+          - -A
+          - --ignore-not-found=true
+          - --wait
+      restartPolicy: OnFailure
+{{- end }}

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -18,6 +18,8 @@ rancherTurtles:
       label: true
     managementv3-cluster:
       enabled: false
+    managementv3-cluster-migration:
+      enabled: false
     propagate-labels:
       enabled: false
     etcd-snapshot-restore:

--- a/test/e2e/specs/migrate_gitops_provv2_mgmtv3.go
+++ b/test/e2e/specs/migrate_gitops_provv2_mgmtv3.go
@@ -1,0 +1,415 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright © 2023 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package specs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+
+	managementv3 "github.com/rancher/turtles/internal/rancher/management/v3"
+	provisioningv1 "github.com/rancher/turtles/internal/rancher/provisioning/v1"
+	"github.com/rancher/turtles/test/e2e"
+	turtlesframework "github.com/rancher/turtles/test/framework"
+	"github.com/rancher/turtles/test/testenv"
+	turtlesnaming "github.com/rancher/turtles/util/naming"
+)
+
+type MigrateToV3UsingGitOpsSpecInput struct {
+	E2EConfig             *clusterctl.E2EConfig
+	BootstrapClusterProxy framework.ClusterProxy
+	ClusterctlConfigPath  string
+	ArtifactFolder        string
+	RancherServerURL      string
+	HelmBinaryPath        string
+	ChartPath             string
+
+	ClusterctlBinaryPath        string
+	ClusterTemplate             []byte
+	ClusterName                 string
+	AdditionalTemplateVariables map[string]string
+
+	CAPIClusterCreateWaitName string
+	DeleteClusterWaitName     string
+
+	// ControlPlaneMachineCount defines the number of control plane machines to be added to the workload cluster.
+	// If not specified, 1 will be used.
+	ControlPlaneMachineCount *int
+
+	// WorkerMachineCount defines number of worker machines to be added to the workload cluster.
+	// If not specified, 1 will be used.
+	WorkerMachineCount *int
+
+	GitAddr           string
+	GitAuthSecretName string
+
+	SkipCleanup      bool
+	SkipDeletionTest bool
+
+	LabelNamespace bool
+
+	// TestClusterReimport defines whether to test un-importing and re-importing the cluster after initial test.
+	TestClusterReimport bool
+
+	// management.cattle.io specifc
+	CapiClusterOwnerLabel          string
+	CapiClusterOwnerNamespaceLabel string
+	OwnedLabelName                 string
+}
+
+// MigrateToV3UsingGitOpsSpec implements a spec that will create a cluster via Fleet and test that it
+// automatically imports into Rancher Manager.
+func MigrateToV3UsingGitOpsSpec(ctx context.Context, inputGetter func() MigrateToV3UsingGitOpsSpecInput) {
+	var (
+		specName              = "migrategitops"
+		input                 MigrateToV3UsingGitOpsSpecInput
+		namespace             *corev1.Namespace
+		repoName              string
+		cancelWatches         context.CancelFunc
+		capiCluster           *types.NamespacedName
+		rancherKubeconfig     *turtlesframework.RancherGetClusterKubeconfigResult
+		originalKubeconfig    *turtlesframework.RancherGetClusterKubeconfigResult
+		rancherConnectRes     *turtlesframework.RunCommandResult
+		rancherCluster        *managementv3.Cluster
+		rancherLegacyCluster  *provisioningv1.Cluster
+		capiClusterCreateWait []interface{}
+		deleteClusterWait     []interface{}
+	)
+
+	validateLegacyRancherCluster := func() {
+		By("Waiting for the rancher cluster record to appear")
+		rancherLegacyCluster = &provisioningv1.Cluster{ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace.Name,
+			Name:      turtlesnaming.Name(capiCluster.Name).ToRancherName(),
+		}}
+		Eventually(komega.Get(rancherLegacyCluster), input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(Succeed())
+
+		By("Waiting for the rancher cluster to have a deployed agent")
+		Eventually(komega.Object(rancherLegacyCluster), input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(HaveField("Status.AgentDeployed", BeTrue()))
+
+		By("Waiting for the rancher cluster to be ready")
+		Eventually(komega.Object(rancherLegacyCluster), input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(HaveField("Status.Ready", BeTrue()))
+
+		By("Waiting for the CAPI cluster to be connectable using Rancher kubeconfig")
+		turtlesframework.RancherGetClusterKubeconfig(ctx, turtlesframework.RancherGetClusterKubeconfigInput{
+			Getter:           input.BootstrapClusterProxy.GetClient(),
+			SecretName:       fmt.Sprintf("%s-capi-kubeconfig", capiCluster.Name),
+			Namespace:        capiCluster.Namespace,
+			RancherServerURL: input.RancherServerURL,
+			WriteToTempFile:  true,
+		}, rancherKubeconfig)
+
+		turtlesframework.RunCommand(ctx, turtlesframework.RunCommandInput{
+			Command: "kubectl",
+			Args: []string{
+				"--kubeconfig",
+				rancherKubeconfig.TempFilePath,
+				"get",
+				"nodes",
+				"--insecure-skip-tls-verify",
+			},
+		}, rancherConnectRes)
+		Expect(rancherConnectRes.Error).NotTo(HaveOccurred(), "Failed getting nodes with Rancher Kubeconfig")
+		Expect(rancherConnectRes.ExitCode).To(Equal(0), "Getting nodes return non-zero exit code")
+	}
+
+	validateRancherCluster := func() {
+		By("Waiting for the rancher cluster record to appear")
+		rancherClusters := &managementv3.ClusterList{}
+		selectors := []client.ListOption{
+			client.MatchingLabels{
+				input.CapiClusterOwnerLabel:          capiCluster.Name,
+				input.CapiClusterOwnerNamespaceLabel: capiCluster.Namespace,
+				input.OwnedLabelName:                 "",
+			},
+		}
+		Eventually(func() bool {
+			Eventually(komega.List(rancherClusters, selectors...)).Should(Succeed())
+			return len(rancherClusters.Items) == 1
+		}, input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(BeTrue())
+		rancherCluster = &rancherClusters.Items[0]
+		Eventually(komega.Get(rancherCluster), input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(Succeed())
+
+		By("Waiting for the rancher cluster to have a deployed agent")
+		Eventually(func() bool {
+			Eventually(komega.Get(rancherCluster), input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(Succeed())
+			return conditions.IsTrue(rancherCluster, managementv3.ClusterConditionAgentDeployed)
+		}, input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(BeTrue())
+
+		By("Waiting for the rancher cluster to be ready")
+		Eventually(func() bool {
+			Eventually(komega.Get(rancherCluster), input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(Succeed())
+			return conditions.IsTrue(rancherCluster, managementv3.ClusterConditionReady)
+		}, input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(BeTrue())
+
+		By("Waiting for the CAPI cluster to be connectable using Rancher kubeconfig")
+		turtlesframework.RancherGetClusterKubeconfig(ctx, turtlesframework.RancherGetClusterKubeconfigInput{
+			Getter:           input.BootstrapClusterProxy.GetClient(),
+			SecretName:       fmt.Sprintf("%s-kubeconfig", rancherCluster.Name),
+			Namespace:        rancherCluster.Spec.FleetWorkspaceName,
+			RancherServerURL: input.RancherServerURL,
+			WriteToTempFile:  true,
+		}, rancherKubeconfig)
+
+		turtlesframework.RunCommand(ctx, turtlesframework.RunCommandInput{
+			Command: "kubectl",
+			Args: []string{
+				"--kubeconfig",
+				rancherKubeconfig.TempFilePath,
+				"get",
+				"nodes",
+				"--insecure-skip-tls-verify",
+			},
+		}, rancherConnectRes)
+		Expect(rancherConnectRes.Error).NotTo(HaveOccurred(), "Failed getting nodes with Rancher Kubeconfig")
+		Expect(rancherConnectRes.ExitCode).To(Equal(0), "Getting nodes return non-zero exit code")
+	}
+
+	BeforeEach(func() {
+		Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
+		input = inputGetter()
+		Expect(input.E2EConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
+		Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+		Expect(input.ClusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. input.ClusterctlConfigPath must be an existing file when calling %s spec", specName)
+		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+
+		Expect(input.E2EConfig.Variables).To(HaveKey(e2e.KubernetesManagementVersionVar))
+		namespace, cancelWatches = e2e.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
+		repoName = e2e.CreateRepoName(specName)
+
+		capiClusterCreateWait = input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), input.CAPIClusterCreateWaitName)
+		Expect(capiClusterCreateWait).ToNot(BeNil(), "Failed to get wait intervals %s", input.CAPIClusterCreateWaitName)
+
+		deleteClusterWait = input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), input.DeleteClusterWaitName)
+		Expect(capiClusterCreateWait).ToNot(BeNil(), "Failed to get wait intervals %s", input.CAPIClusterCreateWaitName)
+
+		capiCluster = &types.NamespacedName{
+			Namespace: namespace.Name,
+			Name:      input.ClusterName,
+		}
+
+		rancherKubeconfig = new(turtlesframework.RancherGetClusterKubeconfigResult)
+		originalKubeconfig = new(turtlesframework.RancherGetClusterKubeconfigResult)
+		rancherConnectRes = new(turtlesframework.RunCommandResult)
+
+		komega.SetClient(input.BootstrapClusterProxy.GetClient())
+		komega.SetContext(ctx)
+	})
+
+	It("Should import a cluster using gitops", func() {
+		controlPlaneMachineCount := 1
+		if input.ControlPlaneMachineCount != nil {
+			controlPlaneMachineCount = *input.ControlPlaneMachineCount
+		}
+
+		workerMachineCount := 1
+		if input.WorkerMachineCount != nil {
+			workerMachineCount = *input.WorkerMachineCount
+		}
+
+		if input.LabelNamespace {
+			turtlesframework.AddLabelsToNamespace(ctx, turtlesframework.AddLabelsToNamespaceInput{
+				ClusterProxy: input.BootstrapClusterProxy,
+				Name:         namespace.Name,
+				Labels: map[string]string{
+					"cluster-api.cattle.io/rancher-auto-import": "true",
+				},
+			})
+		}
+
+		By("Create Git repository")
+
+		repoCloneAddr := turtlesframework.GiteaCreateRepo(ctx, turtlesframework.GiteaCreateRepoInput{
+			ServerAddr: input.GitAddr,
+			RepoName:   repoName,
+			Username:   input.E2EConfig.GetVariable(e2e.GiteaUserNameVar),
+			Password:   input.E2EConfig.GetVariable(e2e.GiteaUserPasswordVar),
+		})
+		repoDir := turtlesframework.GitCloneRepo(ctx, turtlesframework.GitCloneRepoInput{
+			Address:  repoCloneAddr,
+			Username: input.E2EConfig.GetVariable(e2e.GiteaUserNameVar),
+			Password: input.E2EConfig.GetVariable(e2e.GiteaUserPasswordVar),
+		})
+
+		By("Create fleet repository structure")
+
+		clustersDir := filepath.Join(repoDir, "clusters")
+		os.MkdirAll(clustersDir, os.ModePerm)
+
+		additionalVars := map[string]string{
+			"CLUSTER_NAME":                input.ClusterName,
+			"WORKER_MACHINE_COUNT":        strconv.Itoa(workerMachineCount),
+			"CONTROL_PLANE_MACHINE_COUNT": strconv.Itoa(controlPlaneMachineCount),
+		}
+		for k, v := range input.AdditionalTemplateVariables {
+			additionalVars[k] = v
+		}
+
+		clusterPath := filepath.Join(clustersDir, fmt.Sprintf("%s.yaml", input.ClusterName))
+		Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+			Getter:                        input.E2EConfig.GetVariable,
+			Template:                      input.ClusterTemplate,
+			OutputFilePath:                clusterPath,
+			AddtionalEnvironmentVariables: additionalVars,
+		})).To(Succeed())
+
+		fleetPath := filepath.Join(clustersDir, "fleet.yaml")
+		turtlesframework.FleetCreateFleetFile(ctx, turtlesframework.FleetCreateFleetFileInput{
+			Namespace: namespace.Name,
+			FilePath:  fleetPath,
+		})
+
+		By("Committing changes to fleet repo and pushing")
+
+		turtlesframework.GitCommitAndPush(ctx, turtlesframework.GitCommitAndPushInput{
+			CloneLocation: repoDir,
+			Username:      input.E2EConfig.GetVariable(e2e.GiteaUserNameVar),
+			Password:      input.E2EConfig.GetVariable(e2e.GiteaUserPasswordVar),
+			CommitMessage: "ci: add clusters bundle",
+		})
+
+		By("Applying GitRepo")
+
+		turtlesframework.FleetCreateGitRepo(ctx, turtlesframework.FleetCreateGitRepoInput{
+			Name:             repoName,
+			Namespace:        turtlesframework.FleetLocalNamespace,
+			Branch:           turtlesframework.DefaultBranchName,
+			Repo:             repoCloneAddr,
+			FleetGeneration:  1,
+			Paths:            []string{"clusters"},
+			ClientSecretName: input.GitAuthSecretName,
+			ClusterProxy:     input.BootstrapClusterProxy,
+		})
+
+		By("Waiting for the CAPI cluster to appear")
+		capiCluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace.Name,
+			Name:      input.ClusterName,
+		}}
+		Eventually(
+			komega.Get(capiCluster),
+			input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).
+			Should(Succeed(), "Failed to apply CAPI cluster definition to cluster via Fleet")
+
+		By("Waiting for cluster control plane to be Ready")
+		Eventually(komega.Object(capiCluster), capiClusterCreateWait...).Should(HaveField("Status.ControlPlaneReady", BeTrue()))
+
+		By("Waiting for the CAPI cluster to be connectable")
+		Eventually(func() error {
+			remoteClient := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, capiCluster.Namespace, capiCluster.Name).GetClient()
+			namespaces := &corev1.NamespaceList{}
+
+			return remoteClient.List(ctx, namespaces)
+		}, capiClusterCreateWait...).Should(Succeed(), "Failed to connect to workload cluster using CAPI kubeconfig")
+
+		By("Storing the original CAPI cluster kubeconfig")
+		turtlesframework.RancherGetOriginalKubeconfig(ctx, turtlesframework.RancherGetClusterKubeconfigInput{
+			Getter:          input.BootstrapClusterProxy.GetClient(),
+			SecretName:      fmt.Sprintf("%s-kubeconfig", capiCluster.Name),
+			Namespace:       capiCluster.Namespace,
+			WriteToTempFile: true,
+		}, originalKubeconfig)
+
+		By("Running checks on Rancher cluster")
+		validateLegacyRancherCluster()
+
+		testenv.DeployChartMuseum(ctx, testenv.DeployChartMuseumInput{
+			HelmBinaryPath:        input.HelmBinaryPath,
+			ChartsPath:            input.ChartPath,
+			BootstrapClusterProxy: input.BootstrapClusterProxy,
+			WaitInterval:          input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-controllers"),
+		})
+
+		upgradeInput := testenv.UpgradeRancherTurtlesInput{
+			BootstrapClusterProxy:        input.BootstrapClusterProxy,
+			HelmBinaryPath:               input.HelmBinaryPath,
+			Namespace:                    turtlesframework.DefaultRancherTurtlesNamespace,
+			Image:                        fmt.Sprintf("ghcr.io/rancher/turtles-e2e-%s", runtime.GOARCH),
+			Tag:                          "v0.0.1",
+			WaitDeploymentsReadyInterval: input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-controllers"),
+			AdditionalValues:             map[string]string{},
+		}
+
+		// NOTE: this was the default previously in the chart locally and ok as
+		// we where loading the image into kind manually.
+		upgradeInput.AdditionalValues["rancherTurtles.imagePullPolicy"] = "Never"
+
+		upgradeInput.AdditionalValues["rancherTurtles.features.managementv3-cluster.enabled"] = "true"
+		upgradeInput.AdditionalValues["rancherTurtles.features.managementv3-cluster-migration.enabled"] = "true"
+
+		testenv.UpgradeRancherTurtles(ctx, upgradeInput)
+
+		By("Waiting for the Rancher cluster record to be removed")
+		Eventually(komega.Get(rancherLegacyCluster), deleteClusterWait...).Should(MatchError(ContainSubstring("not found")), "Rancher cluster should be unimported (deleted)")
+
+		By("CAPI cluster should NOT have the 'imported' annotation")
+		Consistently(func() bool {
+			Eventually(komega.Get(capiCluster), input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(Succeed())
+			annotations := capiCluster.GetAnnotations()
+			_, found := annotations["imported"]
+			return !found
+		}, 5*time.Second).Should(BeTrue(), "'imported' annotation is not expected on CAPI cluster")
+
+		By("Rancher should be available after removing 'imported' annotation")
+		validateRancherCluster()
+	})
+
+	AfterEach(func() {
+		err := testenv.CollectArtifacts(ctx, input.BootstrapClusterProxy.GetKubeconfigPath(), path.Join(input.ArtifactFolder, input.BootstrapClusterProxy.GetName(), "bootstrap"+specName))
+		if err != nil {
+			fmt.Printf("Failed to collect artifacts for the bootstrap cluster: %v\n", err)
+		}
+
+		err = testenv.CollectArtifacts(ctx, originalKubeconfig.TempFilePath, path.Join(input.ArtifactFolder, input.BootstrapClusterProxy.GetName(), input.ClusterName+specName))
+		if err != nil {
+			fmt.Printf("Failed to collect artifacts for the child cluster: %v\n", err)
+		}
+
+		By("Deleting GitRepo from Rancher")
+		turtlesframework.FleetDeleteGitRepo(ctx, turtlesframework.FleetDeleteGitRepoInput{
+			Name:         repoName,
+			Namespace:    turtlesframework.FleetLocalNamespace,
+			ClusterProxy: input.BootstrapClusterProxy,
+		})
+
+		By("Waiting for the rancher cluster record to be removed")
+		Eventually(komega.Get(rancherCluster), deleteClusterWait...).Should(MatchError(ContainSubstring("not found")), "Rancher cluster should be deleted")
+
+		e2e.DumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, namespace, cancelWatches, capiCluster, input.E2EConfig.GetIntervals, input.SkipCleanup)
+	})
+}

--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -32,6 +32,41 @@ import (
 	"github.com/rancher/turtles/test/e2e/specs"
 )
 
+var _ = Describe("[Docker] [Kubeadm] - [management.cattle.io/v3] Migrate v1 to management v3 cluster functionality should work", Label(e2e.ShortTestLabel), func() {
+	BeforeEach(func() {
+		komega.SetClient(setupClusterResult.BootstrapClusterProxy.GetClient())
+		komega.SetContext(ctx)
+	})
+
+	specs.MigrateToV3UsingGitOpsSpec(ctx, func() specs.MigrateToV3UsingGitOpsSpecInput {
+		return specs.MigrateToV3UsingGitOpsSpecInput{
+			HelmBinaryPath:                 flagVals.HelmBinaryPath,
+			ChartPath:                      flagVals.ChartPath,
+			E2EConfig:                      e2eConfig,
+			BootstrapClusterProxy:          setupClusterResult.BootstrapClusterProxy,
+			ClusterctlConfigPath:           flagVals.ConfigPath,
+			ClusterctlBinaryPath:           flagVals.ClusterctlBinaryPath,
+			ArtifactFolder:                 flagVals.ArtifactFolder,
+			ClusterTemplate:                e2e.CAPIDockerKubeadm,
+			ClusterName:                    "highlander-e2e-clusterv3-migrated",
+			ControlPlaneMachineCount:       ptr.To(1),
+			WorkerMachineCount:             ptr.To(1),
+			GitAddr:                        giteaResult.GitAddress,
+			GitAuthSecretName:              e2e.AuthSecretName,
+			SkipCleanup:                    false,
+			SkipDeletionTest:               false,
+			LabelNamespace:                 true,
+			TestClusterReimport:            true,
+			RancherServerURL:               hostName,
+			CAPIClusterCreateWaitName:      "wait-rancher",
+			DeleteClusterWaitName:          "wait-controllers",
+			CapiClusterOwnerLabel:          e2e.CapiClusterOwnerLabel,
+			CapiClusterOwnerNamespaceLabel: e2e.CapiClusterOwnerNamespaceLabel,
+			OwnedLabelName:                 e2e.OwnedLabelName,
+		}
+	})
+})
+
 var _ = Describe("[Docker] [Kubeadm] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.ShortTestLabel), func() {
 	BeforeEach(func() {
 		SetClient(setupClusterResult.BootstrapClusterProxy.GetClient())


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Perform automatic provisioning cluster removal on upgrade with `v3 clusters` feature flag enabled.
In case of a duplicate cluster entries, a user can re-run the upgrade without settings change.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
