### PR TITLE
Bump elemental provider version

### DIFF
--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -21,7 +21,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api-provider-vsphere/releases/v1.11.0/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "elemental"
-      url:          "https://github.com/rancher-sandbox/cluster-api-provider-elemental/releases/v0.6.0/infrastructure-components.yaml"
+      url:          "https://github.com/rancher-sandbox/cluster-api-provider-elemental/releases/v0.7.0/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "docker"
       url:          "https://github.com/kubernetes-sigs/cluster-api/releases/v1.7.3/infrastructure-components-development.yaml"


### PR DESCRIPTION
kind/feature

**What this PR does / why we need it**:

The Elemental CAPI provider just got a new release: https://github.com/rancher-sandbox/cluster-api-provider-elemental/releases/tag/v0.7.0