### PR TITLE
✨ Check CAPI provider latest version daily

### DIFF
--- a/api/v1alpha1/conditions_consts.go
+++ b/api/v1alpha1/conditions_consts.go
@@ -28,6 +28,9 @@ const (
 	// RancherCredentialSourceMissing occures when a source credential secret is missing.
 	RancherCredentialSourceMissing = "RancherCredentialSourceMissing"
 
-	// LastAppliedConfigurationTime is set as a timestamp infor of the last configuration update byt the CAPI Operator resource.
+	// LastAppliedConfigurationTime is set as a timestamp info of the last configuration update byt the CAPI Operator resource.
 	LastAppliedConfigurationTime = "LastAppliedConfigurationTime"
+
+	// CheckLatestVersionTime is set as a timestamp info of the last timestamp of the latest version being up-to-date for the CAPIProvider.
+	CheckLatestVersionTime = "CheckLatestVersionTime"
 )


### PR DESCRIPTION
- Perform check that CAPIProvider is up-to-date with current latest daily. Longer delay is set to prevent hitting github rate limits.

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This change performs daily check for provider upgrades, and performs the actual upgrade automatically, if the `CAPIProvider` version is not set. If it is set, the version is user managed so we don’t upgrade this automatically.

Once upstream (capi-operator) has a condition to notify about new version availability, this daily check can be changed to rely on the status condition.

This change ensures we don’t leave existing users on older versions of providers.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #673 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
