### PR TITLE
Bump CAPRKE2 to v0.6.0 version

### DIFF
--- a/charts/rancher-turtles/templates/clusterctl-config.yaml
+++ b/charts/rancher-turtles/templates/clusterctl-config.yaml
@@ -37,7 +37,7 @@ data:
       url:          "https://github.com/kubernetes-sigs/cluster-api/releases/v1.7.3/bootstrap-components.yaml"
       type:         "BootstrapProvider"
     - name:         "rke2"
-      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.5.0/bootstrap-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.6.0/bootstrap-components.yaml"
       type:         "BootstrapProvider"
 
     # ControlPlane providers
@@ -45,7 +45,7 @@ data:
       url:          "https://github.com/kubernetes-sigs/cluster-api/releases/v1.7.3/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
     - name:         "rke2"
-      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.5.0/control-plane-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.6.0/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
 
     # Addon providers

--- a/exp/etcdrestore/go.mod
+++ b/exp/etcdrestore/go.mod
@@ -7,7 +7,7 @@ replace github.com/rancher/turtles => ../..
 require (
 	github.com/onsi/ginkgo/v2 v2.20.0
 	github.com/onsi/gomega v1.34.1
-	github.com/rancher/cluster-api-provider-rke2 v0.5.0
+	github.com/rancher/cluster-api-provider-rke2 v0.6.0
 	github.com/rancher/turtles v0.0.0-00010101000000-000000000000
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
 	k8s.io/api v0.29.4

--- a/exp/etcdrestore/go.sum
+++ b/exp/etcdrestore/go.sum
@@ -141,8 +141,8 @@ github.com/prometheus/common v0.45.0 h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lne
 github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/rancher/cluster-api-provider-rke2 v0.5.0 h1:l+E3GqgLPlo9WIE6yamBiYGG3aPk4qbx6XhfqJ8WQKs=
-github.com/rancher/cluster-api-provider-rke2 v0.5.0/go.mod h1:V4jxqD4v1xQFSbgk57IECmXS4Y2DPyhrUDAsg/p75+k=
+github.com/rancher/cluster-api-provider-rke2 v0.6.0 h1:isplluz2yANZ2/19+giY+73W0YmixNZR58BAKTV6B9I=
+github.com/rancher/cluster-api-provider-rke2 v0.6.0/go.mod h1:V4jxqD4v1xQFSbgk57IECmXS4Y2DPyhrUDAsg/p75+k=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/rancher/cluster-api-provider-rke2/releases/tag/v0.6.0

Even though tests for CAPRKE2 are not enabled yet (pending https://github.com/rancher/turtles/pull/634), bumping it to newer version to not forget.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
