### PR TITLE
Pin CAAPF version to v0.3.0

### DIFF
--- a/charts/rancher-turtles/questions.yml
+++ b/charts/rancher-turtles/questions.yml
@@ -72,7 +72,7 @@ questions:
     group: "Rancher Turtles Features Settings"
   - variable: rancherTurtles.features.addon-provider-fleet.enabled
     default: false
-    description: "(Experimental) Enable Fleet Addon Provider functionality in Rancher Turtles"
+    description: "Enable Fleet Addon Provider functionality in Rancher Turtles"
     type: boolean
     label: Seamless integration with Fleet and CAPI
     group: "Rancher Turtles Features Settings"

--- a/charts/rancher-turtles/templates/addon-provider-fleet.yaml
+++ b/charts/rancher-turtles/templates/addon-provider-fleet.yaml
@@ -31,8 +31,10 @@ data:
     spec:
       clusterClass:
         patchResource: true
+        setOwnerReferences: true
       cluster:
         patchResource: true
+        setOwnerReferences: true
         selector:
           matchLabels:
             cluster-api.cattle.io/rancher-auto-import: "true"

--- a/charts/rancher-turtles/templates/clusterctl-config.yaml
+++ b/charts/rancher-turtles/templates/clusterctl-config.yaml
@@ -50,6 +50,6 @@ data:
 
     # Addon providers
     - name:         "fleet"
-      url:          "https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/latest/addon-components.yaml"
+      url:          "https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/v0.3.0/addon-components.yaml"
       type:         "AddonProvider"
 {{- end }}

--- a/test/e2e/suites/import-gitops-v3/suite_test.go
+++ b/test/e2e/suites/import-gitops-v3/suite_test.go
@@ -193,7 +193,9 @@ var _ = BeforeSuite(func() {
 		Image:                        fmt.Sprintf("ghcr.io/rancher/turtles-e2e-%s", runtime.GOARCH),
 		Tag:                          "v0.0.1",
 		WaitDeploymentsReadyInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
-		AdditionalValues:             map[string]string{},
+		AdditionalValues: map[string]string{
+			"rancherTurtles.features.addon-provider-fleet.enabled": "true",
+		},
 	}
 	if flagVals.UseEKS {
 		rtInput.AdditionalValues["rancherTurtles.imagePullSecrets"] = "{regcred}"

--- a/test/e2e/suites/migrate-gitops/suite_test.go
+++ b/test/e2e/suites/migrate-gitops/suite_test.go
@@ -32,8 +32,12 @@ import (
 	"github.com/rancher/turtles/test/e2e"
 	turtlesframework "github.com/rancher/turtles/test/framework"
 	"github.com/rancher/turtles/test/testenv"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -182,6 +186,17 @@ var _ = BeforeSuite(func() {
 	rtInput.AdditionalValues["rancherTurtles.imagePullPolicy"] = "Never"
 	rtInput.AdditionalValues["rancherTurtles.features.addon-provider-fleet.enabled"] = "true"
 	rtInput.AdditionalValues["rancherTurtles.features.managementv3-cluster.enabled"] = "false" // disable the default management.cattle.io/v3 controller
+
+	upgradeInput.PostUpgradeSteps = append(upgradeInput.PostUpgradeSteps, func() {
+		By("Waiting for CAAPF deployment to be available")
+		framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
+			Getter: setupClusterResult.BootstrapClusterProxy.GetClient(),
+			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+				Name:      "caapf-controller-manager",
+				Namespace: "rancher-turtles-system",
+			}},
+		}, e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers")...)
+	})
 
 	testenv.UpgradeRancherTurtles(ctx, upgradeInput)
 

--- a/test/testenv/turtles.go
+++ b/test/testenv/turtles.go
@@ -194,6 +194,7 @@ type UpgradeRancherTurtlesInput struct {
 	AdditionalValues             map[string]string
 	Image                        string
 	Tag                          string
+	PostUpgradeSteps             []func()
 	SkipCleanup                  bool
 }
 
@@ -258,6 +259,10 @@ func UpgradeRancherTurtles(ctx context.Context, input UpgradeRancherTurtlesInput
 
 	if err != nil {
 		Expect(fmt.Errorf("Unable to perform chart upgrade: %w\nOutput: %s, Command: %s", err, out, strings.Join(append(values, additionalValues...), " "))).ToNot(HaveOccurred())
+	}
+
+	for _, step := range input.PostUpgradeSteps {
+		step()
 	}
 }
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Pinned CAAPF to version 0.3.0 and marked it as non-experimental.

Since fleet released v0.10.1-rc.1, but it is not a part of rancher/charts yet, this PR can’t add full e2e suite, which will convert `CNI` installation to the cluster using fleet and enable `hostNetwork: true` setting.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #615  

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
