### PR TITLE
Add helm labels to allow chart downgrade

### DIFF
--- a/internal/controllers/clusterctl/config.go
+++ b/internal/controllers/clusterctl/config.go
@@ -69,7 +69,10 @@ type ConfigImage struct {
 // Config returns current set of embedded turtles clusterctl overrides.
 func Config() *corev1.ConfigMap {
 	configMap := config.DeepCopy()
-	configMap.Namespace = cmp.Or(os.Getenv("POD_NAMESPACE"), "rancher-turtles-system")
+
+	namespace := cmp.Or(os.Getenv("POD_NAMESPACE"), "rancher-turtles-system")
+	configMap.Namespace = namespace
+	configMap.Annotations["meta.helm.sh/release-namespace"] = namespace
 
 	return configMap
 }

--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: clusterctl-config
+  annotations:
+    meta.helm.sh/release-name: rancher-turtles
+  labels:
+    app.kubernetes.io/managed-by: Helm
 data:
   clusterctl.yaml: |
     providers:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Ensure labels match previous helm release for clusterctl-config ConfigMap, which will allow chart validation to pass during downgrade.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
