### PR TITLE
Switch mgmtv3 cluster name to prevent v1 provisioning

### DIFF
--- a/internal/controllers/import_controller_v3.go
+++ b/internal/controllers/import_controller_v3.go
@@ -270,7 +270,7 @@ func (r *CAPIImportManagementV3Reconciler) reconcileNormal(ctx context.Context, 
 		newCluster := &managementv3.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    capiCluster.Namespace,
-				GenerateName: "c-",
+				GenerateName: capiCluster.Name,
 				Labels: map[string]string{
 					capiClusterOwner:          capiCluster.Name,
 					capiClusterOwnerNamespace: capiCluster.Namespace,

--- a/internal/controllers/import_controller_v3_test.go
+++ b/internal/controllers/import_controller_v3_test.go
@@ -90,7 +90,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		rancherCluster = &managementv3.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    capiCluster.Namespace,
-				GenerateName: "c-",
+				GenerateName: capiCluster.Name,
 				Labels: map[string]string{
 					capiClusterOwner:          capiCluster.Name,
 					capiClusterOwnerNamespace: capiCluster.Namespace,
@@ -196,7 +196,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		Eventually(ctx, func(g Gomega) {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
-			g.Expect(rancherClusters.Items[0].Name).To(ContainSubstring("c-"))
+			g.Expect(rancherClusters.Items[0].Name).To(ContainSubstring(capiCluster.Name))
 			g.Expect(rancherClusters.Items[0].Labels).To(HaveKeyWithValue(testLabelName, testLabelVal))
 			g.Expect(rancherClusters.Items[0].Finalizers).To(ContainElement(managementv3.CapiClusterFinalizer))
 		}).Should(Succeed())
@@ -227,7 +227,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
-		Expect(rancherClusters.Items[0].Name).To(ContainSubstring("c-"))
+		Expect(rancherClusters.Items[0].Name).To(ContainSubstring(capiCluster.Name))
 	})
 
 	It("should reconcile a CAPI cluster when rancher cluster exists, and have finalizers set", func() {
@@ -254,7 +254,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(rancherClusters.Items[0].Finalizers).ToNot(ContainElement(managementv3.CapiClusterFinalizer))
 		}).Should(Succeed())
 		cluster := rancherClusters.Items[0]
-		Expect(cluster.Name).To(ContainSubstring("c-"))
+		Expect(cluster.Name).To(ContainSubstring(capiCluster.Name))
 
 		clusterRegistrationToken.Name = cluster.Name
 		clusterRegistrationToken.Namespace = cluster.Name
@@ -297,7 +297,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
-			g.Expect(rancherClusters.Items[0].Name).To(ContainSubstring("c-"))
+			g.Expect(rancherClusters.Items[0].Name).To(ContainSubstring(capiCluster.Name))
 			g.Expect(rancherClusters.Items[0].Labels).To(HaveKeyWithValue(testLabelName, testLabelVal))
 			g.Expect(rancherClusters.Items[0].Finalizers).To(ContainElement(managementv3.CapiClusterFinalizer))
 		}, 10*time.Second).Should(Succeed())
@@ -314,7 +314,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
 		cluster := rancherClusters.Items[0]
-		Expect(cluster.Name).To(ContainSubstring("c-"))
+		Expect(cluster.Name).To(ContainSubstring(capiCluster.Name))
 
 		_, err := testEnv.CreateNamespaceWithName(ctx, cluster.Name)
 		Expect(err).ToNot(HaveOccurred())
@@ -343,7 +343,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
 		cluster := rancherClusters.Items[0]
-		Expect(cluster.Name).To(ContainSubstring("c-"))
+		Expect(cluster.Name).To(ContainSubstring(capiCluster.Name))
 
 		conditions.Set(&cluster, conditions.TrueCondition(managementv3.ClusterConditionReady))
 		Expect(conditions.IsTrue(&cluster, managementv3.ClusterConditionReady)).To(BeTrue())
@@ -378,7 +378,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
 		cluster := rancherClusters.Items[0]
-		Expect(cluster.Name).To(ContainSubstring("c-"))
+		Expect(cluster.Name).To(ContainSubstring(capiCluster.Name))
 
 		clusterRegistrationToken.Name = cluster.Name
 		clusterRegistrationToken.Namespace = cluster.Name
@@ -421,7 +421,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
 		cluster := rancherClusters.Items[0]
-		Expect(cluster.Name).To(ContainSubstring("c-"))
+		Expect(cluster.Name).To(ContainSubstring(capiCluster.Name))
 
 		clusterRegistrationToken.Name = cluster.Name
 		clusterRegistrationToken.Namespace = cluster.Name
@@ -455,7 +455,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
 		cluster := rancherClusters.Items[0]
-		Expect(cluster.Name).To(ContainSubstring("c-"))
+		Expect(cluster.Name).To(ContainSubstring(capiCluster.Name))
 
 		clusterRegistrationToken.Name = cluster.Name
 		clusterRegistrationToken.Namespace = cluster.Name
@@ -514,7 +514,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
-		Expect(rancherClusters.Items[0].Name).To(ContainSubstring("c-"))
+		Expect(rancherClusters.Items[0].Name).To(ContainSubstring(capiCluster.Name))
 		Expect(rancherClusters.Items[0].Labels).To(HaveKeyWithValue(testLabelName, testLabelVal))
 	})
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR showcases creation of the v3 cluster without v1 provisioning cluster. The cluster is imported, but is not displayed in the UI, thus this PR marked a s draft and is for discussion.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
