### PR TITLE
🌱 Add option to skip rancher pre-requisites

### DIFF
--- a/charts/rancher-turtles/templates/pre-install-job.yaml
+++ b/charts/rancher-turtles/templates/pre-install-job.yaml
@@ -1,4 +1,5 @@
 {{- if index .Values "rancherTurtles" "features" "embedded-capi" "disabled" }}
+{{- if index .Values "rancherTurtles" "rancherInstalled"}}
 ---
 apiVersion: management.cattle.io/v3
 kind: Feature
@@ -9,6 +10,7 @@ metadata:
     "helm.sh/hook-weight": "1"
 spec:
   value: false
+{{- end }}
 {{- end }}
 {{- if index .Values "rancherTurtles" "features" "rancher-webhook" "cleanup" }}
 ---

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -5,6 +5,7 @@ rancherTurtles:
   namespace: rancher-turtles-system
   managerArguments: []
   imagePullSecrets: []
+  rancherInstalled: true
   features:
     cluster-api-operator:
       cleanup: true

--- a/internal/controllers/capiprovider_controller.go
+++ b/internal/controllers/capiprovider_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
@@ -96,8 +97,9 @@ func (r *CAPIProviderReconciler) patchStatus(ctx context.Context, capiProvider *
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *CAPIProviderReconciler) SetupWithManager(_ context.Context, mgr ctrl.Manager) (err error) {
+func (r *CAPIProviderReconciler) SetupWithManager(_ context.Context, mgr ctrl.Manager, options controller.Options) (err error) {
 	b := ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
 		For(&turtlesv1.CAPIProvider{})
 
 	resources := []client.Object{

--- a/internal/controllers/capiprovider_controller_test.go
+++ b/internal/controllers/capiprovider_controller_test.go
@@ -27,6 +27,7 @@ import (
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
@@ -53,7 +54,7 @@ var _ = Describe("Reconcile CAPIProvider", func() {
 			Scheme: testEnv.GetScheme(),
 		}
 
-		Expect(r.SetupWithManager(ctx, testEnv.Manager)).ToNot(HaveOccurred())
+		Expect(r.SetupWithManager(ctx, testEnv.Manager, controller.Options{})).ToNot(HaveOccurred())
 	})
 
 	It("Should create infrastructure docker provider and secret", func() {

--- a/main.go
+++ b/main.go
@@ -261,6 +261,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		RancherClient: rancherClient,
 	}).SetupWithManager(ctx, mgr, controller.Options{
 		MaxConcurrentReconciles: concurrencyNumber,
+		CacheSyncTimeout:        maxDuration,
 	}); err != nil {
 		setupLog.Error(err, "unable to create rancher management v3 cleanup controller")
 		os.Exit(1)
@@ -272,7 +273,10 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		if err := (&controllers.RancherKubeconfigSecretReconciler{
 			Client:           mgr.GetClient(),
 			WatchFilterValue: watchFilterValue,
-		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: concurrencyNumber}); err != nil {
+		}).SetupWithManager(ctx, mgr, controller.Options{
+			MaxConcurrentReconciles: concurrencyNumber,
+			CacheSyncTimeout:        maxDuration,
+		}); err != nil {
 			setupLog.Error(err, "unable to create Rancher kubeconfig secret controller")
 			os.Exit(1)
 		}
@@ -283,7 +287,10 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	if err := (&controllers.CAPIProviderReconciler{
 		Client: mgr.GetClient(),
 		Scheme: scheme,
-	}).SetupWithManager(ctx, mgr); err != nil {
+	}).SetupWithManager(ctx, mgr, controller.Options{
+		MaxConcurrentReconciles: concurrencyNumber,
+		CacheSyncTimeout:        maxDuration,
+	}); err != nil {
 		setupLog.Error(err, "unable to create CAPI Provider controller")
 		os.Exit(1)
 	}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This change should allow to install turtles in development scenario without dependency on rancher, for the expense of added requirement to patch the `embedded-cluster-api` feature gate manually.

This can be done by specifying `--set rancherTurtles.rancherInstalled=false` flag.

Deletion will need to be performed according to https://turtles.docs.rancher.com/getting-started/uninstall_turtles

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #627

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
