### PR TITLE
Disable 'rancher-kubeconfigs' feature gate in charts

### DIFF
--- a/charts/rancher-turtles/questions.yml
+++ b/charts/rancher-turtles/questions.yml
@@ -22,7 +22,7 @@ questions:
     show_subquestion_if: true
     subquestions:
     - variable: rancherTurtles.features.cluster-api-operator.kubectlImage
-      default: "registry.k8s.io/kubernetes/kubectl:v1.28.0"
+      default: "registry.k8s.io/kubernetes/kubectl:v1.30.0"
       description: "Specify the image to use when cleaning up the Cluster API Operator manifests"
       type: string
       label: Cleanup Image
@@ -36,7 +36,7 @@ questions:
     show_subquestion_if: true
     subquestions:
     - variable: rancherTurtles.features.rancher-webhook.kubectlImage
-      default: "registry.k8s.io/kubernetes/kubectl:v1.28.0"
+      default: "registry.k8s.io/kubernetes/kubectl:v1.30.0"
       description: "Specify the image to use when cleaning up the webhooks"
       type: string
       label: Webhook Cleanup Image

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -8,12 +8,12 @@ rancherTurtles:
   features:
     cluster-api-operator:
       cleanup: true
-      kubectlImage: registry.k8s.io/kubernetes/kubectl:v1.28.0
+      kubectlImage: registry.k8s.io/kubernetes/kubectl:v1.30.0
     embedded-capi:
       disabled: true
     rancher-webhook:
       cleanup: true
-      kubectlImage: registry.k8s.io/kubernetes/kubectl:v1.28.0
+      kubectlImage: registry.k8s.io/kubernetes/kubectl:v1.30.0
     rancher-kubeconfigs:
       label: true
     managementv3-cluster:

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -15,7 +15,7 @@ rancherTurtles:
       cleanup: true
       kubectlImage: registry.k8s.io/kubernetes/kubectl:v1.30.0
     rancher-kubeconfigs:
-      label: true
+      label: false
     managementv3-cluster:
       enabled: true
     managementv3-cluster-migration:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -39,7 +39,7 @@ make test-e2e
 This will consequently:
 1. Build a docker image with the current repository code using `docker-build` Makefile target.
 2. Generate a test release chart containing docker image tag built in the previous step
-3. Install all prerequisite dependencies, like `helm`, `kubectl>=v1.27.0`, download `cluster-api-operator` helm release file from pre-specified URL.
+3. Install all prerequisite dependencies, like `helm`, `kubectl>=v1.30.0`, download `cluster-api-operator` helm release file from pre-specified URL.
 4. Create the test cluster, run the test suite, cleanup all test resourses.
 5. Collect the [artifacts](#artifacts)
 

--- a/test/e2e/suites/update-labels/suite_test.go
+++ b/test/e2e/suites/update-labels/suite_test.go
@@ -162,8 +162,8 @@ var _ = BeforeSuite(func() {
 		Tag:                          e2eConfig.GetVariable(e2e.TurtlesVersionVar),
 		WaitDeploymentsReadyInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
 		AdditionalValues: map[string]string{
-			"cluster-api-operator.cluster-api.version":          "v1.6.0",
-			"rancherTurtles.features.rancher-kubeconfigs.label": "true", // force to be true even if the default in teh chart changes
+			"cluster-api-operator.cluster-api.version":          "v1.7.3",
+			"rancherTurtles.features.rancher-kubeconfigs.label": "true", // force to be true even if the default in the chart changes
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
'rancher-kubeconfigs' FG introduced in https://github.com/rancher/turtles/pull/178 was meant to test CAPI >=v1.5.x in turtles at the time Rancher was not ready yet. However, with the newer Rancher version (v2.9.x using CAPI v1.7.x) it should be possible to test newer version of CAPI without this feature gate enabled. Moreover, `update-labels` test [suite](https://github.com/rancher/turtles/blob/main/test/e2e/suites/update-labels/suite_test.go#L166) this FG by explicitly setting it to true anyways, but by default we should not expose it as enabled in charts.

Additionally, it is a follow-up to #658 to bump leftover dependencies to newer versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
