### PR TITLE
chore: Use straight quotes instead of curly in the git command

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -40,7 +40,7 @@ git clone git@github.com:rancher/turtles.git
 ```bash
 # Create tags locally
 git tag -s -a ${RELEASE_TAG} -m ${RELEASE_TAG}
-git tag -s  -a test/${RELEASE_TAG} -m “Testing framework ${RELEASE_TAG}”
+git tag -s  -a test/${RELEASE_TAG} -m "Testing framework ${RELEASE_TAG}"
 
 # Push tags
 git push upstream ${RELEASE_TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:
That is because bash expects straight quotes (" or ') for string delimiters.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
