### PR TITLE
Run short e2e tests only for code changes

### DIFF
--- a/.github/workflows/e2e-short.yaml
+++ b/.github/workflows/e2e-short.yaml
@@ -2,7 +2,7 @@ name: Run short e2e tests
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
 
 env:
   MANAGEMENT_CLUSTER_ENVIRONMENT: "isolated-kind"


### PR DESCRIPTION
**What this PR does / why we need it**:
We run e2e tests in every PR and current workflow defines the type of actions to run e2e short tests are as following:

```
on:
  pull_request:
    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
```

Description of each activity type:
- opened: Triggered when a new pull request is opened.
- edited: Triggered when an existing pull request is edited.
- synchronize: Triggered when a pull request's head branch is updated (e.g., new commits are pushed to the branch).
- reopened: Triggered when a closed pull request is reopened.
- labeled: Triggered when a label is added to a pull request.
- unlabeled: Triggered when a label is removed from a pull request.

Personally, it seems too much to re-run whole e2e-short tests when just editing PR description or labeling/unlabeling (it does not matter for us, because we don't have a selective test mechanism based on PR labels) of PR happens (in fact it happens to me a lot and that always re-runs the job which takes as of now ~1h). So, I would like to re-run e2e-short tests only when it is required: new/re-opened PR, code change push.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
