### PR TITLE
chore: add v3 checks to nightly + fix e2e naming in workflow yaml

### DIFF
--- a/.github/workflows/e2e-long.yaml
+++ b/.github/workflows/e2e-long.yaml
@@ -17,6 +17,15 @@ jobs:
       artifact_name: artifacts_import_gitops
       use_eks: true
     secrets: inherit
+  e2e_import_gitops_v3:
+    uses: ./.github/workflows/run-e2e-suite.yaml
+    with:
+      test_suite: $(pwd)/test/e2e/suites/import-gitops-v3
+      test_name: Import via GitOps [v3]
+      run_azure_janitor: false
+      artifact_name: artifacts_import_gitops_v3
+      use_eks: true
+    secrets: inherit
   e2e_v2prov:
     uses: ./.github/workflows/run-e2e-suite.yaml
     with:
@@ -42,5 +51,14 @@ jobs:
       test_name: Embedded CAPI disabled
       run_azure_janitor: false
       artifact_name: artifacts_embedded_capi
+      use_eks: true
+    secrets: inherit
+  e2e_embedded_capi_disabled_v3:
+    uses: ./.github/workflows/run-e2e-suite.yaml
+    with:
+      test_suite: $(pwd)/test/e2e/suites/embedded-capi-disabled-v3
+      test_name: Embedded CAPI disabled [v3]
+      run_azure_janitor: false
+      artifact_name: artifacts_embedded_capi_v3
       use_eks: true
     secrets: inherit

--- a/.github/workflows/e2e-long.yaml
+++ b/.github/workflows/e2e-long.yaml
@@ -39,7 +39,7 @@ jobs:
     uses: ./.github/workflows/run-e2e-suite.yaml
     with:
       test_suite: $(pwd)/test/e2e/suites/embedded-capi-disabled
-      test_name: Update labels
+      test_name: Embedded CAPI disabled
       run_azure_janitor: false
       artifact_name: artifacts_embedded_capi
       use_eks: true


### PR DESCRIPTION
**What this PR does / why we need it**:

This change adds v3 suites to nightly E2E execution.

Additionally, `embedded-capi-disabled` suite has been failing for a few days but the alert we receive in Slack is marking `update-labels` as root of the issue. This fixes the naming in the E2E workflow definition.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
