### PR TITLE
🐛 CAPIProvider: Always provide a name for UI and -o wide

### DIFF
--- a/api/v1alpha1/capiprovider_types.go
+++ b/api/v1alpha1/capiprovider_types.go
@@ -115,6 +115,9 @@ type CAPIProviderStatus struct {
 	// +kubebuilder:default={CLUSTER_TOPOLOGY:"true",EXP_CLUSTER_RESOURCE_SET:"true",EXP_MACHINE_POOL: "true"}
 	Variables map[string]string `json:"variables,omitempty"`
 
+	// Name reflects actual provider name, which will be visible to users in 'kubectl get capiproviders -A -o wide'
+	Name string `json:"name,omitempty"`
+
 	operatorv1.ProviderStatus `json:",inline"`
 }
 
@@ -123,7 +126,7 @@ type CAPIProviderStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type"
-// +kubebuilder:printcolumn:name="ProviderName",type="string",JSONPath=".spec.name"
+// +kubebuilder:printcolumn:name="ProviderName",type="string",JSONPath=".status.name"
 // +kubebuilder:printcolumn:name="InstalledVersion",type="string",JSONPath=".status.installedVersion"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 // +kubebuilder:validation:XValidation:message="CAPI Provider type should always be set.",rule="has(self.spec.type)"

--- a/api/v1alpha1/capiprovider_wrapper.go
+++ b/api/v1alpha1/capiprovider_wrapper.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"cmp"
+
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
@@ -72,6 +74,11 @@ func (b *CAPIProviderList) GetItems() []operatorv1.GenericProvider {
 // SetVariables updates the Variables field in the CAPIProvider status.
 func (b *CAPIProvider) SetVariables(v map[string]string) {
 	b.Status.Variables = v
+}
+
+// SetProviderName updates provider name based on spec field or metadata.name.
+func (b *CAPIProvider) SetProviderName() {
+	b.Status.Name = cmp.Or(b.Spec.Name, b.Name)
 }
 
 // SetPhase updates the Phase field in the CAPIProvider status.

--- a/charts/rancher-turtles/templates/rancher-turtles-components.yaml
+++ b/charts/rancher-turtles/templates/rancher-turtles-components.yaml
@@ -18,7 +18,7 @@ spec:
     - jsonPath: .spec.type
       name: Type
       type: string
-    - jsonPath: .spec.name
+    - jsonPath: .status.name
       name: ProviderName
       type: string
     - jsonPath: .status.installedVersion
@@ -3064,6 +3064,10 @@ spec:
               installedVersion:
                 description: InstalledVersion is the version of the provider that
                   is installed.
+                type: string
+              name:
+                description: Name reflects actual provider name, which will be visible
+                  to users in 'kubectl get capiproviders -A -o wide'
                 type: string
               observedGeneration:
                 description: ObservedGeneration is the latest generation observed

--- a/config/crd/bases/turtles-capi.cattle.io_capiproviders.yaml
+++ b/config/crd/bases/turtles-capi.cattle.io_capiproviders.yaml
@@ -18,7 +18,7 @@ spec:
     - jsonPath: .spec.type
       name: Type
       type: string
-    - jsonPath: .spec.name
+    - jsonPath: .status.name
       name: ProviderName
       type: string
     - jsonPath: .status.installedVersion
@@ -3064,6 +3064,10 @@ spec:
               installedVersion:
                 description: InstalledVersion is the version of the provider that
                   is installed.
+                type: string
+              name:
+                description: Name reflects actual provider name, which will be visible
+                  to users in 'kubectl get capiproviders -A -o wide'
                 type: string
               observedGeneration:
                 description: ObservedGeneration is the latest generation observed

--- a/internal/controllers/capiprovider_controller_test.go
+++ b/internal/controllers/capiprovider_controller_test.go
@@ -76,6 +76,33 @@ var _ = Describe("Reconcile CAPIProvider", func() {
 		})))
 	})
 
+	It("Should inherit docker provider name", func() {
+		provider := &turtlesv1.CAPIProvider{ObjectMeta: metav1.ObjectMeta{
+			Name:      "docker",
+			Namespace: ns.Name,
+		}, Spec: turtlesv1.CAPIProviderSpec{
+			Type: turtlesv1.Infrastructure,
+		}}
+		Expect(cl.Create(ctx, provider)).ToNot(HaveOccurred())
+
+		Eventually(Object(provider)).Should(
+			HaveField("Status.Name", Equal(provider.Name)))
+	})
+
+	It("Should inherit docker provider name from the spec", func() {
+		provider := &turtlesv1.CAPIProvider{ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: ns.Name,
+		}, Spec: turtlesv1.CAPIProviderSpec{
+			Name: "docker",
+			Type: turtlesv1.Infrastructure,
+		}}
+		Expect(cl.Create(ctx, provider)).ToNot(HaveOccurred())
+
+		Eventually(Object(provider)).Should(
+			HaveField("Status.Name", Equal(provider.Spec.Name)))
+	})
+
 	It("Should update infrastructure docker provider version and secret content from CAPI Provider change", func() {
 		provider := &turtlesv1.CAPIProvider{ObjectMeta: metav1.ObjectMeta{
 			Name:      "docker",

--- a/internal/sync/provider_sync.go
+++ b/internal/sync/provider_sync.go
@@ -125,6 +125,8 @@ func (s *ProviderSync) SyncObjects() {
 }
 
 func (s *ProviderSync) syncStatus() {
+	s.DefaultSynchronizer.Source.SetProviderName()
+
 	switch {
 	case conditions.IsTrue(s.Source, operatorv1.ProviderInstalledCondition):
 		s.Source.SetPhase(turtlesv1.Ready)


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Ensure that we always display provider name, which defaults to `.spec.name OR .metadata.name` in the `-o wide` of kubectl or UI, in cases when the name is not set in the spec.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #630 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
