### PR TITLE
🐛 Skip CAPIProvider reconciliation on deletion timestamp

### DIFF
--- a/internal/controllers/capiprovider_controller.go
+++ b/internal/controllers/capiprovider_controller.go
@@ -21,12 +21,11 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
 
@@ -46,19 +45,13 @@ type CAPIProviderReconciler struct {
 //+kubebuilder:rbac:groups=operator.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reconciles the CAPIProvider object.
-func (r *CAPIProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *CAPIProviderReconciler) Reconcile(ctx context.Context, capiProvider *turtlesv1.CAPIProvider) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 
-	capiProvider := &turtlesv1.CAPIProvider{ObjectMeta: metav1.ObjectMeta{
-		Name:      req.Name,
-		Namespace: req.Namespace,
-	}}
-	if err := r.Client.Get(ctx, req.NamespacedName, capiProvider); apierrors.IsNotFound(err) {
-		return ctrl.Result{}, nil
-	} else if err != nil {
-		log.Error(err, "Unable to get CAPIProvider manifest: "+req.String())
+	if !capiProvider.DeletionTimestamp.IsZero() {
+		log.Info("Provider is in the process of deletion, skipping reconcile...")
 
-		return ctrl.Result{}, err
+		return ctrl.Result{}, nil
 	}
 
 	return r.reconcileNormal(ctx, capiProvider)
@@ -113,5 +106,5 @@ func (r *CAPIProviderReconciler) SetupWithManager(_ context.Context, mgr ctrl.Ma
 		b = b.Owns(resource)
 	}
 
-	return b.Complete(r)
+	return b.Complete(reconcile.AsReconciler(r.Client, r))
 }


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
CAPI provider reconciler is re-applying proxied provider during deletion phase, causing re-creation of the infra resources. This change prevents it from happening.

Deletion will need to be performed according to https://turtles.docs.rancher.com/getting-started/uninstall_turtles

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #704

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
