### PR TITLE
test: fix v1 controller test on embedded-capi-disabled suite

### DIFF
--- a/test/e2e/suites/embedded-capi-disabled/embedded_capi_disabled_test.go
+++ b/test/e2e/suites/embedded-capi-disabled/embedded_capi_disabled_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster functionality should work with namespace auto-import (embedded capi disable from start)", Label(e2e.FullTestLabel), func() {
-
 	BeforeEach(func() {
 		SetClient(setupClusterResult.BootstrapClusterProxy.GetClient())
 		SetContext(ctx)

--- a/test/e2e/suites/embedded-capi-disabled/suite_test.go
+++ b/test/e2e/suites/embedded-capi-disabled/suite_test.go
@@ -197,8 +197,9 @@ var _ = BeforeSuite(func() {
 		Tag:                          "v0.0.1",
 		WaitDeploymentsReadyInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
 		AdditionalValues: map[string]string{
-			"cluster-api-operator.cert-manager.enabled":      "false",
-			"rancherTurtles.features.embedded-capi.disabled": "false",
+			"cluster-api-operator.cert-manager.enabled":            "false",
+			"rancherTurtles.features.embedded-capi.disabled":       "false",
+			"rancherTurtles.features.managementv3-cluster.enabled": "false",
 		},
 	}
 	if flagVals.UseEKS {


### PR DESCRIPTION
**What this PR does / why we need it**:

`embedded-capi-disabled` E2E test suite has been failing for a few days now. As the default installation of Turtles is now using the v3 controller, we need to explicitly install Turtles with v1 controller to run the existing validation.

**Which issue(s) this PR fixes**:
Fixes #592 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
