### PR TITLE
🌱 Make latest check optional behind followLatest field

### DIFF
--- a/api/v1alpha1/capiprovider_types.go
+++ b/api/v1alpha1/capiprovider_types.go
@@ -60,6 +60,12 @@ type CAPIProviderSpec struct {
 	// +kubebuilder:example={CLUSTER_TOPOLOGY:"true",EXP_CLUSTER_RESOURCE_SET:"true",EXP_MACHINE_POOL: "true"}
 	Variables map[string]string `json:"variables,omitempty"`
 
+	// FollowLatest allows to track current latest version, and update provider accordingly to keep
+	// manifests in sync with new releases. Maximum version of the released components is limited by the provider
+	// override in the clusterctl.yaml data within clusterctl-config `ConfigMap`, or the fetchConfig.url.
+	// +optional
+	FollowLatest bool `json:"followLatest,omitempty"`
+
 	// ProviderSpec is the spec of the underlying CAPI Provider resource.
 	operatorv1.ProviderSpec `json:",inline"`
 }

--- a/charts/rancher-turtles/templates/addon-provider-fleet.yaml
+++ b/charts/rancher-turtles/templates/addon-provider-fleet.yaml
@@ -10,6 +10,7 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   type: addon
+  followLatest: true
   additionalManifests:
     name: fleet-addon-config
     namespace: '{{ .Values.rancherTurtles.namespace }}'

--- a/charts/rancher-turtles/templates/core-provider.yaml
+++ b/charts/rancher-turtles/templates/core-provider.yaml
@@ -21,6 +21,7 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   name: cluster-api
+  followLatest: true
   type: core
   version: {{ index .Values "cluster-api-operator" "cluster-api" "version" }}
   additionalManifests:

--- a/charts/rancher-turtles/templates/rancher-turtles-components.yaml
+++ b/charts/rancher-turtles/templates/rancher-turtles-components.yaml
@@ -2769,6 +2769,12 @@ spec:
                       desired version of the release from GitHub.
                     type: string
                 type: object
+              followLatest:
+                description: |-
+                  FollowLatest allows to track current latest version, and update provider accordingly to keep
+                  manifests in sync with new releases. Maximum version of the released components is limited by the provider
+                  override in the clusterctl.yaml data within clusterctl-config `ConfigMap`, or the fetchConfig.url.
+                type: boolean
               manager:
                 description: Manager defines the properties that can be enabled on
                   the controller manager for the provider.

--- a/charts/rancher-turtles/templates/rke2-bootstrap.yaml
+++ b/charts/rancher-turtles/templates/rke2-bootstrap.yaml
@@ -22,6 +22,7 @@ metadata:
 spec:
   name: rke2
   type: bootstrap
+  followLatest: true
 {{- if index .Values  "cluster-api-operator" "cluster-api" "rke2" "version" }}
   version: {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "version" }}
 {{- end }}

--- a/charts/rancher-turtles/templates/rke2-controlplane.yaml
+++ b/charts/rancher-turtles/templates/rke2-controlplane.yaml
@@ -22,6 +22,7 @@ metadata:
 spec:
   name: rke2
   type: controlPlane
+  followLatest: true
 {{- if index .Values  "cluster-api-operator" "cluster-api" "rke2" "version" }}
   version: {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "version" }}
 {{- end }}

--- a/config/crd/bases/turtles-capi.cattle.io_capiproviders.yaml
+++ b/config/crd/bases/turtles-capi.cattle.io_capiproviders.yaml
@@ -2769,6 +2769,12 @@ spec:
                       desired version of the release from GitHub.
                     type: string
                 type: object
+              followLatest:
+                description: |-
+                  FollowLatest allows to track current latest version, and update provider accordingly to keep
+                  manifests in sync with new releases. Maximum version of the released components is limited by the provider
+                  override in the clusterctl.yaml data within clusterctl-config `ConfigMap`, or the fetchConfig.url.
+                type: boolean
               manager:
                 description: Manager defines the properties that can be enabled on
                   the controller manager for the provider.

--- a/internal/sync/provider_sync.go
+++ b/internal/sync/provider_sync.go
@@ -153,7 +153,7 @@ func (s *ProviderSync) rolloutInfrastructure() {
 
 func (s *ProviderSync) updateLatestVersion(ctx context.Context) error {
 	// Skip for user specified versions
-	if s.Source.Spec.Version != "" {
+	if s.Source.Spec.Version != "" || !s.Source.Spec.FollowLatest {
 		return nil
 	}
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Follow up on #673. This change allows to selectively enable `followLatest` version behavior by setting the field in the spec. The behavior will be enabled by default for `rancher/turtles` `CAPIProviders` shipped with the helm chart installation, but will need a UI support, in order to set this field.

Latest version is determined and limited by the state of the `clusterctl.yaml` file, preventing occasions of unbounded latest version installation, and so always follows the max version from the `clusterctl-config` `ConfigMap`.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher/turtles/issues/691

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
