### PR TITLE
Refactor E2E suite to make it more generic

### DIFF
--- a/.github/workflows/e2e-long.yaml
+++ b/.github/workflows/e2e-long.yaml
@@ -15,7 +15,7 @@ jobs:
       test_name: Import via GitOps
       run_azure_janitor: false
       artifact_name: artifacts_import_gitops
-      use_eks: true
+      management_cluster_infrastructure: eks
     secrets: inherit
   e2e_import_gitops_v3:
     uses: ./.github/workflows/run-e2e-suite.yaml
@@ -24,7 +24,7 @@ jobs:
       test_name: Import via GitOps [v3]
       run_azure_janitor: false
       artifact_name: artifacts_import_gitops_v3
-      use_eks: true
+      management_cluster_infrastructure: eks
     secrets: inherit
   e2e_v2prov:
     uses: ./.github/workflows/run-e2e-suite.yaml
@@ -33,7 +33,7 @@ jobs:
       test_name: v2 provisioning
       run_azure_janitor: true
       artifact_name: artifacts_v2prov
-      use_eks: true
+      management_cluster_infrastructure: eks
     secrets: inherit
   e2e_update_labels:
     uses: ./.github/workflows/run-e2e-suite.yaml
@@ -42,7 +42,7 @@ jobs:
       test_name: Update labels
       run_azure_janitor: true
       artifact_name: artifacts_update_labels
-      use_eks: true
+      management_cluster_infrastructure: eks
     secrets: inherit
   e2e_embedded_capi_disabled:
     uses: ./.github/workflows/run-e2e-suite.yaml
@@ -51,7 +51,7 @@ jobs:
       test_name: Embedded CAPI disabled
       run_azure_janitor: false
       artifact_name: artifacts_embedded_capi
-      use_eks: true
+      management_cluster_infrastructure: eks
     secrets: inherit
   e2e_embedded_capi_disabled_v3:
     uses: ./.github/workflows/run-e2e-suite.yaml
@@ -60,5 +60,5 @@ jobs:
       test_name: Embedded CAPI disabled [v3]
       run_azure_janitor: false
       artifact_name: artifacts_embedded_capi_v3
-      use_eks: true
+      management_cluster_infrastructure: eks
     secrets: inherit

--- a/.github/workflows/e2e-short-test.yaml
+++ b/.github/workflows/e2e-short-test.yaml
@@ -3,6 +3,10 @@ name: Run short e2e tests (with runner)
 on:
   workflow_dispatch:
 
+env:
+  MANAGEMENT_CLUSTER_INFRASTRUCTURE: "isolated-kind"
+  GINKGO_LABEL_FILTER: "short"
+
 jobs:
   e2e:
     runs-on: org--rancher--amd64-containers
@@ -17,7 +21,7 @@ jobs:
         with:
           go-version: "=1.22.0"
       - name: Run e2e tests
-        run: ISOLATED_MODE=true  USE_EKS=false GINKGO_LABEL_FILTER=short make test-e2e
+        run: make test-e2e
       - name: Collect run artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-short.yaml
+++ b/.github/workflows/e2e-short.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
+env:
+  MANAGEMENT_CLUSTER_INFRASTRUCTURE: "isolated-kind"
+  GINKGO_LABEL_FILTER: "short"
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
@@ -34,7 +38,7 @@ jobs:
         with:
           go-version: "=1.22.0"
       - name: Run e2e tests
-        run: ISOLATED_MODE=true  USE_EKS=false GINKGO_LABEL_FILTER=short make test-e2e
+        run: make test-e2e
       - name: Collect run artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run-e2e-suite.yaml
+++ b/.github/workflows/run-e2e-suite.yaml
@@ -1,6 +1,11 @@
 on:
   workflow_call:
     inputs:
+      management_cluster_infrastructure:
+        description: "The infrastructure to use for the management cluster: eks, kind or isolated-kind"
+        type: string
+        required: true
+        default: "eks"
       test_suite:
         description: "The test suite to run (i.e. path to it)"
         required: true
@@ -17,10 +22,6 @@ on:
         description: "Run the Azure janitor after the test to cleanup"
         required: false
         default: false
-        type: boolean
-      use_eks:
-        description: "Use EKS for the management cluster"
-        required: true
         type: boolean
 
 permissions:
@@ -42,6 +43,9 @@ env:
   AWS_REGION: eu-west-2
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  MANAGEMENT_CLUSTER_INFRASTRUCTURE: ${{ inputs.management_cluster_infrastructure }}
+  GINKGO_LABEL_FILTER: full 
+  GINKGO_TESTS: ${{ inputs.test_suite }}
 
 jobs:
   run_e2e_tests:
@@ -80,10 +84,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: build and push e2e image
-        if: ${{ inputs.use_eks }}
+        if: ${{ inputs.management_cluster_infrastructure == 'eks' }}
         run: make e2e-image-push
       - name: Run e2e tests
-        run: GINKGO_LABEL_FILTER=full USE_EKS=${{ inputs.use_eks }} GINKGO_TESTS=${{ inputs.test_suite }} make test-e2e
+        run: make test-e2e
       - name: Collect run artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -75,12 +75,13 @@ E2E_CONF_FILE ?= $(ROOT_DIR)/$(TEST_DIR)/e2e/config/operator.yaml
 GINKGO_ARGS ?=
 SKIP_RESOURCE_CLEANUP ?= false
 USE_EXISTING_CLUSTER ?= false
-USE_EKS ?= true
-ISOLATED_MODE ?= false
 GITEA_CUSTOM_INGRESS ?= false
 GINKGO_NOCOLOR ?= false
 GINKGO_LABEL_FILTER ?= short
 GINKGO_TESTS ?= $(ROOT_DIR)/$(TEST_DIR)/e2e/suites/...
+
+MANAGEMENT_CLUSTER_INFRASTRUCTURE ?= eks
+E2ECONFIG_VARS ?= MANAGEMENT_CLUSTER_INFRASTRUCTURE=$(MANAGEMENT_CLUSTER_INFRASTRUCTURE)
 
 # to set multiple ginkgo skip flags, if any
 ifneq ($(strip $(GINKGO_SKIP)),)
@@ -529,7 +530,7 @@ release-chart: $(HELM) $(NOTES) build-chart verify-gen
 
 .PHONY: test-e2e
 test-e2e: $(GINKGO) $(HELM) $(CLUSTERCTL) kubectl e2e-image ## Run the end-to-end tests
-	$(GINKGO) -v --trace -poll-progress-after=$(GINKGO_POLL_PROGRESS_AFTER) \
+	$(E2ECONFIG_VARS) $(GINKGO) -v --trace -poll-progress-after=$(GINKGO_POLL_PROGRESS_AFTER) \
 		-poll-progress-interval=$(GINKGO_POLL_PROGRESS_INTERVAL) --tags=e2e --focus="$(GINKGO_FOCUS)" --label-filter="$(GINKGO_LABEL_FILTER)" \
 		$(_SKIP_ARGS) --nodes=$(GINKGO_NODES) --timeout=$(GINKGO_TIMEOUT) --no-color=$(GINKGO_NOCOLOR) \
 		--output-dir="$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" $(GINKGO_ARGS) $(GINKGO_TESTS) -- \
@@ -540,8 +541,6 @@ test-e2e: $(GINKGO) $(HELM) $(CLUSTERCTL) kubectl e2e-image ## Run the end-to-en
 		-e2e.chart-path=$(ROOT_DIR)/$(CHART_RELEASE_DIR) \
 	    -e2e.skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) \
 		-e2e.use-existing-cluster=$(USE_EXISTING_CLUSTER) \
-		-e2e.isolated-mode=$(ISOLATED_MODE) \
-		-e2e.use-eks=$(USE_EKS) \
 		-e2e.gitea-custom-ingress=$(GITEA_CUSTOM_INGRESS)
 
 .PHONY: e2e-image

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -27,6 +27,7 @@ intervals:
   default/wait-turtles-uninstall: ["10m", "30s"]
 
 variables:
+  MANAGEMENT_CLUSTER_INFRASTRUCTURE: "isolated-kind" # supported options are eks, isolated-kind, kind
   RANCHER_VERSION: "v2.8.1"
   KUBERNETES_VERSION: "v1.28.6"
   KUBERNETES_MANAGEMENT_VERSION: "v1.27.0"

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -95,7 +95,17 @@ const (
 	NginxIngressDeployment  = "ingress-nginx-controller"
 )
 
+type ManagementClusterInfrastuctureType string
+
 const (
+	ManagementClusterInfrastuctureEKS          ManagementClusterInfrastuctureType = "eks"
+	ManagementClusterInfrastuctureIsolatedKind ManagementClusterInfrastuctureType = "isolated-kind"
+	ManagementClusterInfrastuctureKind         ManagementClusterInfrastuctureType = "kind"
+)
+
+const (
+	ManagementClusterInfrastucture = "MANAGEMENT_CLUSTER_INFRASTRUCTURE"
+
 	KubernetesManagementVersionVar = "KUBERNETES_MANAGEMENT_VERSION"
 
 	KubernetesVersionVar   = "KUBERNETES_VERSION"

--- a/test/e2e/flags.go
+++ b/test/e2e/flags.go
@@ -30,9 +30,6 @@ type FlagValues struct {
 	// UseExistingCluster instructs the test to use the current cluster instead of creating a new one (default discovery rules apply).
 	UseExistingCluster bool
 
-	// UseEKS instructs the test to create an EKS cluster instead of using kind.
-	UseEKS bool
-
 	// ArtifactFolder is the folder to store e2e test artifacts.
 	ArtifactFolder string
 
@@ -48,10 +45,6 @@ type FlagValues struct {
 	// ChartPath is the path to the operator chart.
 	ChartPath string
 
-	// IsolatedMode instructs the test to run without ngrok and exposing the cluster to the internet. This setup will only work with CAPD
-	// or other providers that run in the same network as the bootstrap cluster.
-	IsolatedMode bool
-
 	// ClusterctlBinaryPath is the path to the clusterctl binary to use.
 	ClusterctlBinaryPath string
 
@@ -65,11 +58,9 @@ func InitFlags(values *FlagValues) {
 	flag.StringVar(&values.ArtifactFolder, "e2e.artifacts-folder", "_artifacts", "folder where e2e test artifact should be stored")
 	flag.BoolVar(&values.SkipCleanup, "e2e.skip-resource-cleanup", false, "if true, the resource cleanup after tests will be skipped")
 	flag.BoolVar(&values.UseExistingCluster, "e2e.use-existing-cluster", false, "if true, the test uses the current cluster instead of creating a new one (default discovery rules apply)")
-	flag.BoolVar(&values.UseEKS, "e2e.use-eks", true, "if true, the test uses EKS for the management cluster")
 	flag.StringVar(&values.HelmBinaryPath, "e2e.helm-binary-path", "helm", "path to the helm binary")
 	flag.StringVar(&values.HelmExtraValuesDir, "e2e.helm-extra-values-path", "/tmp", "path to the extra values file")
 	flag.StringVar(&values.ClusterctlBinaryPath, "e2e.clusterctl-binary-path", "helm", "path to the clusterctl binary")
 	flag.StringVar(&values.ChartPath, "e2e.chart-path", "", "path to the operator chart")
-	flag.BoolVar(&values.IsolatedMode, "e2e.isolated-mode", false, "if true, the test will run without ngrok and exposing the cluster to the internet. This setup will only work with CAPD or other providers that run in the same network as the bootstrap cluster.")
 	flag.BoolVar(&values.GiteaCustomIngress, "e2e.gitea-custom-ingress", false, "if true, the test will use a custom ingress for Gitea")
 }

--- a/test/e2e/suites/embedded-capi-disabled-v3/suite_test.go
+++ b/test/e2e/suites/embedded-capi-disabled-v3/suite_test.go
@@ -31,9 +31,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/rancher/turtles/test/e2e"
 	"github.com/rancher/turtles/test/framework"
-	turtlesframework "github.com/rancher/turtles/test/framework"
 	"github.com/rancher/turtles/test/testenv"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -84,26 +82,7 @@ var _ = BeforeSuite(func() {
 	By(fmt.Sprintf("Loading the e2e test configuration from %q", flagVals.ConfigPath))
 	e2eConfig = e2e.LoadE2EConfig(flagVals.ConfigPath)
 
-	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
-	ingressType := testenv.NgrokIngress
-	dockerUsername := ""
-	dockerPassword := ""
-	var customClusterProvider testenv.CustomClusterProvider
-
-	if flagVals.UseEKS {
-		Expect(flagVals.IsolatedMode).To(BeFalse(), "You cannot use eks with isolated")
-		dockerUsername = os.Getenv("GITHUB_USERNAME")
-		Expect(dockerUsername).NotTo(BeEmpty(), "Github username is required")
-		dockerPassword = os.Getenv("GITHUB_TOKEN")
-		Expect(dockerPassword).NotTo(BeEmpty(), "Github token is required")
-		customClusterProvider = testenv.EKSBootsrapCluster
-		Expect(customClusterProvider).NotTo(BeNil(), "EKS custom cluster provider is required")
-		ingressType = testenv.EKSNginxIngress
-	}
-
-	if flagVals.IsolatedMode {
-		ingressType = testenv.CustomIngress
-	}
+	preSetupOutput := testenv.PreManagementClusterSetupHook(e2eConfig)
 
 	By(fmt.Sprintf("Creating a clusterctl config into %q", flagVals.ArtifactFolder))
 	clusterctlConfigPath = e2e.CreateClusterctlLocalRepository(ctx, e2eConfig, filepath.Join(flagVals.ArtifactFolder, "repository"))
@@ -115,16 +94,15 @@ var _ = BeforeSuite(func() {
 		Scheme:                e2e.InitScheme(),
 		ArtifactFolder:        flagVals.ArtifactFolder,
 		KubernetesVersion:     e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
-		IsolatedMode:          flagVals.IsolatedMode,
 		HelmBinaryPath:        flagVals.HelmBinaryPath,
-		CustomClusterProvider: customClusterProvider,
+		CustomClusterProvider: preSetupOutput.CustomClusterProvider,
 	})
 
 	testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 		BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:           flagVals.HelmBinaryPath,
 		HelmExtraValuesPath:      filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher-ingress.yaml"),
-		IngressType:              ingressType,
+		IngressType:              preSetupOutput.IngressType,
 		CustomIngress:            e2e.NginxIngress,
 		CustomIngressNamespace:   e2e.NginxIngressNamespace,
 		CustomIngressDeployment:  e2e.NginxIngressDeployment,
@@ -136,32 +114,6 @@ var _ = BeforeSuite(func() {
 		NgrokRepoURL:             e2eConfig.GetVariable(e2e.NgrokUrlVar),
 		DefaultIngressClassPatch: e2e.IngressClassPatch,
 	})
-
-	if flagVals.IsolatedMode {
-		hostName = setupClusterResult.IsolatedHostName
-	}
-
-	if flagVals.UseEKS {
-		By("Getting ingress hostname")
-		svcRes := &testenv.WaitForServiceIngressHostnameResult{}
-		testenv.WaitForServiceIngressHostname(ctx, testenv.WaitForServiceIngressHostnameInput{
-			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
-			ServiceName:           "ingress-nginx-controller",
-			ServiceNamespace:      "ingress-nginx",
-			IngressWaitInterval:   e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-rancher"),
-		}, svcRes)
-		hostName = svcRes.Hostname
-
-		By("Deploying ghcr details")
-		framework.CreateDockerRegistrySecret(ctx, framework.CreateDockerRegistrySecretInput{
-			Name:                  "regcred",
-			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
-			Namespace:             "rancher-turtles-system",
-			DockerServer:          "https://ghcr.io",
-			DockerUsername:        dockerUsername,
-			DockerPassword:        dockerPassword,
-		})
-	}
 
 	// NOTE: deploy Rancher first with the embedded-cluster-api feature disabled.
 	// and the deploy Rancher Turtles.
@@ -177,7 +129,6 @@ var _ = BeforeSuite(func() {
 		RancherChartURL:        e2eConfig.GetVariable(e2e.RancherUrlVar),
 		RancherChartPath:       e2eConfig.GetVariable(e2e.RancherPathVar),
 		RancherVersion:         e2eConfig.GetVariable(e2e.RancherVersionVar),
-		RancherHost:            hostName,
 		RancherNamespace:       e2e.RancherNamespace,
 		RancherPassword:        e2eConfig.GetVariable(e2e.RancherPasswordVar),
 		RancherFeatures:        "embedded-cluster-api=false",
@@ -186,14 +137,18 @@ var _ = BeforeSuite(func() {
 		ControllerWaitInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
 		Variables:              e2eConfig.Variables,
 	}
-	if !flagVals.IsolatedMode && !flagVals.UseEKS {
-		// i.e. we are using ngrok locally
-		rancherInput.RancherIngressConfig = e2e.IngressConfig
-		rancherInput.RancherServicePatch = e2e.RancherServicePatch
-	}
-	if flagVals.UseEKS {
-		rancherInput.RancherIngressClassName = "nginx"
-	}
+
+	rancherHookResult := testenv.PreRancherInstallHook(
+		&testenv.PreRancherInstallHookInput{
+			Ctx:                ctx,
+			RancherInput:       &rancherInput,
+			E2EConfig:          e2eConfig,
+			SetupClusterResult: setupClusterResult,
+			PreSetupOutput:     preSetupOutput,
+		})
+
+	hostName = rancherHookResult.HostName
+
 	testenv.DeployRancher(ctx, rancherInput)
 
 	rtInput := testenv.DeployRancherTurtlesInput{
@@ -201,7 +156,7 @@ var _ = BeforeSuite(func() {
 		HelmBinaryPath:               flagVals.HelmBinaryPath,
 		ChartPath:                    flagVals.ChartPath,
 		CAPIProvidersYAML:            e2e.CapiProviders,
-		Namespace:                    turtlesframework.DefaultRancherTurtlesNamespace,
+		Namespace:                    framework.DefaultRancherTurtlesNamespace,
 		Image:                        fmt.Sprintf("ghcr.io/rancher/turtles-e2e-%s", runtime.GOARCH),
 		Tag:                          "v0.0.1",
 		WaitDeploymentsReadyInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
@@ -210,14 +165,9 @@ var _ = BeforeSuite(func() {
 			"rancherTurtles.features.embedded-capi.disabled": "false",
 		},
 	}
-	if flagVals.UseEKS {
-		rtInput.AdditionalValues["rancherTurtles.imagePullSecrets"] = "{regcred}"
-		rtInput.AdditionalValues["rancherTurtles.imagePullPolicy"] = "IfNotPresent"
-	} else {
-		// NOTE: this was the default previously in the chart locally and ok as
-		// we where loading the image into kind manually.
-		rtInput.AdditionalValues["rancherTurtles.imagePullPolicy"] = "Never"
-	}
+
+	testenv.PreRancherTurtlesInstallHook(&rtInput, e2eConfig)
+
 	testenv.DeployRancherTurtles(ctx, rtInput)
 
 	// NOTE: there are no short or local tests in this suite
@@ -233,7 +183,7 @@ var _ = BeforeSuite(func() {
 		},
 		CAPIProvidersYAML: e2e.FullProviders,
 		TemplateData: map[string]string{
-			"AWSEncodedCredentials": e2eConfig.GetVariable(e2e.CapaEncodedCredentialsVar),
+			"AWSEncodedCredentials": awsCreds,
 		},
 		WaitDeploymentsReadyInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
 		WaitForDeployments: []testenv.NamespaceName{
@@ -248,21 +198,7 @@ var _ = BeforeSuite(func() {
 		},
 	})
 
-	giteaValues := map[string]string{
-		"gitea.admin.username": e2eConfig.GetVariable(e2e.GiteaUserNameVar),
-		"gitea.admin.password": e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
-	}
-
-	giteaServiceType := corev1.ServiceTypeNodePort
-	if flagVals.UseEKS {
-		giteaServiceType = corev1.ServiceTypeLoadBalancer
-	}
-
-	if flagVals.GiteaCustomIngress {
-		giteaServiceType = corev1.ServiceTypeClusterIP
-	}
-
-	giteaResult = testenv.DeployGitea(ctx, testenv.DeployGiteaInput{
+	giteaInput := testenv.DeployGiteaInput{
 		BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:        flagVals.HelmBinaryPath,
 		ChartRepoName:         e2eConfig.GetVariable(e2e.GiteaRepoNameVar),
@@ -270,16 +206,22 @@ var _ = BeforeSuite(func() {
 		ChartName:             e2eConfig.GetVariable(e2e.GiteaChartNameVar),
 		ChartVersion:          e2eConfig.GetVariable(e2e.GiteaChartVersionVar),
 		ValuesFilePath:        "../../data/gitea/values.yaml",
-		Values:                giteaValues,
-		RolloutWaitInterval:   e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea"),
-		ServiceWaitInterval:   e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea-service"),
-		AuthSecretName:        e2e.AuthSecretName,
-		Username:              e2eConfig.GetVariable(e2e.GiteaUserNameVar),
-		Password:              e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
-		ServiceType:           giteaServiceType,
-		CustomIngressConfig:   e2e.GiteaIngress,
-		Variables:             e2eConfig.Variables,
-	})
+		Values: map[string]string{
+			"gitea.admin.username": e2eConfig.GetVariable(e2e.GiteaUserNameVar),
+			"gitea.admin.password": e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
+		},
+		RolloutWaitInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea"),
+		ServiceWaitInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea-service"),
+		AuthSecretName:      e2e.AuthSecretName,
+		Username:            e2eConfig.GetVariable(e2e.GiteaUserNameVar),
+		Password:            e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
+		CustomIngressConfig: e2e.GiteaIngress,
+		Variables:           e2eConfig.Variables,
+	}
+
+	testenv.PreGiteaInstallHook(&giteaInput, e2eConfig)
+
+	giteaResult = testenv.DeployGitea(ctx, giteaInput)
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/suites/embedded-capi-disabled/suite_test.go
+++ b/test/e2e/suites/embedded-capi-disabled/suite_test.go
@@ -29,14 +29,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/rancher/turtles/test/e2e"
 	"github.com/rancher/turtles/test/framework"
-	turtlesframework "github.com/rancher/turtles/test/framework"
 	"github.com/rancher/turtles/test/testenv"
 )
 
@@ -85,26 +83,7 @@ var _ = BeforeSuite(func() {
 	By(fmt.Sprintf("Loading the e2e test configuration from %q", flagVals.ConfigPath))
 	e2eConfig = e2e.LoadE2EConfig(flagVals.ConfigPath)
 
-	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
-	ingressType := testenv.NgrokIngress
-	dockerUsername := ""
-	dockerPassword := ""
-	var customClusterProvider testenv.CustomClusterProvider
-
-	if flagVals.UseEKS {
-		Expect(flagVals.IsolatedMode).To(BeFalse(), "You cannot use eks with isolated")
-		dockerUsername = os.Getenv("GITHUB_USERNAME")
-		Expect(dockerUsername).NotTo(BeEmpty(), "Github username is required")
-		dockerPassword = os.Getenv("GITHUB_TOKEN")
-		Expect(dockerPassword).NotTo(BeEmpty(), "Github token is required")
-		customClusterProvider = testenv.EKSBootsrapCluster
-		Expect(customClusterProvider).NotTo(BeNil(), "EKS custom cluster provider is required")
-		ingressType = testenv.EKSNginxIngress
-	}
-
-	if flagVals.IsolatedMode {
-		ingressType = testenv.CustomIngress
-	}
+	preSetupOutput := testenv.PreManagementClusterSetupHook(e2eConfig)
 
 	By(fmt.Sprintf("Creating a clusterctl config into %q", flagVals.ArtifactFolder))
 	clusterctlConfigPath = e2e.CreateClusterctlLocalRepository(ctx, e2eConfig, filepath.Join(flagVals.ArtifactFolder, "repository"))
@@ -116,16 +95,15 @@ var _ = BeforeSuite(func() {
 		Scheme:                e2e.InitScheme(),
 		ArtifactFolder:        flagVals.ArtifactFolder,
 		KubernetesVersion:     e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
-		IsolatedMode:          flagVals.IsolatedMode,
 		HelmBinaryPath:        flagVals.HelmBinaryPath,
-		CustomClusterProvider: customClusterProvider,
+		CustomClusterProvider: preSetupOutput.CustomClusterProvider,
 	})
 
 	testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 		BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:           flagVals.HelmBinaryPath,
 		HelmExtraValuesPath:      filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher-ingress.yaml"),
-		IngressType:              ingressType,
+		IngressType:              preSetupOutput.IngressType,
 		CustomIngress:            e2e.NginxIngress,
 		CustomIngressNamespace:   e2e.NginxIngressNamespace,
 		CustomIngressDeployment:  e2e.NginxIngressDeployment,
@@ -137,32 +115,6 @@ var _ = BeforeSuite(func() {
 		NgrokRepoURL:             e2eConfig.GetVariable(e2e.NgrokUrlVar),
 		DefaultIngressClassPatch: e2e.IngressClassPatch,
 	})
-
-	if flagVals.IsolatedMode {
-		hostName = setupClusterResult.IsolatedHostName
-	}
-
-	if flagVals.UseEKS {
-		By("Getting ingress hostname")
-		svcRes := &testenv.WaitForServiceIngressHostnameResult{}
-		testenv.WaitForServiceIngressHostname(ctx, testenv.WaitForServiceIngressHostnameInput{
-			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
-			ServiceName:           "ingress-nginx-controller",
-			ServiceNamespace:      "ingress-nginx",
-			IngressWaitInterval:   e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-rancher"),
-		}, svcRes)
-		hostName = svcRes.Hostname
-
-		By("Deploying ghcr details")
-		framework.CreateDockerRegistrySecret(ctx, framework.CreateDockerRegistrySecretInput{
-			Name:                  "regcred",
-			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
-			Namespace:             "rancher-turtles-system",
-			DockerServer:          "https://ghcr.io",
-			DockerUsername:        dockerUsername,
-			DockerPassword:        dockerPassword,
-		})
-	}
 
 	// NOTE: deploy Rancher first with the embedded-cluster-api feature disabled.
 	// and the deploy Rancher Turtles.
@@ -178,7 +130,6 @@ var _ = BeforeSuite(func() {
 		RancherChartURL:        e2eConfig.GetVariable(e2e.RancherUrlVar),
 		RancherChartPath:       e2eConfig.GetVariable(e2e.RancherPathVar),
 		RancherVersion:         e2eConfig.GetVariable(e2e.RancherVersionVar),
-		RancherHost:            hostName,
 		RancherNamespace:       e2e.RancherNamespace,
 		RancherPassword:        e2eConfig.GetVariable(e2e.RancherPasswordVar),
 		RancherFeatures:        "embedded-cluster-api=false",
@@ -187,14 +138,18 @@ var _ = BeforeSuite(func() {
 		ControllerWaitInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
 		Variables:              e2eConfig.Variables,
 	}
-	if !flagVals.IsolatedMode && !flagVals.UseEKS {
-		// i.e. we are using ngrok locally
-		rancherInput.RancherIngressConfig = e2e.IngressConfig
-		rancherInput.RancherServicePatch = e2e.RancherServicePatch
-	}
-	if flagVals.UseEKS {
-		rancherInput.RancherIngressClassName = "nginx"
-	}
+
+	rancherHookResult := testenv.PreRancherInstallHook(
+		&testenv.PreRancherInstallHookInput{
+			Ctx:                ctx,
+			RancherInput:       &rancherInput,
+			E2EConfig:          e2eConfig,
+			SetupClusterResult: setupClusterResult,
+			PreSetupOutput:     preSetupOutput,
+		})
+
+	hostName = rancherHookResult.HostName
+
 	testenv.DeployRancher(ctx, rancherInput)
 
 	rtInput := testenv.DeployRancherTurtlesInput{
@@ -202,7 +157,7 @@ var _ = BeforeSuite(func() {
 		HelmBinaryPath:               flagVals.HelmBinaryPath,
 		ChartPath:                    flagVals.ChartPath,
 		CAPIProvidersYAML:            e2e.CapiProviders,
-		Namespace:                    turtlesframework.DefaultRancherTurtlesNamespace,
+		Namespace:                    framework.DefaultRancherTurtlesNamespace,
 		Image:                        fmt.Sprintf("ghcr.io/rancher/turtles-e2e-%s", runtime.GOARCH),
 		Tag:                          "v0.0.1",
 		WaitDeploymentsReadyInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
@@ -212,14 +167,9 @@ var _ = BeforeSuite(func() {
 			"rancherTurtles.features.managementv3-cluster.enabled": "false",
 		},
 	}
-	if flagVals.UseEKS {
-		rtInput.AdditionalValues["rancherTurtles.imagePullSecrets"] = "{regcred}"
-		rtInput.AdditionalValues["rancherTurtles.imagePullPolicy"] = "IfNotPresent"
-	} else {
-		// NOTE: this was the default previously in the chart locally and ok as
-		// we where loading the image into kind manually.
-		rtInput.AdditionalValues["rancherTurtles.imagePullPolicy"] = "Never"
-	}
+
+	testenv.PreRancherTurtlesInstallHook(&rtInput, e2eConfig)
+
 	testenv.DeployRancherTurtles(ctx, rtInput)
 
 	// NOTE: there are no short or local tests in this suite
@@ -235,7 +185,7 @@ var _ = BeforeSuite(func() {
 		},
 		CAPIProvidersYAML: e2e.FullProviders,
 		TemplateData: map[string]string{
-			"AWSEncodedCredentials": e2eConfig.GetVariable(e2e.CapaEncodedCredentialsVar),
+			"AWSEncodedCredentials": awsCreds,
 		},
 		WaitDeploymentsReadyInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
 		WaitForDeployments: []testenv.NamespaceName{
@@ -250,21 +200,7 @@ var _ = BeforeSuite(func() {
 		},
 	})
 
-	giteaValues := map[string]string{
-		"gitea.admin.username": e2eConfig.GetVariable(e2e.GiteaUserNameVar),
-		"gitea.admin.password": e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
-	}
-
-	giteaServiceType := corev1.ServiceTypeNodePort
-	if flagVals.UseEKS {
-		giteaServiceType = corev1.ServiceTypeLoadBalancer
-	}
-
-	if flagVals.GiteaCustomIngress {
-		giteaServiceType = corev1.ServiceTypeClusterIP
-	}
-
-	giteaResult = testenv.DeployGitea(ctx, testenv.DeployGiteaInput{
+	giteaInput := testenv.DeployGiteaInput{
 		BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:        flagVals.HelmBinaryPath,
 		ChartRepoName:         e2eConfig.GetVariable(e2e.GiteaRepoNameVar),
@@ -272,16 +208,22 @@ var _ = BeforeSuite(func() {
 		ChartName:             e2eConfig.GetVariable(e2e.GiteaChartNameVar),
 		ChartVersion:          e2eConfig.GetVariable(e2e.GiteaChartVersionVar),
 		ValuesFilePath:        "../../data/gitea/values.yaml",
-		Values:                giteaValues,
-		RolloutWaitInterval:   e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea"),
-		ServiceWaitInterval:   e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea-service"),
-		AuthSecretName:        e2e.AuthSecretName,
-		Username:              e2eConfig.GetVariable(e2e.GiteaUserNameVar),
-		Password:              e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
-		ServiceType:           giteaServiceType,
-		CustomIngressConfig:   e2e.GiteaIngress,
-		Variables:             e2eConfig.Variables,
-	})
+		Values: map[string]string{
+			"gitea.admin.username": e2eConfig.GetVariable(e2e.GiteaUserNameVar),
+			"gitea.admin.password": e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
+		},
+		RolloutWaitInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea"),
+		ServiceWaitInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea-service"),
+		AuthSecretName:      e2e.AuthSecretName,
+		Username:            e2eConfig.GetVariable(e2e.GiteaUserNameVar),
+		Password:            e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
+		CustomIngressConfig: e2e.GiteaIngress,
+		Variables:           e2eConfig.Variables,
+	}
+
+	testenv.PreGiteaInstallHook(&giteaInput, e2eConfig)
+
+	giteaResult = testenv.DeployGitea(ctx, giteaInput)
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/suites/import-gitops-v3/suite_test.go
+++ b/test/e2e/suites/import-gitops-v3/suite_test.go
@@ -30,10 +30,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher/turtles/test/e2e"
-	"github.com/rancher/turtles/test/framework"
 	turtlesframework "github.com/rancher/turtles/test/framework"
 	"github.com/rancher/turtles/test/testenv"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -84,26 +82,7 @@ var _ = BeforeSuite(func() {
 	By(fmt.Sprintf("Loading the e2e test configuration from %q", flagVals.ConfigPath))
 	e2eConfig = e2e.LoadE2EConfig(flagVals.ConfigPath)
 
-	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
-	ingressType := testenv.NgrokIngress
-	dockerUsername := ""
-	dockerPassword := ""
-	var customClusterProvider testenv.CustomClusterProvider
-
-	if flagVals.UseEKS {
-		Expect(flagVals.IsolatedMode).To(BeFalse(), "You cannot use eks with isolated")
-		dockerUsername = os.Getenv("GITHUB_USERNAME")
-		Expect(dockerUsername).NotTo(BeEmpty(), "Github username is required")
-		dockerPassword = os.Getenv("GITHUB_TOKEN")
-		Expect(dockerPassword).NotTo(BeEmpty(), "Github token is required")
-		customClusterProvider = testenv.EKSBootsrapCluster
-		Expect(customClusterProvider).NotTo(BeNil(), "EKS custom cluster provider is required")
-		ingressType = testenv.EKSNginxIngress
-	}
-
-	if flagVals.IsolatedMode {
-		ingressType = testenv.CustomIngress
-	}
+	preSetupOutput := testenv.PreManagementClusterSetupHook(e2eConfig)
 
 	By(fmt.Sprintf("Creating a clusterctl config into %q", flagVals.ArtifactFolder))
 	clusterctlConfigPath = e2e.CreateClusterctlLocalRepository(ctx, e2eConfig, filepath.Join(flagVals.ArtifactFolder, "repository"))
@@ -115,16 +94,15 @@ var _ = BeforeSuite(func() {
 		Scheme:                e2e.InitScheme(),
 		ArtifactFolder:        flagVals.ArtifactFolder,
 		KubernetesVersion:     e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
-		IsolatedMode:          flagVals.IsolatedMode,
 		HelmBinaryPath:        flagVals.HelmBinaryPath,
-		CustomClusterProvider: customClusterProvider,
+		CustomClusterProvider: preSetupOutput.CustomClusterProvider,
 	})
 
 	testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 		BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:           flagVals.HelmBinaryPath,
 		HelmExtraValuesPath:      filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher-ingress.yaml"),
-		IngressType:              ingressType,
+		IngressType:              preSetupOutput.IngressType,
 		CustomIngress:            e2e.NginxIngress,
 		CustomIngressNamespace:   e2e.NginxIngressNamespace,
 		CustomIngressDeployment:  e2e.NginxIngressDeployment,
@@ -136,32 +114,6 @@ var _ = BeforeSuite(func() {
 		NgrokRepoURL:             e2eConfig.GetVariable(e2e.NgrokUrlVar),
 		DefaultIngressClassPatch: e2e.IngressClassPatch,
 	})
-
-	if flagVals.IsolatedMode {
-		hostName = setupClusterResult.IsolatedHostName
-	}
-
-	if flagVals.UseEKS {
-		By("Getting ingress hostname")
-		svcRes := &testenv.WaitForServiceIngressHostnameResult{}
-		testenv.WaitForServiceIngressHostname(ctx, testenv.WaitForServiceIngressHostnameInput{
-			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
-			ServiceName:           "ingress-nginx-controller",
-			ServiceNamespace:      "ingress-nginx",
-			IngressWaitInterval:   e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-rancher"),
-		}, svcRes)
-		hostName = svcRes.Hostname
-
-		By("Deploying ghcr details")
-		framework.CreateDockerRegistrySecret(ctx, framework.CreateDockerRegistrySecretInput{
-			Name:                  "regcred",
-			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
-			Namespace:             "rancher-turtles-system",
-			DockerServer:          "https://ghcr.io",
-			DockerUsername:        dockerUsername,
-			DockerPassword:        dockerPassword,
-		})
-	}
 
 	rancherInput := testenv.DeployRancherInput{
 		BootstrapClusterProxy:  setupClusterResult.BootstrapClusterProxy,
@@ -175,7 +127,6 @@ var _ = BeforeSuite(func() {
 		RancherChartURL:        e2eConfig.GetVariable(e2e.RancherUrlVar),
 		RancherChartPath:       e2eConfig.GetVariable(e2e.RancherPathVar),
 		RancherVersion:         e2eConfig.GetVariable(e2e.RancherVersionVar),
-		RancherHost:            hostName,
 		RancherNamespace:       e2e.RancherNamespace,
 		RancherPassword:        e2eConfig.GetVariable(e2e.RancherPasswordVar),
 		RancherPatches:         [][]byte{e2e.RancherSettingPatch},
@@ -183,14 +134,18 @@ var _ = BeforeSuite(func() {
 		ControllerWaitInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
 		Variables:              e2eConfig.Variables,
 	}
-	if !flagVals.IsolatedMode && !flagVals.UseEKS {
-		// i.e. we are using ngrok locally
-		rancherInput.RancherIngressConfig = e2e.IngressConfig
-		rancherInput.RancherServicePatch = e2e.RancherServicePatch
-	}
-	if flagVals.UseEKS {
-		rancherInput.RancherIngressClassName = "nginx"
-	}
+
+	rancherHookResult := testenv.PreRancherInstallHook(
+		&testenv.PreRancherInstallHookInput{
+			Ctx:                ctx,
+			RancherInput:       &rancherInput,
+			E2EConfig:          e2eConfig,
+			SetupClusterResult: setupClusterResult,
+			PreSetupOutput:     preSetupOutput,
+		})
+
+	hostName = rancherHookResult.HostName
+
 	testenv.DeployRancher(ctx, rancherInput)
 
 	rtInput := testenv.DeployRancherTurtlesInput{
@@ -206,14 +161,9 @@ var _ = BeforeSuite(func() {
 			"rancherTurtles.features.addon-provider-fleet.enabled": "true",
 		},
 	}
-	if flagVals.UseEKS {
-		rtInput.AdditionalValues["rancherTurtles.imagePullSecrets"] = "{regcred}"
-		rtInput.AdditionalValues["rancherTurtles.imagePullPolicy"] = "IfNotPresent"
-	} else {
-		// NOTE: this was the default previously in the chart locally and ok as
-		// we where loading the image into kind manually.
-		rtInput.AdditionalValues["rancherTurtles.imagePullPolicy"] = "Never"
-	}
+
+	testenv.PreRancherTurtlesInstallHook(&rtInput, e2eConfig)
+
 	testenv.DeployRancherTurtles(ctx, rtInput)
 
 	if !shortTestOnly() && !localTestOnly() {
@@ -229,7 +179,7 @@ var _ = BeforeSuite(func() {
 			},
 			CAPIProvidersYAML: e2e.FullProviders,
 			TemplateData: map[string]string{
-				"AWSEncodedCredentials": e2eConfig.GetVariable(e2e.CapaEncodedCredentialsVar),
+				"AWSEncodedCredentials": awsCreds,
 			},
 			WaitDeploymentsReadyInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
 			WaitForDeployments: []testenv.NamespaceName{
@@ -245,21 +195,7 @@ var _ = BeforeSuite(func() {
 		})
 	}
 
-	giteaValues := map[string]string{
-		"gitea.admin.username": e2eConfig.GetVariable(e2e.GiteaUserNameVar),
-		"gitea.admin.password": e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
-	}
-
-	giteaServiceType := corev1.ServiceTypeNodePort
-	if flagVals.UseEKS {
-		giteaServiceType = corev1.ServiceTypeLoadBalancer
-	}
-
-	if flagVals.GiteaCustomIngress {
-		giteaServiceType = corev1.ServiceTypeClusterIP
-	}
-
-	giteaResult = testenv.DeployGitea(ctx, testenv.DeployGiteaInput{
+	giteaInput := testenv.DeployGiteaInput{
 		BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:        flagVals.HelmBinaryPath,
 		ChartRepoName:         e2eConfig.GetVariable(e2e.GiteaRepoNameVar),
@@ -267,16 +203,22 @@ var _ = BeforeSuite(func() {
 		ChartName:             e2eConfig.GetVariable(e2e.GiteaChartNameVar),
 		ChartVersion:          e2eConfig.GetVariable(e2e.GiteaChartVersionVar),
 		ValuesFilePath:        "../../data/gitea/values.yaml",
-		Values:                giteaValues,
-		RolloutWaitInterval:   e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea"),
-		ServiceWaitInterval:   e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea-service"),
-		AuthSecretName:        e2e.AuthSecretName,
-		Username:              e2eConfig.GetVariable(e2e.GiteaUserNameVar),
-		Password:              e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
-		ServiceType:           giteaServiceType,
-		CustomIngressConfig:   e2e.GiteaIngress,
-		Variables:             e2eConfig.Variables,
-	})
+		Values: map[string]string{
+			"gitea.admin.username": e2eConfig.GetVariable(e2e.GiteaUserNameVar),
+			"gitea.admin.password": e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
+		},
+		RolloutWaitInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea"),
+		ServiceWaitInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea-service"),
+		AuthSecretName:      e2e.AuthSecretName,
+		Username:            e2eConfig.GetVariable(e2e.GiteaUserNameVar),
+		Password:            e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
+		CustomIngressConfig: e2e.GiteaIngress,
+		Variables:           e2eConfig.Variables,
+	}
+
+	testenv.PreGiteaInstallHook(&giteaInput, e2eConfig)
+
+	giteaResult = testenv.DeployGitea(ctx, giteaInput)
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/suites/migrate-gitops/suite_test.go
+++ b/test/e2e/suites/migrate-gitops/suite_test.go
@@ -30,14 +30,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher/turtles/test/e2e"
-	turtlesframework "github.com/rancher/turtles/test/framework"
+	"github.com/rancher/turtles/test/framework"
 	"github.com/rancher/turtles/test/testenv"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/cluster-api/test/framework"
+	capiframework "sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -90,19 +89,7 @@ var _ = BeforeSuite(func() {
 	By(fmt.Sprintf("Creating a clusterctl config into %q", flagVals.ArtifactFolder))
 	clusterctlConfigPath = e2e.CreateClusterctlLocalRepository(ctx, e2eConfig, filepath.Join(flagVals.ArtifactFolder, "repository"))
 
-	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
-	ingressType := testenv.NgrokIngress
-	var customClusterProvider testenv.CustomClusterProvider
-
-	if flagVals.UseEKS {
-		customClusterProvider = testenv.EKSBootsrapCluster
-		Expect(customClusterProvider).NotTo(BeNil(), "EKS custom cluster provider is required")
-		ingressType = testenv.EKSNginxIngress
-	}
-
-	if flagVals.IsolatedMode {
-		ingressType = testenv.CustomIngress
-	}
+	preSetupOutput := testenv.PreManagementClusterSetupHook(e2eConfig)
 
 	setupClusterResult = testenv.SetupTestCluster(ctx, testenv.SetupTestClusterInput{
 		UseExistingCluster:    flagVals.UseExistingCluster,
@@ -111,16 +98,15 @@ var _ = BeforeSuite(func() {
 		Scheme:                e2e.InitScheme(),
 		ArtifactFolder:        flagVals.ArtifactFolder,
 		KubernetesVersion:     e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
-		IsolatedMode:          flagVals.IsolatedMode,
 		HelmBinaryPath:        flagVals.HelmBinaryPath,
-		CustomClusterProvider: customClusterProvider,
+		CustomClusterProvider: preSetupOutput.CustomClusterProvider,
 	})
 
 	testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 		BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:           flagVals.HelmBinaryPath,
 		HelmExtraValuesPath:      filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher-ingress.yaml"),
-		IngressType:              ingressType,
+		IngressType:              preSetupOutput.IngressType,
 		CustomIngress:            e2e.NginxIngress,
 		CustomIngressNamespace:   e2e.NginxIngressNamespace,
 		CustomIngressDeployment:  e2e.NginxIngressDeployment,
@@ -132,10 +118,6 @@ var _ = BeforeSuite(func() {
 		NgrokRepoURL:             e2eConfig.GetVariable(e2e.NgrokUrlVar),
 		DefaultIngressClassPatch: e2e.IngressClassPatch,
 	})
-
-	if flagVals.IsolatedMode {
-		hostName = setupClusterResult.IsolatedHostName
-	}
 
 	rancherInput := testenv.DeployRancherInput{
 		BootstrapClusterProxy:  setupClusterResult.BootstrapClusterProxy,
@@ -157,11 +139,18 @@ var _ = BeforeSuite(func() {
 		ControllerWaitInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
 		Variables:              e2eConfig.Variables,
 	}
-	if !flagVals.IsolatedMode && !flagVals.UseEKS {
-		// i.e. we are using ngrok locally
-		rancherInput.RancherIngressConfig = e2e.IngressConfig
-		rancherInput.RancherServicePatch = e2e.RancherServicePatch
-	}
+
+	rancherHookResult := testenv.PreRancherInstallHook(
+		&testenv.PreRancherInstallHookInput{
+			Ctx:                ctx,
+			RancherInput:       &rancherInput,
+			E2EConfig:          e2eConfig,
+			SetupClusterResult: setupClusterResult,
+			PreSetupOutput:     preSetupOutput,
+		})
+
+	hostName = rancherHookResult.HostName
+
 	testenv.DeployRancher(ctx, rancherInput)
 
 	rtInput := testenv.DeployRancherTurtlesInput{
@@ -169,11 +158,12 @@ var _ = BeforeSuite(func() {
 		HelmBinaryPath:               flagVals.HelmBinaryPath,
 		ChartPath:                    "https://rancher.github.io/turtles",
 		CAPIProvidersYAML:            e2e.CapiProviders,
-		Namespace:                    turtlesframework.DefaultRancherTurtlesNamespace,
+		Namespace:                    framework.DefaultRancherTurtlesNamespace,
 		Version:                      "v0.6.0",
 		WaitDeploymentsReadyInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
 		AdditionalValues:             map[string]string{},
 	}
+
 	testenv.DeployRancherTurtles(ctx, rtInput)
 
 	testenv.DeployChartMuseum(ctx, testenv.DeployChartMuseumInput{
@@ -186,22 +176,21 @@ var _ = BeforeSuite(func() {
 	upgradeInput := testenv.UpgradeRancherTurtlesInput{
 		BootstrapClusterProxy:        setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:               flagVals.HelmBinaryPath,
-		Namespace:                    turtlesframework.DefaultRancherTurtlesNamespace,
+		Namespace:                    framework.DefaultRancherTurtlesNamespace,
 		Image:                        fmt.Sprintf("ghcr.io/rancher/turtles-e2e-%s", runtime.GOARCH),
 		Tag:                          "v0.0.1",
 		WaitDeploymentsReadyInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
 		AdditionalValues:             rtInput.AdditionalValues,
 	}
 
-	// NOTE: this was the default previously in the chart locally and ok as
-	// we where loading the image into kind manually.
-	rtInput.AdditionalValues["rancherTurtles.imagePullPolicy"] = "Never"
 	rtInput.AdditionalValues["rancherTurtles.features.addon-provider-fleet.enabled"] = "true"
 	rtInput.AdditionalValues["rancherTurtles.features.managementv3-cluster.enabled"] = "false" // disable the default management.cattle.io/v3 controller
 
+	testenv.PreRancherTurtlesUpgradelHook(&upgradeInput, e2eConfig)
+
 	upgradeInput.PostUpgradeSteps = append(upgradeInput.PostUpgradeSteps, func() {
 		By("Waiting for CAAPF deployment to be available")
-		framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
+		capiframework.WaitForDeploymentsAvailable(ctx, capiframework.WaitForDeploymentsAvailableInput{
 			Getter: setupClusterResult.BootstrapClusterProxy.GetClient(),
 			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
 				Name:      "caapf-controller-manager",
@@ -212,21 +201,7 @@ var _ = BeforeSuite(func() {
 
 	testenv.UpgradeRancherTurtles(ctx, upgradeInput)
 
-	giteaValues := map[string]string{
-		"gitea.admin.username": e2eConfig.GetVariable(e2e.GiteaUserNameVar),
-		"gitea.admin.password": e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
-	}
-
-	giteaServiceType := corev1.ServiceTypeNodePort
-	if flagVals.UseEKS {
-		giteaServiceType = corev1.ServiceTypeLoadBalancer
-	}
-
-	if flagVals.GiteaCustomIngress {
-		giteaServiceType = corev1.ServiceTypeClusterIP
-	}
-
-	giteaResult = testenv.DeployGitea(ctx, testenv.DeployGiteaInput{
+	giteaInput := testenv.DeployGiteaInput{
 		BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:        flagVals.HelmBinaryPath,
 		ChartRepoName:         e2eConfig.GetVariable(e2e.GiteaRepoNameVar),
@@ -234,16 +209,22 @@ var _ = BeforeSuite(func() {
 		ChartName:             e2eConfig.GetVariable(e2e.GiteaChartNameVar),
 		ChartVersion:          e2eConfig.GetVariable(e2e.GiteaChartVersionVar),
 		ValuesFilePath:        "../../data/gitea/values.yaml",
-		Values:                giteaValues,
-		RolloutWaitInterval:   e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea"),
-		ServiceWaitInterval:   e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea-service"),
-		AuthSecretName:        e2e.AuthSecretName,
-		Username:              e2eConfig.GetVariable(e2e.GiteaUserNameVar),
-		Password:              e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
-		ServiceType:           giteaServiceType,
-		CustomIngressConfig:   e2e.GiteaIngress,
-		Variables:             e2eConfig.Variables,
-	})
+		Values: map[string]string{
+			"gitea.admin.username": e2eConfig.GetVariable(e2e.GiteaUserNameVar),
+			"gitea.admin.password": e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
+		},
+		RolloutWaitInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea"),
+		ServiceWaitInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-gitea-service"),
+		AuthSecretName:      e2e.AuthSecretName,
+		Username:            e2eConfig.GetVariable(e2e.GiteaUserNameVar),
+		Password:            e2eConfig.GetVariable(e2e.GiteaUserPasswordVar),
+		CustomIngressConfig: e2e.GiteaIngress,
+		Variables:           e2eConfig.Variables,
+	}
+
+	testenv.PreGiteaInstallHook(&giteaInput, e2eConfig)
+
+	giteaResult = testenv.DeployGitea(ctx, giteaInput)
 })
 
 var _ = AfterSuite(func() {
@@ -256,7 +237,7 @@ var _ = AfterSuite(func() {
 	testenv.UninstallRancherTurtles(ctx, testenv.UninstallRancherTurtlesInput{
 		BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:        flagVals.HelmBinaryPath,
-		Namespace:             turtlesframework.DefaultRancherTurtlesNamespace,
+		Namespace:             framework.DefaultRancherTurtlesNamespace,
 		DeleteWaitInterval:    e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-turtles-uninstall"),
 	})
 

--- a/test/e2e/suites/update-labels/suite_test.go
+++ b/test/e2e/suites/update-labels/suite_test.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/rancher/turtles/test/e2e"
 	"github.com/rancher/turtles/test/framework"
-	turtlesframework "github.com/rancher/turtles/test/framework"
 	"github.com/rancher/turtles/test/testenv"
 )
 
@@ -83,26 +82,7 @@ var _ = BeforeSuite(func() {
 	By(fmt.Sprintf("Loading the e2e test configuration from %q", flagVals.ConfigPath))
 	e2eConfig = e2e.LoadE2EConfig(flagVals.ConfigPath)
 
-	hostName = e2eConfig.GetVariable(e2e.RancherHostnameVar)
-	ingressType := testenv.NgrokIngress
-	dockerUsername := ""
-	dockerPassword := ""
-	var customClusterProvider testenv.CustomClusterProvider
-
-	if flagVals.UseEKS {
-		Expect(flagVals.IsolatedMode).To(BeFalse(), "You cannot use eks with isolated")
-		dockerUsername = os.Getenv("GITHUB_USERNAME")
-		Expect(dockerUsername).NotTo(BeEmpty(), "Github username is required")
-		dockerPassword = os.Getenv("GITHUB_TOKEN")
-		Expect(dockerPassword).NotTo(BeEmpty(), "Github token is required")
-		customClusterProvider = testenv.EKSBootsrapCluster
-		Expect(customClusterProvider).NotTo(BeNil(), "EKS custom cluster provider is required")
-		ingressType = testenv.EKSNginxIngress
-	}
-
-	if flagVals.IsolatedMode {
-		ingressType = testenv.CustomIngress
-	}
+	preSetupOutput := testenv.PreManagementClusterSetupHook(e2eConfig)
 
 	By(fmt.Sprintf("Creating a clusterctl config into %q", flagVals.ArtifactFolder))
 	clusterctlConfigPath = e2e.CreateClusterctlLocalRepository(ctx, e2eConfig, filepath.Join(flagVals.ArtifactFolder, "repository"))
@@ -114,16 +94,15 @@ var _ = BeforeSuite(func() {
 		Scheme:                e2e.InitScheme(),
 		ArtifactFolder:        flagVals.ArtifactFolder,
 		KubernetesVersion:     e2eConfig.GetVariable(e2e.KubernetesManagementVersionVar),
-		IsolatedMode:          flagVals.IsolatedMode,
 		HelmBinaryPath:        flagVals.HelmBinaryPath,
-		CustomClusterProvider: customClusterProvider,
+		CustomClusterProvider: preSetupOutput.CustomClusterProvider,
 	})
 
 	testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 		BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:           flagVals.HelmBinaryPath,
 		HelmExtraValuesPath:      filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher-ingress.yaml"),
-		IngressType:              ingressType,
+		IngressType:              preSetupOutput.IngressType,
 		CustomIngress:            e2e.NginxIngress,
 		CustomIngressNamespace:   e2e.NginxIngressNamespace,
 		CustomIngressDeployment:  e2e.NginxIngressDeployment,
@@ -135,32 +114,6 @@ var _ = BeforeSuite(func() {
 		NgrokRepoURL:             e2eConfig.GetVariable(e2e.NgrokUrlVar),
 		DefaultIngressClassPatch: e2e.IngressClassPatch,
 	})
-
-	if flagVals.IsolatedMode {
-		hostName = setupClusterResult.IsolatedHostName
-	}
-
-	if flagVals.UseEKS {
-		By("Getting ingress hostname")
-		svcRes := &testenv.WaitForServiceIngressHostnameResult{}
-		testenv.WaitForServiceIngressHostname(ctx, testenv.WaitForServiceIngressHostnameInput{
-			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
-			ServiceName:           "ingress-nginx-controller",
-			ServiceNamespace:      "ingress-nginx",
-			IngressWaitInterval:   e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-rancher"),
-		}, svcRes)
-		hostName = svcRes.Hostname
-
-		By("Deploying ghcr details")
-		framework.CreateDockerRegistrySecret(ctx, framework.CreateDockerRegistrySecretInput{
-			Name:                  "regcred",
-			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
-			Namespace:             "rancher-turtles-system",
-			DockerServer:          "https://ghcr.io",
-			DockerUsername:        dockerUsername,
-			DockerPassword:        dockerPassword,
-		})
-	}
 
 	rancherInput := testenv.DeployRancherInput{
 		BootstrapClusterProxy:  setupClusterResult.BootstrapClusterProxy,
@@ -174,7 +127,6 @@ var _ = BeforeSuite(func() {
 		RancherChartURL:        e2eConfig.GetVariable(e2e.RancherUrlVar),
 		RancherChartPath:       e2eConfig.GetVariable(e2e.RancherPathVar),
 		RancherVersion:         e2eConfig.GetVariable(e2e.RancherVersionVar),
-		RancherHost:            hostName,
 		RancherNamespace:       e2e.RancherNamespace,
 		RancherPassword:        e2eConfig.GetVariable(e2e.RancherPasswordVar),
 		RancherPatches:         [][]byte{e2e.RancherSettingPatch},
@@ -182,14 +134,18 @@ var _ = BeforeSuite(func() {
 		ControllerWaitInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
 		Variables:              e2eConfig.Variables,
 	}
-	if !flagVals.IsolatedMode && !flagVals.UseEKS {
-		// i.e. we are using ngrok locally
-		rancherInput.RancherIngressConfig = e2e.IngressConfig
-		rancherInput.RancherServicePatch = e2e.RancherServicePatch
-	}
-	if flagVals.UseEKS {
-		rancherInput.RancherIngressClassName = "nginx"
-	}
+
+	rancherHookResult := testenv.PreRancherInstallHook(
+		&testenv.PreRancherInstallHookInput{
+			Ctx:                ctx,
+			RancherInput:       &rancherInput,
+			E2EConfig:          e2eConfig,
+			SetupClusterResult: setupClusterResult,
+			PreSetupOutput:     preSetupOutput,
+		})
+
+	hostName = rancherHookResult.HostName
+
 	testenv.DeployRancher(ctx, rancherInput)
 
 	rtInput := testenv.DeployRancherTurtlesInput{
@@ -197,7 +153,7 @@ var _ = BeforeSuite(func() {
 		HelmBinaryPath:               flagVals.HelmBinaryPath,
 		ChartPath:                    flagVals.ChartPath,
 		CAPIProvidersYAML:            e2e.CapiProviders,
-		Namespace:                    turtlesframework.DefaultRancherTurtlesNamespace,
+		Namespace:                    framework.DefaultRancherTurtlesNamespace,
 		Image:                        fmt.Sprintf("ghcr.io/rancher/turtles-e2e-%s", runtime.GOARCH),
 		Tag:                          "v0.0.1",
 		WaitDeploymentsReadyInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
@@ -206,14 +162,9 @@ var _ = BeforeSuite(func() {
 			"rancherTurtles.features.rancher-kubeconfigs.label": "true", // force to be true even if the default in teh chart changes
 		},
 	}
-	if flagVals.UseEKS {
-		rtInput.AdditionalValues["rancherTurtles.imagePullSecrets"] = "{regcred}"
-		rtInput.AdditionalValues["rancherTurtles.imagePullPolicy"] = "IfNotPresent"
-	} else {
-		// NOTE: this was the default previously in the chart locally and ok as
-		// we where loading the image into kind manually.
-		rtInput.AdditionalValues["rancherTurtles.imagePullPolicy"] = "Never"
-	}
+
+	testenv.PreRancherTurtlesInstallHook(&rtInput, e2eConfig)
+
 	testenv.DeployRancherTurtles(ctx, rtInput)
 
 	testenv.RestartRancher(ctx, testenv.RestartRancherInput{


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This PR is a part of the E2E refactoring issue, it includes the following changes:
- Our suite setup includes a lot of duplicate code for setting up management clusters on different infrastructures, I moved all related code to the testenv package. Any potential users of this code can reuse it or take it as an example and implement their own in case their e2e suite setup differs from ours.
- Some E2E configuration options are passed partially through ginkgo flags and the YAML config. I started moving some options from flags to config files so we have a single place for most configurations. I will open a follow-up PR with moving other values too.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
