### PR TITLE
Run e2e-long-test in EIO provided Containerized Org-Level Runners

### DIFF
--- a/.github/workflows/e2e-long-test.yaml
+++ b/.github/workflows/e2e-long-test.yaml
@@ -32,7 +32,14 @@ env:
 jobs:
   e2e_import_gitops:
     name: E2E Tests - Import Gitops
-    runs-on: [self-hosted, linux]
+    # Use the BCI Node.js container when running in EIO's provided runners,
+    # because the Node.js runtime is needed. If using public GH provided runners,
+    # a container isn't necessary, because they already provide the runtime, but
+    # the BCI image can still be used anyway.
+    container: registry.suse.com/bci/nodejs:20
+    # For when running in EIO's provided runners. More details are available in
+    # https://github.com/rancherlabs/eio/wiki/GitHub-Actions-Runners.
+    runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
     steps:
     - name: Checkout
       uses: actions/checkout@v4.1.7
@@ -64,7 +71,14 @@ jobs:
         commit: true
   e2e_v2prov:
     name: E2E Tests - v2prov
-    runs-on: [self-hosted, linux]
+    # Use the BCI Node.js container when running in EIO's provided runners,
+    # because the Node.js runtime is needed. If using public GH provided runners,
+    # a container isn't necessary, because they already provide the runtime, but
+    # the BCI image can still be used anyway.
+    container: registry.suse.com/bci/nodejs:20
+    # For when running in EIO's provided runners. More details are available in
+    # https://github.com/rancherlabs/eio/wiki/GitHub-Actions-Runners.
+    runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
     needs: e2e_import_gitops
     steps:
     - name: Checkout
@@ -97,7 +111,14 @@ jobs:
         commit: true
   e2e_update_labels:
     name: E2E Tests - Update labels
-    runs-on: [self-hosted, linux]
+    # Use the BCI Node.js container when running in EIO's provided runners,
+    # because the Node.js runtime is needed. If using public GH provided runners,
+    # a container isn't necessary, because they already provide the runtime, but
+    # the BCI image can still be used anyway.
+    container: registry.suse.com/bci/nodejs:20
+    # For when running in EIO's provided runners. More details are available in
+    # https://github.com/rancherlabs/eio/wiki/GitHub-Actions-Runners.
+    runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
     needs: e2e_v2prov
     steps:
     - name: Checkout
@@ -130,7 +151,14 @@ jobs:
         commit: true
   e2e_embedded_capi_disabled:
     name: E2E Tests - Embedded CAPI Disabled
-    runs-on: [self-hosted, linux]
+    # Use the BCI Node.js container when running in EIO's provided runners,
+    # because the Node.js runtime is needed. If using public GH provided runners,
+    # a container isn't necessary, because they already provide the runtime, but
+    # the BCI image can still be used anyway.
+    container: registry.suse.com/bci/nodejs:20
+    # For when running in EIO's provided runners. More details are available in
+    # https://github.com/rancherlabs/eio/wiki/GitHub-Actions-Runners.
+    runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
     needs: e2e_update_labels
     steps:
     - name: Checkout

--- a/.github/workflows/e2e-short-test.yaml
+++ b/.github/workflows/e2e-short-test.yaml
@@ -9,8 +9,14 @@ env:
 
 jobs:
   e2e:
-    runs-on: org--rancher--amd64-containers
-    container: ubuntu:22.04
+    # Use the BCI Node.js container when running in EIO's provided runners,
+    # because the Node.js runtime is needed. If using public GH provided runners,
+    # a container isn't necessary, because they already provide the runtime, but
+    # the BCI image can still be used anyway.
+    container: registry.suse.com/bci/nodejs:20
+    # For when running in EIO's provided runners. More details are available in
+    # https://github.com/rancherlabs/eio/wiki/GitHub-Actions-Runners.
+    runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7


### PR DESCRIPTION
**What this PR does / why we need it**:
e2e long tests are stuck waiting for GH runner to be picked up and eventually timing out (after a long waiting): https://github.com/rancher/turtles/actions/workflows/e2e-long.yaml

This PR tries to move only e2e-long-tests to be run in EIO provided Containerized Org-Level Runners (xref: https://github.com/rancherlabs/eio/wiki/GitHub-Actions-Runners#containerized-org-level-runners). All the other GH workflows as of now are currently using public provided GH runners.

<!-- Enter a description of the change and why this change is needed -->


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
