### PR TITLE
Refactor e2e suite setup to make it more customizable

### DIFF
--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -92,6 +92,7 @@ const (
 	RancherTurtlesNamespace = "rancher-turtles-system"
 	RancherNamespace        = "cattle-system"
 	NginxIngressNamespace   = "ingress-nginx"
+	NginxIngressDeployment  = "ingress-nginx-controller"
 )
 
 const (

--- a/test/e2e/suites/embedded-capi-disabled-v3/suite_test.go
+++ b/test/e2e/suites/embedded-capi-disabled-v3/suite_test.go
@@ -84,45 +84,50 @@ var _ = BeforeSuite(func() {
 	By(fmt.Sprintf("Loading the e2e test configuration from %q", flagVals.ConfigPath))
 	e2eConfig = e2e.LoadE2EConfig(flagVals.ConfigPath)
 
+	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
+	ingressType := testenv.NgrokIngress
 	dockerUsername := ""
 	dockerPassword := ""
+	var customClusterProvider testenv.CustomClusterProvider
+
 	if flagVals.UseEKS {
 		Expect(flagVals.IsolatedMode).To(BeFalse(), "You cannot use eks with isolated")
 		dockerUsername = os.Getenv("GITHUB_USERNAME")
 		Expect(dockerUsername).NotTo(BeEmpty(), "Github username is required")
 		dockerPassword = os.Getenv("GITHUB_TOKEN")
 		Expect(dockerPassword).NotTo(BeEmpty(), "Github token is required")
+		customClusterProvider = testenv.EKSBootsrapCluster
+		Expect(customClusterProvider).NotTo(BeNil(), "EKS custom cluster provider is required")
+		ingressType = testenv.EKSNginxIngress
+	}
+
+	if flagVals.IsolatedMode {
+		ingressType = testenv.CustomIngress
 	}
 
 	By(fmt.Sprintf("Creating a clusterctl config into %q", flagVals.ArtifactFolder))
 	clusterctlConfigPath = e2e.CreateClusterctlLocalRepository(ctx, e2eConfig, filepath.Join(flagVals.ArtifactFolder, "repository"))
 
-	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
-
 	setupClusterResult = testenv.SetupTestCluster(ctx, testenv.SetupTestClusterInput{
-		UseExistingCluster:   flagVals.UseExistingCluster,
-		E2EConfig:            e2eConfig,
-		ClusterctlConfigPath: clusterctlConfigPath,
-		Scheme:               e2e.InitScheme(),
-		ArtifactFolder:       flagVals.ArtifactFolder,
-		KubernetesVersion:    e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
-		IsolatedMode:         flagVals.IsolatedMode,
-		HelmBinaryPath:       flagVals.HelmBinaryPath,
-		UseEKS:               flagVals.UseEKS,
+		UseExistingCluster:    flagVals.UseExistingCluster,
+		E2EConfig:             e2eConfig,
+		ClusterctlConfigPath:  clusterctlConfigPath,
+		Scheme:                e2e.InitScheme(),
+		ArtifactFolder:        flagVals.ArtifactFolder,
+		KubernetesVersion:     e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
+		IsolatedMode:          flagVals.IsolatedMode,
+		HelmBinaryPath:        flagVals.HelmBinaryPath,
+		CustomClusterProvider: customClusterProvider,
 	})
-
-	if flagVals.IsolatedMode {
-		hostName = setupClusterResult.IsolatedHostName
-	}
 
 	testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 		BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:           flagVals.HelmBinaryPath,
 		HelmExtraValuesPath:      filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher-ingress.yaml"),
-		IsolatedMode:             flagVals.IsolatedMode,
-		UseEKS:                   flagVals.UseEKS,
-		NginxIngress:             e2e.NginxIngress,
-		NginxIngressNamespace:    e2e.NginxIngressNamespace,
+		IngressType:              ingressType,
+		CustomIngress:            e2e.NginxIngress,
+		CustomIngressNamespace:   e2e.NginxIngressNamespace,
+		CustomIngressDeployment:  e2e.NginxIngressDeployment,
 		IngressWaitInterval:      e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-rancher"),
 		NgrokApiKey:              e2eConfig.GetVariable(e2e.NgrokApiKeyVar),
 		NgrokAuthToken:           e2eConfig.GetVariable(e2e.NgrokAuthTokenVar),
@@ -131,6 +136,10 @@ var _ = BeforeSuite(func() {
 		NgrokRepoURL:             e2eConfig.GetVariable(e2e.NgrokUrlVar),
 		DefaultIngressClassPatch: e2e.IngressClassPatch,
 	})
+
+	if flagVals.IsolatedMode {
+		hostName = setupClusterResult.IsolatedHostName
+	}
 
 	if flagVals.UseEKS {
 		By("Getting ingress hostname")

--- a/test/e2e/suites/import-gitops-v3/suite_test.go
+++ b/test/e2e/suites/import-gitops-v3/suite_test.go
@@ -84,45 +84,50 @@ var _ = BeforeSuite(func() {
 	By(fmt.Sprintf("Loading the e2e test configuration from %q", flagVals.ConfigPath))
 	e2eConfig = e2e.LoadE2EConfig(flagVals.ConfigPath)
 
+	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
+	ingressType := testenv.NgrokIngress
 	dockerUsername := ""
 	dockerPassword := ""
+	var customClusterProvider testenv.CustomClusterProvider
+
 	if flagVals.UseEKS {
 		Expect(flagVals.IsolatedMode).To(BeFalse(), "You cannot use eks with isolated")
 		dockerUsername = os.Getenv("GITHUB_USERNAME")
 		Expect(dockerUsername).NotTo(BeEmpty(), "Github username is required")
 		dockerPassword = os.Getenv("GITHUB_TOKEN")
 		Expect(dockerPassword).NotTo(BeEmpty(), "Github token is required")
+		customClusterProvider = testenv.EKSBootsrapCluster
+		Expect(customClusterProvider).NotTo(BeNil(), "EKS custom cluster provider is required")
+		ingressType = testenv.EKSNginxIngress
+	}
+
+	if flagVals.IsolatedMode {
+		ingressType = testenv.CustomIngress
 	}
 
 	By(fmt.Sprintf("Creating a clusterctl config into %q", flagVals.ArtifactFolder))
 	clusterctlConfigPath = e2e.CreateClusterctlLocalRepository(ctx, e2eConfig, filepath.Join(flagVals.ArtifactFolder, "repository"))
 
-	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
-
 	setupClusterResult = testenv.SetupTestCluster(ctx, testenv.SetupTestClusterInput{
-		UseExistingCluster:   flagVals.UseExistingCluster,
-		E2EConfig:            e2eConfig,
-		ClusterctlConfigPath: clusterctlConfigPath,
-		Scheme:               e2e.InitScheme(),
-		ArtifactFolder:       flagVals.ArtifactFolder,
-		KubernetesVersion:    e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
-		IsolatedMode:         flagVals.IsolatedMode,
-		HelmBinaryPath:       flagVals.HelmBinaryPath,
-		UseEKS:               flagVals.UseEKS,
+		UseExistingCluster:    flagVals.UseExistingCluster,
+		E2EConfig:             e2eConfig,
+		ClusterctlConfigPath:  clusterctlConfigPath,
+		Scheme:                e2e.InitScheme(),
+		ArtifactFolder:        flagVals.ArtifactFolder,
+		KubernetesVersion:     e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
+		IsolatedMode:          flagVals.IsolatedMode,
+		HelmBinaryPath:        flagVals.HelmBinaryPath,
+		CustomClusterProvider: customClusterProvider,
 	})
-
-	if flagVals.IsolatedMode {
-		hostName = setupClusterResult.IsolatedHostName
-	}
 
 	testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 		BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:           flagVals.HelmBinaryPath,
 		HelmExtraValuesPath:      filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher-ingress.yaml"),
-		IsolatedMode:             flagVals.IsolatedMode,
-		UseEKS:                   flagVals.UseEKS,
-		NginxIngress:             e2e.NginxIngress,
-		NginxIngressNamespace:    e2e.NginxIngressNamespace,
+		IngressType:              ingressType,
+		CustomIngress:            e2e.NginxIngress,
+		CustomIngressNamespace:   e2e.NginxIngressNamespace,
+		CustomIngressDeployment:  e2e.NginxIngressDeployment,
 		IngressWaitInterval:      e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-rancher"),
 		NgrokApiKey:              e2eConfig.GetVariable(e2e.NgrokApiKeyVar),
 		NgrokAuthToken:           e2eConfig.GetVariable(e2e.NgrokAuthTokenVar),
@@ -131,6 +136,10 @@ var _ = BeforeSuite(func() {
 		NgrokRepoURL:             e2eConfig.GetVariable(e2e.NgrokUrlVar),
 		DefaultIngressClassPatch: e2e.IngressClassPatch,
 	})
+
+	if flagVals.IsolatedMode {
+		hostName = setupClusterResult.IsolatedHostName
+	}
 
 	if flagVals.UseEKS {
 		By("Getting ingress hostname")

--- a/test/e2e/suites/import-gitops/suite_test.go
+++ b/test/e2e/suites/import-gitops/suite_test.go
@@ -87,45 +87,50 @@ var _ = BeforeSuite(func() {
 	By(fmt.Sprintf("Loading the e2e test configuration from %q", flagVals.ConfigPath))
 	e2eConfig = e2e.LoadE2EConfig(flagVals.ConfigPath)
 
+	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
+	ingressType := testenv.NgrokIngress
 	dockerUsername := ""
 	dockerPassword := ""
+	var customClusterProvider testenv.CustomClusterProvider
+
 	if flagVals.UseEKS {
 		Expect(flagVals.IsolatedMode).To(BeFalse(), "You cannot use eks with isolated")
 		dockerUsername = os.Getenv("GITHUB_USERNAME")
 		Expect(dockerUsername).NotTo(BeEmpty(), "Github username is required")
 		dockerPassword = os.Getenv("GITHUB_TOKEN")
 		Expect(dockerPassword).NotTo(BeEmpty(), "Github token is required")
+		customClusterProvider = testenv.EKSBootsrapCluster
+		Expect(customClusterProvider).NotTo(BeNil(), "EKS custom cluster provider is required")
+		ingressType = testenv.EKSNginxIngress
+	}
+
+	if flagVals.IsolatedMode {
+		ingressType = testenv.CustomIngress
 	}
 
 	By(fmt.Sprintf("Creating a clusterctl config into %q", flagVals.ArtifactFolder))
 	clusterctlConfigPath = e2e.CreateClusterctlLocalRepository(ctx, e2eConfig, filepath.Join(flagVals.ArtifactFolder, "repository"))
 
-	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
-
 	setupClusterResult = testenv.SetupTestCluster(ctx, testenv.SetupTestClusterInput{
-		UseExistingCluster:   flagVals.UseExistingCluster,
-		E2EConfig:            e2eConfig,
-		ClusterctlConfigPath: clusterctlConfigPath,
-		Scheme:               e2e.InitScheme(),
-		ArtifactFolder:       flagVals.ArtifactFolder,
-		KubernetesVersion:    e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
-		IsolatedMode:         flagVals.IsolatedMode,
-		HelmBinaryPath:       flagVals.HelmBinaryPath,
-		UseEKS:               flagVals.UseEKS,
+		UseExistingCluster:    flagVals.UseExistingCluster,
+		E2EConfig:             e2eConfig,
+		ClusterctlConfigPath:  clusterctlConfigPath,
+		Scheme:                e2e.InitScheme(),
+		ArtifactFolder:        flagVals.ArtifactFolder,
+		KubernetesVersion:     e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
+		IsolatedMode:          flagVals.IsolatedMode,
+		HelmBinaryPath:        flagVals.HelmBinaryPath,
+		CustomClusterProvider: customClusterProvider,
 	})
-
-	if flagVals.IsolatedMode {
-		hostName = setupClusterResult.IsolatedHostName
-	}
 
 	testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 		BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:           flagVals.HelmBinaryPath,
 		HelmExtraValuesPath:      filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher-ingress.yaml"),
-		IsolatedMode:             flagVals.IsolatedMode,
-		UseEKS:                   flagVals.UseEKS,
-		NginxIngress:             e2e.NginxIngress,
-		NginxIngressNamespace:    e2e.NginxIngressNamespace,
+		IngressType:              ingressType,
+		CustomIngress:            e2e.NginxIngress,
+		CustomIngressNamespace:   e2e.NginxIngressNamespace,
+		CustomIngressDeployment:  e2e.NginxIngressDeployment,
 		IngressWaitInterval:      e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-rancher"),
 		NgrokApiKey:              e2eConfig.GetVariable(e2e.NgrokApiKeyVar),
 		NgrokAuthToken:           e2eConfig.GetVariable(e2e.NgrokAuthTokenVar),
@@ -134,6 +139,10 @@ var _ = BeforeSuite(func() {
 		NgrokRepoURL:             e2eConfig.GetVariable(e2e.NgrokUrlVar),
 		DefaultIngressClassPatch: e2e.IngressClassPatch,
 	})
+
+	if flagVals.IsolatedMode {
+		hostName = setupClusterResult.IsolatedHostName
+	}
 
 	if flagVals.UseEKS {
 		By("Getting ingress hostname")

--- a/test/e2e/suites/update-labels/suite_test.go
+++ b/test/e2e/suites/update-labels/suite_test.go
@@ -83,45 +83,50 @@ var _ = BeforeSuite(func() {
 	By(fmt.Sprintf("Loading the e2e test configuration from %q", flagVals.ConfigPath))
 	e2eConfig = e2e.LoadE2EConfig(flagVals.ConfigPath)
 
+	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
+	ingressType := testenv.NgrokIngress
 	dockerUsername := ""
 	dockerPassword := ""
+	var customClusterProvider testenv.CustomClusterProvider
+
 	if flagVals.UseEKS {
 		Expect(flagVals.IsolatedMode).To(BeFalse(), "You cannot use eks with isolated")
 		dockerUsername = os.Getenv("GITHUB_USERNAME")
 		Expect(dockerUsername).NotTo(BeEmpty(), "Github username is required")
 		dockerPassword = os.Getenv("GITHUB_TOKEN")
 		Expect(dockerPassword).NotTo(BeEmpty(), "Github token is required")
+		customClusterProvider = testenv.EKSBootsrapCluster
+		Expect(customClusterProvider).NotTo(BeNil(), "EKS custom cluster provider is required")
+		ingressType = testenv.EKSNginxIngress
+	}
+
+	if flagVals.IsolatedMode {
+		ingressType = testenv.CustomIngress
 	}
 
 	By(fmt.Sprintf("Creating a clusterctl config into %q", flagVals.ArtifactFolder))
 	clusterctlConfigPath = e2e.CreateClusterctlLocalRepository(ctx, e2eConfig, filepath.Join(flagVals.ArtifactFolder, "repository"))
 
-	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
-
 	setupClusterResult = testenv.SetupTestCluster(ctx, testenv.SetupTestClusterInput{
-		UseExistingCluster:   flagVals.UseExistingCluster,
-		E2EConfig:            e2eConfig,
-		ClusterctlConfigPath: clusterctlConfigPath,
-		Scheme:               e2e.InitScheme(),
-		ArtifactFolder:       flagVals.ArtifactFolder,
-		KubernetesVersion:    e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
-		IsolatedMode:         flagVals.IsolatedMode,
-		HelmBinaryPath:       flagVals.HelmBinaryPath,
-		UseEKS:               flagVals.UseEKS,
+		UseExistingCluster:    flagVals.UseExistingCluster,
+		E2EConfig:             e2eConfig,
+		ClusterctlConfigPath:  clusterctlConfigPath,
+		Scheme:                e2e.InitScheme(),
+		ArtifactFolder:        flagVals.ArtifactFolder,
+		KubernetesVersion:     e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
+		IsolatedMode:          flagVals.IsolatedMode,
+		HelmBinaryPath:        flagVals.HelmBinaryPath,
+		CustomClusterProvider: customClusterProvider,
 	})
-
-	if flagVals.IsolatedMode {
-		hostName = setupClusterResult.IsolatedHostName
-	}
 
 	testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 		BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:           flagVals.HelmBinaryPath,
 		HelmExtraValuesPath:      filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher-ingress.yaml"),
-		IsolatedMode:             flagVals.IsolatedMode,
-		UseEKS:                   flagVals.UseEKS,
-		NginxIngress:             e2e.NginxIngress,
-		NginxIngressNamespace:    e2e.NginxIngressNamespace,
+		IngressType:              ingressType,
+		CustomIngress:            e2e.NginxIngress,
+		CustomIngressNamespace:   e2e.NginxIngressNamespace,
+		CustomIngressDeployment:  e2e.NginxIngressDeployment,
 		IngressWaitInterval:      e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-rancher"),
 		NgrokApiKey:              e2eConfig.GetVariable(e2e.NgrokApiKeyVar),
 		NgrokAuthToken:           e2eConfig.GetVariable(e2e.NgrokAuthTokenVar),
@@ -130,6 +135,10 @@ var _ = BeforeSuite(func() {
 		NgrokRepoURL:             e2eConfig.GetVariable(e2e.NgrokUrlVar),
 		DefaultIngressClassPatch: e2e.IngressClassPatch,
 	})
+
+	if flagVals.IsolatedMode {
+		hostName = setupClusterResult.IsolatedHostName
+	}
 
 	if flagVals.UseEKS {
 		By("Getting ingress hostname")

--- a/test/e2e/suites/v2prov/suite_test.go
+++ b/test/e2e/suites/v2prov/suite_test.go
@@ -83,45 +83,50 @@ var _ = BeforeSuite(func() {
 	By(fmt.Sprintf("Loading the e2e test configuration from %q", flagVals.ConfigPath))
 	e2eConfig = e2e.LoadE2EConfig(flagVals.ConfigPath)
 
+	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
+	ingressType := testenv.NgrokIngress
 	dockerUsername := ""
 	dockerPassword := ""
+	var customClusterProvider testenv.CustomClusterProvider
+
 	if flagVals.UseEKS {
 		Expect(flagVals.IsolatedMode).To(BeFalse(), "You cannot use eks with isolated")
 		dockerUsername = os.Getenv("GITHUB_USERNAME")
 		Expect(dockerUsername).NotTo(BeEmpty(), "Github username is required")
 		dockerPassword = os.Getenv("GITHUB_TOKEN")
 		Expect(dockerPassword).NotTo(BeEmpty(), "Github token is required")
+		customClusterProvider = testenv.EKSBootsrapCluster
+		Expect(customClusterProvider).NotTo(BeNil(), "EKS custom cluster provider is required")
+		ingressType = testenv.EKSNginxIngress
+	}
+
+	if flagVals.IsolatedMode {
+		ingressType = testenv.CustomIngress
 	}
 
 	By(fmt.Sprintf("Creating a clusterctl config into %q", flagVals.ArtifactFolder))
 	clusterctlConfigPath = e2e.CreateClusterctlLocalRepository(ctx, e2eConfig, filepath.Join(flagVals.ArtifactFolder, "repository"))
 
-	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
-
 	setupClusterResult = testenv.SetupTestCluster(ctx, testenv.SetupTestClusterInput{
-		UseExistingCluster:   flagVals.UseExistingCluster,
-		E2EConfig:            e2eConfig,
-		ClusterctlConfigPath: clusterctlConfigPath,
-		Scheme:               e2e.InitScheme(),
-		ArtifactFolder:       flagVals.ArtifactFolder,
-		KubernetesVersion:    e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
-		IsolatedMode:         flagVals.IsolatedMode,
-		HelmBinaryPath:       flagVals.HelmBinaryPath,
-		UseEKS:               flagVals.UseEKS,
+		UseExistingCluster:    flagVals.UseExistingCluster,
+		E2EConfig:             e2eConfig,
+		ClusterctlConfigPath:  clusterctlConfigPath,
+		Scheme:                e2e.InitScheme(),
+		ArtifactFolder:        flagVals.ArtifactFolder,
+		KubernetesVersion:     e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
+		IsolatedMode:          flagVals.IsolatedMode,
+		HelmBinaryPath:        flagVals.HelmBinaryPath,
+		CustomClusterProvider: customClusterProvider,
 	})
-
-	if flagVals.IsolatedMode {
-		hostName = setupClusterResult.IsolatedHostName
-	}
 
 	testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 		BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:           flagVals.HelmBinaryPath,
 		HelmExtraValuesPath:      filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher-ingress.yaml"),
-		IsolatedMode:             flagVals.IsolatedMode,
-		UseEKS:                   flagVals.UseEKS,
-		NginxIngress:             e2e.NginxIngress,
-		NginxIngressNamespace:    e2e.NginxIngressNamespace,
+		IngressType:              ingressType,
+		CustomIngress:            e2e.NginxIngress,
+		CustomIngressNamespace:   e2e.NginxIngressNamespace,
+		CustomIngressDeployment:  e2e.NginxIngressDeployment,
 		IngressWaitInterval:      e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-rancher"),
 		NgrokApiKey:              e2eConfig.GetVariable(e2e.NgrokApiKeyVar),
 		NgrokAuthToken:           e2eConfig.GetVariable(e2e.NgrokAuthTokenVar),
@@ -130,6 +135,10 @@ var _ = BeforeSuite(func() {
 		NgrokRepoURL:             e2eConfig.GetVariable(e2e.NgrokUrlVar),
 		DefaultIngressClassPatch: e2e.IngressClassPatch,
 	})
+
+	if flagVals.IsolatedMode {
+		hostName = setupClusterResult.IsolatedHostName
+	}
 
 	if flagVals.UseEKS {
 		By("Getting ingress hostname")

--- a/test/testenv/bootstrapclusterproviders.go
+++ b/test/testenv/bootstrapclusterproviders.go
@@ -1,0 +1,48 @@
+/*
+Copyright © 2023 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testenv
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+)
+
+type CustomClusterProvider func(ctx context.Context, config *clusterctl.E2EConfig, clusterName, kubernetesVersion string) bootstrap.ClusterProvider
+
+// EKSBootsrapCluster creates a new EKS bootstrap cluster and returns a ClusterProvider
+func EKSBootsrapCluster(ctx context.Context, config *clusterctl.E2EConfig, clusterName, kubernetesVersion string) bootstrap.ClusterProvider {
+	By("Creating a new EKS bootstrap cluster")
+
+	region := config.Variables["KUBERNETES_MANAGEMENT_AWS_REGION"]
+	Expect(region).ToNot(BeEmpty(), "KUBERNETES_MANAGEMENT_AWS_REGION must be set in the e2e config")
+
+	eksCreateResult := &CreateEKSBootstrapClusterAndValidateImagesInputResult{}
+	CreateEKSBootstrapClusterAndValidateImages(ctx, CreateEKSBootstrapClusterAndValidateImagesInput{
+		Name:       clusterName,
+		Version:    kubernetesVersion,
+		Region:     region,
+		NumWorkers: 1,
+		Images:     config.Images,
+	}, eksCreateResult)
+
+	return eksCreateResult.BootstrapClusterProvider
+}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Part of https://github.com/rancher/turtles/issues/603. This PR makes bootstrap cluster setup and ingress deployment more flexible, if anyone imports our framework they can now inject their own way to create bootstrap cluster or deploy ingress on it.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
