### PR TITLE
add pre-upgrade/post-delete clusterctl cm cleanup

### DIFF
--- a/charts/rancher-turtles/templates/clusterctl-cm-cleanup-job.yaml
+++ b/charts/rancher-turtles/templates/clusterctl-cm-cleanup-job.yaml
@@ -1,0 +1,66 @@
+{{- if index .Values "rancherTurtles" "features" "rancher-webhook" "cleanup" }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pre-upgrade-job
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
+  annotations:
+    "helm.sh/hook": "post-delete, pre-upgrade"
+    "helm.sh/hook-weight": "-2"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pre-upgrade-job-delete-clusterctl-configmap
+  annotations:
+    "helm.sh/hook": "post-delete, pre-upgrade"
+    "helm.sh/hook-weight": "-2"
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pre-upgrade-job-clusterctl-configmap-cleanup
+  annotations:
+    "helm.sh/hook": "post-delete, pre-upgrade"
+    "helm.sh/hook-weight": "-2"
+subjects:
+  - kind: ServiceAccount
+    name: pre-upgrade-job
+    namespace: '{{ .Values.rancherTurtles.namespace }}'
+roleRef:
+  kind: ClusterRole
+  name: pre-upgrade-job-delete-clusterctl-configmap
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rancher-clusterctl-configmap-cleanup
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
+  annotations:
+    "helm.sh/hook": "post-delete, pre-upgrade"
+    "helm.sh/hook-weight": "-1"
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: pre-upgrade-job
+      containers:
+        - name: rancher-clusterctl-configmap-cleanup
+          image: {{ index .Values "rancherTurtles" "features" "rancher-webhook" "kubectlImage" }}
+          args:
+          - delete
+          - configmap
+          - --namespace={{ .Values.rancherTurtles.namespace }}
+          - clusterctl-config
+          - --ignore-not-found=true
+      restartPolicy: Never
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

With v0.12.0 `clusterctl-config` ConfigMap is [no longer controlled by Helm](https://github.com/rancher/turtles/pull/742/files#diff-e7819a05b9d46150caea3c686e263975ec995c3bec814906fe92fce5f033fb86), as it was in v0.11.0 and before. Upgrading from v0.11 (or before) to v0.12 works as expected but we can't downgrade if the source version is v0.12, as Helm will try to assume control over the resource but it won't be able to, as it is missing the annotations/labels to control it. This could be fixed by simply annotating/labeling the ConfigMap resource but it goes against the purpose of detaching Helm and `clusterctl-config`, which will be maintained for future versions >v0.12.

In this case, together with @Danil-Grigorev, we thought about adding a `pre-upgrade` hook that cleans the conflicting resource before any upgrades. Unfortunately, this error occurs during chart rendering/validation, which means no hook is applied before it exits with error. The error won't cause a problem in future releases, as `clusterctl-config` will maintain the behavior of v0.12.

This change proposes that we create a `["pre-upgrade", "post-delete"]` job that cleans up the ConfigMap, avoiding any future conflicts with upgrades and uninstalls and, for the specific case of downgrading from >=v0.12 to <v0.12, there will be a note added to the docs on how to bypass the problem.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
