### PR TITLE
feat: new issue template for provider certification

### DIFF
--- a/.github/ISSUE_TEMPLATE/certification_request.yaml
+++ b/.github/ISSUE_TEMPLATE/certification_request.yaml
@@ -1,0 +1,50 @@
+name: Request for CAPI Provider Certification
+description: Request that a CAPI provider is added to the list of certified providers.
+body:
+  - type: textarea
+    id: provider
+    attributes:
+      label: What is the provider you would like to be added?
+      placeholder: "Specify the name and the type of provider."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repository
+    attributes:
+      label: What is the repository URL?
+      placeholder: "Link to GitHub repository where the provider's source code is hosted."
+    validations:
+      required: true
+
+  - type: textarea
+    id: check_successful
+    attributes:
+      label: Did you follow the certification process?
+      placeholder: "You need to follow the certification process before requesting a provider to be added to the list. You can refer to the Turtles documentation [here](https://turtles.docs.rancher.com/tasks/provider-certification/intro)."
+    validations:
+      required: true     
+
+  - type: textarea
+    id: certification_info
+    attributes:
+      label: Confirm test suite integration for the provider.
+      placeholder: "You can share the CI status badge and the integration source code."
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why do you think this provider should be added?
+      placeholder: "All providers in the certified list are actively validated which means we have to keep it limited to the most relevant projects."
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else you would like to add?
+      placeholder: "Miscellaneous information."
+    validations:
+      required: false


### PR DESCRIPTION
**What this PR does / why we need it**:

As part of provider certification, this adds a new issue template for requesting a provider to be added to the list of Certified Providers once it is validated. This can be interesting for certain providers that we're not able to validate ourselves but users may be interested in using. After they certify the providers themselves,they can request it be added to the list and we can decide whether the provider is worth adding the main E2E suite so that it can be added to the Certified Table in the docs.

**Which issue(s) this PR fixes**:
Fixes #680 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
