### PR TITLE
E2E: Add custom ingress for gitea

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ SKIP_RESOURCE_CLEANUP ?= false
 USE_EXISTING_CLUSTER ?= false
 USE_EKS ?= true
 ISOLATED_MODE ?= false
+GITEA_CUSTOM_INGRESS ?= false
 GINKGO_NOCOLOR ?= false
 GINKGO_LABEL_FILTER ?= short
 GINKGO_TESTS ?= $(ROOT_DIR)/$(TEST_DIR)/e2e/suites/...
@@ -535,7 +536,8 @@ test-e2e: $(GINKGO) $(HELM) $(CLUSTERCTL) kubectl e2e-image ## Run the end-to-en
 	    -e2e.skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) \
 		-e2e.use-existing-cluster=$(USE_EXISTING_CLUSTER) \
 		-e2e.isolated-mode=$(ISOLATED_MODE) \
-		-e2e.use-eks=$(USE_EKS)
+		-e2e.use-eks=$(USE_EKS) \
+		-e2e.gitea-custom-ingress=$(GITEA_CUSTOM_INGRESS)
 
 .PHONY: e2e-image
 e2e-image: ## Build the image for e2e tests

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -80,6 +80,9 @@ var (
 
 	//go:embed data/cluster-templates/vsphere-kubeadm.yaml
 	CAPIvSphereKubeadm []byte
+
+	//go:embed data/gitea/ingress.yaml
+	GiteaIngress []byte
 )
 
 const (

--- a/test/e2e/data/cluster-templates/vsphere-kubeadm.yaml
+++ b/test/e2e/data/cluster-templates/vsphere-kubeadm.yaml
@@ -57,6 +57,7 @@ spec:
       numCPUs: 2
       os: Linux
       powerOffMode: hard
+      resourcePool: '${VSPHERE_RESOURCE_POOL}'
       server: '${VSPHERE_SERVER}'
       template: '${VSPHERE_TEMPLATE}'
       thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
@@ -186,6 +187,7 @@ spec:
       server: '${VSPHERE_SERVER}'
       template: '${VSPHERE_TEMPLATE}'
       thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
+      resourcePool: '${VSPHERE_RESOURCE_POOL}'
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/gitea/ingress.yaml
+++ b/test/e2e/data/gitea/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gitea-http
+  namespace: default
+spec:
+  ingressClassName: ngrok # This ingress in intended to be used only with ngrok
+  rules:
+  - host: gitea.${RANCHER_HOSTNAME}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: gitea-http
+            port:
+              number: 3000

--- a/test/e2e/flags.go
+++ b/test/e2e/flags.go
@@ -54,6 +54,9 @@ type FlagValues struct {
 
 	// ClusterctlBinaryPath is the path to the clusterctl binary to use.
 	ClusterctlBinaryPath string
+
+	// GiteaCustomIngress is the flag to enable custom ingress for Gitea.
+	GiteaCustomIngress bool
 }
 
 // InitFlags is used to specify the standard flags for the e2e tests.
@@ -68,4 +71,5 @@ func InitFlags(values *FlagValues) {
 	flag.StringVar(&values.ClusterctlBinaryPath, "e2e.clusterctl-binary-path", "helm", "path to the clusterctl binary")
 	flag.StringVar(&values.ChartPath, "e2e.chart-path", "", "path to the operator chart")
 	flag.BoolVar(&values.IsolatedMode, "e2e.isolated-mode", false, "if true, the test will run without ngrok and exposing the cluster to the internet. This setup will only work with CAPD or other providers that run in the same network as the bootstrap cluster.")
+	flag.BoolVar(&values.GiteaCustomIngress, "e2e.gitea-custom-ingress", false, "if true, the test will use a custom ingress for Gitea")
 }

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -41,6 +41,7 @@ import (
 	managementv3 "github.com/rancher/turtles/internal/rancher/management/v3"
 	provisioningv1 "github.com/rancher/turtles/internal/rancher/provisioning/v1"
 	turtlesframework "github.com/rancher/turtles/test/framework"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 func SetupSpecNamespace(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder string) (*corev1.Namespace, context.CancelFunc) {
@@ -86,6 +87,7 @@ func InitScheme() *runtime.Scheme {
 	Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
 	Expect(provisioningv1.AddToScheme(scheme)).To(Succeed())
 	Expect(managementv3.AddToScheme(scheme)).To(Succeed())
+	Expect(networkingv1.AddToScheme(scheme)).To(Succeed())
 	return scheme
 }
 

--- a/test/e2e/specs/import_gitops.go
+++ b/test/e2e/specs/import_gitops.go
@@ -277,6 +277,7 @@ func CreateUsingGitOpsSpec(ctx context.Context, inputGetter func() CreateUsingGi
 		turtlesframework.RancherGetOriginalKubeconfig(ctx, turtlesframework.RancherGetClusterKubeconfigInput{
 			Getter:          input.BootstrapClusterProxy.GetClient(),
 			SecretName:      fmt.Sprintf("%s-kubeconfig", capiCluster.Name),
+			ClusterName:     capiCluster.Name,
 			Namespace:       capiCluster.Namespace,
 			WriteToTempFile: true,
 		}, originalKubeconfig)

--- a/test/e2e/specs/import_gitops_mgmtv3.go
+++ b/test/e2e/specs/import_gitops_mgmtv3.go
@@ -297,6 +297,7 @@ func CreateMgmtV3UsingGitOpsSpec(ctx context.Context, inputGetter func() CreateM
 		turtlesframework.RancherGetOriginalKubeconfig(ctx, turtlesframework.RancherGetClusterKubeconfigInput{
 			Getter:          input.BootstrapClusterProxy.GetClient(),
 			SecretName:      fmt.Sprintf("%s-kubeconfig", capiCluster.Name),
+			ClusterName:     capiCluster.Name,
 			Namespace:       capiCluster.Namespace,
 			WriteToTempFile: true,
 		}, originalKubeconfig)

--- a/test/e2e/specs/migrate_gitops_provv1_mgmtv3.go
+++ b/test/e2e/specs/migrate_gitops_provv1_mgmtv3.go
@@ -341,6 +341,7 @@ func MigrateToV3UsingGitOpsSpec(ctx context.Context, inputGetter func() MigrateT
 		turtlesframework.RancherGetOriginalKubeconfig(ctx, turtlesframework.RancherGetClusterKubeconfigInput{
 			Getter:          input.BootstrapClusterProxy.GetClient(),
 			SecretName:      fmt.Sprintf("%s-kubeconfig", capiCluster.Name),
+			ClusterName:     capiCluster.Name,
 			Namespace:       capiCluster.Namespace,
 			WriteToTempFile: true,
 		}, originalKubeconfig)

--- a/test/e2e/suites/import-gitops-v3/suite_test.go
+++ b/test/e2e/suites/import-gitops-v3/suite_test.go
@@ -29,14 +29,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	"github.com/rancher/turtles/test/e2e"
 	"github.com/rancher/turtles/test/framework"
 	turtlesframework "github.com/rancher/turtles/test/framework"
 	"github.com/rancher/turtles/test/testenv"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // Test suite flags.
@@ -237,10 +237,15 @@ var _ = BeforeSuite(func() {
 	giteaValues := map[string]string{
 		"gitea.admin.username": e2eConfig.GetVariable(e2e.GiteaUserNameVar),
 		"gitea.admin.password": e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
-		"service.http.type":    "NodePort",
 	}
+
+	giteaServiceType := corev1.ServiceTypeNodePort
 	if flagVals.UseEKS {
-		giteaValues["service.http.type"] = "LoadBalancer"
+		giteaServiceType = corev1.ServiceTypeLoadBalancer
+	}
+
+	if flagVals.GiteaCustomIngress {
+		giteaServiceType = corev1.ServiceTypeClusterIP
 	}
 
 	giteaResult = testenv.DeployGitea(ctx, testenv.DeployGiteaInput{
@@ -257,6 +262,9 @@ var _ = BeforeSuite(func() {
 		AuthSecretName:        e2e.AuthSecretName,
 		Username:              e2eConfig.GetVariable(e2e.GiteaUserNameVar),
 		Password:              e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
+		ServiceType:           giteaServiceType,
+		CustomIngressConfig:   e2e.GiteaIngress,
+		Variables:             e2eConfig.Variables,
 	})
 })
 

--- a/test/e2e/suites/import-gitops/suite_test.go
+++ b/test/e2e/suites/import-gitops/suite_test.go
@@ -29,14 +29,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	"github.com/rancher/turtles/test/e2e"
 	"github.com/rancher/turtles/test/framework"
 	turtlesframework "github.com/rancher/turtles/test/framework"
 	"github.com/rancher/turtles/test/testenv"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // Test suite flags.
@@ -301,10 +301,15 @@ var _ = BeforeSuite(func() {
 	giteaValues := map[string]string{
 		"gitea.admin.username": e2eConfig.GetVariable(e2e.GiteaUserNameVar),
 		"gitea.admin.password": e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
-		"service.http.type":    "NodePort",
 	}
+
+	giteaServiceType := corev1.ServiceTypeNodePort
 	if flagVals.UseEKS {
-		giteaValues["service.http.type"] = "LoadBalancer"
+		giteaServiceType = corev1.ServiceTypeLoadBalancer
+	}
+
+	if flagVals.GiteaCustomIngress {
+		giteaServiceType = corev1.ServiceTypeClusterIP
 	}
 
 	giteaResult = testenv.DeployGitea(ctx, testenv.DeployGiteaInput{
@@ -321,6 +326,9 @@ var _ = BeforeSuite(func() {
 		AuthSecretName:        e2e.AuthSecretName,
 		Username:              e2eConfig.GetVariable(e2e.GiteaUserNameVar),
 		Password:              e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
+		ServiceType:           giteaServiceType,
+		CustomIngressConfig:   e2e.GiteaIngress,
+		Variables:             e2eConfig.Variables,
 	})
 })
 

--- a/test/e2e/suites/migrate-gitops/suite_test.go
+++ b/test/e2e/suites/migrate-gitops/suite_test.go
@@ -29,13 +29,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	"github.com/rancher/turtles/test/e2e"
 	turtlesframework "github.com/rancher/turtles/test/framework"
 	"github.com/rancher/turtles/test/testenv"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // Test suite flags.
@@ -188,7 +188,15 @@ var _ = BeforeSuite(func() {
 	giteaValues := map[string]string{
 		"gitea.admin.username": e2eConfig.GetVariable(e2e.GiteaUserNameVar),
 		"gitea.admin.password": e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
-		"service.http.type":    "NodePort",
+	}
+
+	giteaServiceType := corev1.ServiceTypeNodePort
+	if flagVals.UseEKS {
+		giteaServiceType = corev1.ServiceTypeLoadBalancer
+	}
+
+	if flagVals.GiteaCustomIngress {
+		giteaServiceType = corev1.ServiceTypeClusterIP
 	}
 
 	giteaResult = testenv.DeployGitea(ctx, testenv.DeployGiteaInput{
@@ -205,6 +213,9 @@ var _ = BeforeSuite(func() {
 		AuthSecretName:        e2e.AuthSecretName,
 		Username:              e2eConfig.GetVariable(e2e.GiteaUserNameVar),
 		Password:              e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
+		ServiceType:           giteaServiceType,
+		CustomIngressConfig:   e2e.GiteaIngress,
+		Variables:             e2eConfig.Variables,
 	})
 })
 

--- a/test/framework/helper.go
+++ b/test/framework/helper.go
@@ -38,7 +38,7 @@ type VariableLookupFunc func(key string) string
 // GetVariable is used to get the value for a variable. The expectation is that the variable exists in one of
 // the sources. Assertion will fail if its not found. The order of precedence when checking for variables is:
 // 1. Environment variables
-// 2. Base variablesß
+// 2. Base variables
 // This is a re-implementation of the CAPI function to add additional logging.
 func GetVariable(vars VariableCollection) VariableLookupFunc {
 	Expect(vars).ToNot(BeNil(), "Variable should not be nil")

--- a/test/framework/rancher_helpers.go
+++ b/test/framework/rancher_helpers.go
@@ -43,6 +43,7 @@ type RancherGetClusterKubeconfigInput struct {
 	Getter           framework.Getter
 	SecretName       string
 	Namespace        string
+	ClusterName      string
 	RancherServerURL string
 	WriteToTempFile  bool
 }
@@ -160,7 +161,7 @@ func RancherGetOriginalKubeconfig(ctx context.Context, input RancherGetClusterKu
 func (i *RancherGetClusterKubeconfigInput) isDockerCluster(ctx context.Context) bool {
 	cluster := &clusterv1.Cluster{}
 	key := client.ObjectKey{
-		Name:      i.SecretName,
+		Name:      i.ClusterName,
 		Namespace: i.Namespace,
 	}
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR adds an option to set up a custom ingress object for Gitea. We need an ingress for every service we want to expose to the local host on Mac. 
Setting up Gitea ingress is enabled by setting an e2e flag, we'll rethink this approach along with other flags as a part of https://github.com/rancher/turtles/issues/603.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
