### PR TITLE
fix: Install cert-manager before capi-operator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing Guidelines
 
-Please check our Contributing Guide [here](https://turtles.docs.rancher.com/docs/contributing/intro).
+Please check our Developer Guide [here](https://turtles.docs.rancher.com/developer-guide/intro).

--- a/scripts/kind-cluster-with-extramounts.yaml
+++ b/scripts/kind-cluster-with-extramounts.yaml
@@ -3,7 +3,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: capi-test
 nodes:
 - role: control-plane
-  image: kindest/node:v1.26.3
+  image: kindest/node:v1.27.13
   extraMounts:
     - hostPath: /var/run/docker.sock
       containerPath: /var/run/docker.sock

--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -30,7 +30,13 @@ kubectl rollout status deployment coredns -n kube-system --timeout=90s
 
 helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
 helm repo add capi-operator https://kubernetes-sigs.github.io/cluster-api-operator
+helm repo add jetstack https://charts.jetstack.io
 helm repo update
+
+helm install cert-manager jetstack/cert-manager \
+	--namespace cert-manager \
+	--create-namespace \
+	--set crds.enabled=true
 
 export EXP_CLUSTER_RESOURCE_SET=true
 export CLUSTER_TOPOLOGY=true
@@ -39,7 +45,6 @@ helm install capi-operator capi-operator/cluster-api-operator \
 	--create-namespace -n capi-operator-system \
 	--set infrastructure=docker:v1.4.6 \
 	--set core=cluster-api:v1.4.6 \
-	--set cert-manager.enabled=true \
 	--timeout 90s --wait
 
 kubectl rollout status deployment capi-operator-cluster-api-operator -n capi-operator-system --timeout=180s


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

The CAPI Operator Helm chart no longer installs cert-manager as a prerequisite. This PR changes the dev script to install cert-manager beforehand.

Also fixed the link to the dev guide.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
