### PR TITLE
🐛 Apply finalizer on rancher cluster to avoid re-create race condition

### DIFF
--- a/internal/controllers/import_controller_v3_test.go
+++ b/internal/controllers/import_controller_v3_test.go
@@ -170,7 +170,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		}).Should(Succeed())
 	})
 
-	It("should reconcile a CAPI cluster when rancher cluster doesn't exist", func() {
+	It("should reconcile a CAPI cluster when rancher cluster doesn't exist, and set finalizers", func() {
 		ns.Labels = map[string]string{}
 		Expect(cl.Update(ctx, ns)).To(Succeed())
 		capiCluster.Labels = map[string]string{
@@ -195,9 +195,15 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		Eventually(ctx, func(g Gomega) {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
+			g.Expect(rancherClusters.Items[0].Name).To(ContainSubstring("c-"))
+			g.Expect(rancherClusters.Items[0].Labels).To(HaveKeyWithValue(testLabelName, testLabelVal))
+			g.Expect(rancherClusters.Items[0].Finalizers).To(ContainElement(managementv3.CapiClusterFinalizer))
 		}).Should(Succeed())
-		Expect(rancherClusters.Items[0].Name).To(ContainSubstring("c-"))
-		Expect(rancherClusters.Items[0].Labels).To(HaveKeyWithValue(testLabelName, testLabelVal))
+
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(capiCluster), capiCluster)).ToNot(HaveOccurred())
+			g.Expect(capiCluster.Finalizers).To(ContainElement(managementv3.CapiClusterFinalizer))
+		}).Should(Succeed())
 	})
 
 	It("should reconcile a CAPI cluster when rancher cluster doesn't exist and annotation is set on the namespace", func() {
@@ -223,7 +229,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		Expect(rancherClusters.Items[0].Name).To(ContainSubstring("c-"))
 	})
 
-	It("should reconcile a CAPI cluster when rancher cluster exists", func() {
+	It("should reconcile a CAPI cluster when rancher cluster exists, and have finalizers set", func() {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(sampleTemplate))
@@ -244,6 +250,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		Eventually(ctx, func(g Gomega) {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
+			g.Expect(rancherClusters.Items[0].Finalizers).ToNot(ContainElement(managementv3.CapiClusterFinalizer))
 		}).Should(Succeed())
 		cluster := rancherClusters.Items[0]
 		Expect(cluster.Name).To(ContainSubstring("c-"))
@@ -282,11 +289,16 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 					Name:      unstructuredObj.GetName(),
 				}, unstructuredObj)).To(Succeed())
 
-				g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
-				g.Expect(rancherClusters.Items).To(HaveLen(1))
-				g.Expect(rancherClusters.Items[0].Name).To(ContainSubstring("c-"))
-				g.Expect(rancherClusters.Items[0].Labels).To(HaveKeyWithValue(testLabelName, testLabelVal))
 			}
+
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(capiCluster), capiCluster)).ToNot(HaveOccurred())
+			g.Expect(capiCluster.Finalizers).To(ContainElement(managementv3.CapiClusterFinalizer))
+
+			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
+			g.Expect(rancherClusters.Items).To(HaveLen(1))
+			g.Expect(rancherClusters.Items[0].Name).To(ContainSubstring("c-"))
+			g.Expect(rancherClusters.Items[0].Labels).To(HaveKeyWithValue(testLabelName, testLabelVal))
+			g.Expect(rancherClusters.Items[0].Finalizers).To(ContainElement(managementv3.CapiClusterFinalizer))
 		}, 10*time.Second).Should(Succeed())
 	})
 
@@ -534,4 +546,5 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			Expect(rancherClusters.Items).To(HaveLen(0))
 		}).Should(Succeed())
 	})
+
 })


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

As we are unable to set ownership references from CAPI cluster to a cluster scoped management v3 cluster, we have to manage deletion manually. This comes with a problem of tracking deletion order for rancher/capi cluster, and setting `imported` annotation to prevent re-import scenario.

There is a race condition if removal of management v3 cluster happens too fast - turtles misses the opportunity to set `imported` annotation first and causes immediate re-import of the cluster. To prevent such scenario, we need to set `capicluster.turtles.cattle.io` to the management v3 resource we created at all times, and clean it up within the `imported` annotation handling scope on deletion.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #589 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
