### PR TITLE
Re-enable RKE2 tests for 0.6.0 version, after migration

### DIFF
--- a/test/e2e/data/cluster-templates/docker-rke2.yaml
+++ b/test/e2e/data/cluster-templates/docker-rke2.yaml
@@ -169,3 +169,5 @@ data:
 kind: ConfigMap
 metadata:
   name: ${CLUSTER_NAME}-lb-config
+  annotations:
+    "helm.sh/resource-policy": keep

--- a/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
+++ b/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
@@ -62,7 +62,7 @@ var _ = Describe("[Docker] [Kubeadm] - [management.cattle.io/v3] Create and dele
 	})
 })
 
-var _ = Describe("[Docker] [RKE2] - [management.cattle.io/v3] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.DontRunLabel), func() {
+var _ = Describe("[Docker] [RKE2] - [management.cattle.io/v3] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.FullTestLabel), func() {
 	BeforeEach(func() {
 		komega.SetClient(setupClusterResult.BootstrapClusterProxy.GetClient())
 		komega.SetContext(ctx)
@@ -84,7 +84,7 @@ var _ = Describe("[Docker] [RKE2] - [management.cattle.io/v3] Create and delete 
 			SkipCleanup:                    false,
 			SkipDeletionTest:               false,
 			LabelNamespace:                 true,
-			TestClusterReimport:            true,
+			TestClusterReimport:            false,
 			RancherServerURL:               hostName,
 			CAPIClusterCreateWaitName:      "wait-rancher",
 			DeleteClusterWaitName:          "wait-controllers",

--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -62,36 +62,6 @@ var _ = Describe("[Docker] [Kubeadm] Create and delete CAPI cluster functionalit
 	})
 })
 
-var _ = Describe("[Docker] [RKE2] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.DontRunLabel), func() {
-	BeforeEach(func() {
-		SetClient(setupClusterResult.BootstrapClusterProxy.GetClient())
-		SetContext(ctx)
-	})
-
-	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
-		return specs.CreateUsingGitOpsSpecInput{
-			E2EConfig:                 e2eConfig,
-			BootstrapClusterProxy:     setupClusterResult.BootstrapClusterProxy,
-			ClusterctlConfigPath:      flagVals.ConfigPath,
-			ClusterctlBinaryPath:      e2eConfig.GetVariable(e2e.ClusterctlBinaryPathVar),
-			ArtifactFolder:            artifactsFolder,
-			ClusterTemplate:           e2e.CAPIDockerRKE2,
-			ClusterName:               "clusterv1-docker-rke2",
-			ControlPlaneMachineCount:  ptr.To[int](1),
-			WorkerMachineCount:        ptr.To[int](1),
-			GitAddr:                   giteaResult.GitAddress,
-			GitAuthSecretName:         e2e.AuthSecretName,
-			SkipCleanup:               false,
-			SkipDeletionTest:          false,
-			LabelNamespace:            true,
-			TestClusterReimport:       true,
-			RancherServerURL:          hostName,
-			CAPIClusterCreateWaitName: "wait-rancher",
-			DeleteClusterWaitName:     "wait-controllers",
-		}
-	})
-})
-
 var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.FullTestLabel), func() {
 	BeforeEach(func() {
 		komega.SetClient(setupClusterResult.BootstrapClusterProxy.GetClient())


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Released version 0.6.0 is not currently tested in rancher turtles.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
