### PR TITLE
Install kubectl binary in e2e run suite GH workflow

### DIFF
--- a/.github/workflows/run-e2e-suite.yaml
+++ b/.github/workflows/run-e2e-suite.yaml
@@ -69,6 +69,10 @@ jobs:
           sudo mv ./aws-iam-authenticator /usr/local/bin
 
           aws-iam-authenticator version
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.30.0
       - name: Checkout
         uses: actions/checkout@v4.1.3
         with:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Install kubectl binary with specific version v1.30.0 in e2e run suite GH workflow. e2e nightly runs started failing after #659 where we set MINIMUM_KUBECTL_VERSION to v1.30.0. However, version of kubectl used in GH env (not coming from our codebase) seems to be 1.28.4 which is <  v1.30.0 MINIMUM_KUBECTL_VERSION, hence, they started failing https://github.com/rancher/turtles/actions/runs/10419056888/job/28856363769. 

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Tested this patch here: https://github.com/rancher/turtles/actions/runs/10421045742/job/28862355979

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
