### PR TITLE
Perform finalizer removal independently from main controller loop

### DIFF
--- a/internal/controllers/import_controller_v3.go
+++ b/internal/controllers/import_controller_v3.go
@@ -168,6 +168,11 @@ func (r *CAPIImportManagementV3Reconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{RequeueAfter: defaultRequeueDuration}, nil
 	}
 
+	if turtlesannotations.HasClusterImportAnnotation(capiCluster) {
+		log.Info("cluster was imported already and has imported=true annotation set, skipping re-import")
+		return ctrl.Result{}, nil
+	}
+
 	// Collect errors as an aggregate to return together after all patches have been performed.
 	var errs []error
 

--- a/main.go
+++ b/main.go
@@ -226,15 +226,15 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 			setupLog.Error(err, "unable to create capi controller")
 			os.Exit(1)
 		}
+	}
 
-		if err := (&controllers.CAPIDowngradeReconciler{
-			RancherClient: rancherClient,
-		}).SetupWithManager(ctx, mgr, controller.Options{
-			MaxConcurrentReconciles: concurrencyNumber,
-		}); err != nil {
-			setupLog.Error(err, "unable to create rancher management v3 downgrade controller")
-			os.Exit(1)
-		}
+	if err := (&controllers.CAPICleanupReconciler{
+		RancherClient: rancherClient,
+	}).SetupWithManager(ctx, mgr, controller.Options{
+		MaxConcurrentReconciles: concurrencyNumber,
+	}); err != nil {
+		setupLog.Error(err, "unable to create rancher management v3 cleanup controller")
+		os.Exit(1)
 	}
 
 	if feature.Gates.Enabled(feature.RancherKubeSecretPatch) {


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Due to deletion logic executed only based on CAPICluster state, the cleanup procedure never removes finalizer if it fails, and the CAPI cluster is annotated with “imported: true”. This needs to be executed separately, this PR changes that.

Typically the problem appeared after longer duration of time - once the cluster got fully imported and stayed untouched for a couple of minuted, then deleted. Thus [e2e](https://github.com/rancher/rancher-turtles-e2e) suite was more successful in uncovering the issue.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #589 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
