### PR TITLE
✨ Pass the new GVK flag to azure manager

### DIFF
--- a/charts/rancher-turtles/templates/azure-rbac.yaml
+++ b/charts/rancher-turtles/templates/azure-rbac.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: caprke2-azure-aggregated-role
+  labels:
+    cluster.x-k8s.io/aggregate-to-capz-manager: "true"
+rules:
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - rke2configs
+  verbs:
+  - create
+  - update
+  - delete
+  - get
+  - list
+  - patch
+  - watch

--- a/charts/rancher-turtles/templates/clusterctl-config.yaml
+++ b/charts/rancher-turtles/templates/clusterctl-config.yaml
@@ -17,7 +17,7 @@ data:
       url:          "https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/v2.3.5/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "azure"
-      url:          "https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/v1.13.2/infrastructure-components.yaml"
+      url:          "https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/v1.16.0/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "docker"
       url:          "https://github.com/kubernetes-sigs/cluster-api/releases/v1.4.6/infrastructure-components-development.yaml"

--- a/internal/sync/azure_provider_sync.go
+++ b/internal/sync/azure_provider_sync.go
@@ -1,0 +1,74 @@
+/*
+Copyright © 2023 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
+
+	turtlesv1 "github.com/rancher/turtles/api/v1alpha1"
+	"github.com/rancher/turtles/internal/api"
+)
+
+// NewAzureProviderSync creates a new mirror object.
+func NewAzureProviderSync(cl client.Client, capiProvider *turtlesv1.CAPIProvider) Sync {
+	template := ProviderSync{}.Template(capiProvider)
+
+	destination, ok := template.(api.Provider)
+	if !ok || destination == nil {
+		return nil
+	}
+
+	spec := capiProvider.GetSpec()
+	if spec.Deployment == nil {
+		spec.Deployment = &operatorv1.DeploymentSpec{}
+	}
+
+	var container *operatorv1.ContainerSpec
+
+	for i := range spec.Deployment.Containers {
+		if spec.Deployment.Containers[i].Name == "manager" {
+			container = &spec.Deployment.Containers[i]
+			break
+		}
+	}
+
+	if container != nil {
+		if len(container.Args) == 0 {
+			container.Args = map[string]string{
+				"--bootstrap-config-gvk": "RKE2Config.v1beta1.bootstrap.cluster.x-k8s.io",
+			}
+		} else if _, found := container.Args["--bootstrap-config-gvk"]; !found {
+			container.Args["--bootstrap-config-gvk"] = "RKE2Config.v1beta1.bootstrap.cluster.x-k8s.io"
+		}
+	} else {
+		spec.Deployment.Containers = append(spec.Deployment.Containers, operatorv1.ContainerSpec{
+			Name: "manager",
+			Args: map[string]string{
+				"--bootstrap-config-gvk": "RKE2Config.v1beta1.bootstrap.cluster.x-k8s.io",
+			},
+		})
+	}
+
+	capiProvider.SetSpec(spec)
+
+	return &ProviderSync{
+		DefaultSynchronizer: NewDefaultSynchronizer(cl, capiProvider, template),
+		Destination:         destination,
+	}
+}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Since the introduction of the flags upstream in
- https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4931
- https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4933

And implementing upstream https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/4854, we need some changes to our turtles provider.

The CAPZ supports using different `GVK` for establishing controller to watch over changes within the bootstrap token. With that turtles will be able to leverage this flag for any user creating `azure` `CAPIProvider`.

The default value (**set to watch  `RKE2Config` for us**) of the CLI flag can be overridden, if the `CAPIProvider` resource has additionally specified:
```yaml
spec:
…
  deployment:
    containers:
    - args:
        --bootstrap-config-gvk: KubeadmConfig.v1beta1.bootstrap.cluster.x-k8s.io
      name: manager
```
This allows to run the CAPZ with `kubeadm` bootstrap/controlPlane provider if required.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #633 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
