### PR TITLE
🐛 Remove requirement to specify CAPIProvider secret

### DIFF
--- a/internal/sync/azure_provider_sync.go
+++ b/internal/sync/azure_provider_sync.go
@@ -67,6 +67,12 @@ func NewAzureProviderSync(cl client.Client, capiProvider *turtlesv1.CAPIProvider
 
 	capiProvider.SetSpec(spec)
 
+	if capiProvider.Spec.Variables == nil {
+		capiProvider.Spec.Variables = map[string]string{}
+	}
+
+	capiProvider.Spec.Variables["EXP_AKS_RESOURCE_HEALTH"] = "true"
+
 	return &ProviderSync{
 		DefaultSynchronizer: NewDefaultSynchronizer(cl, capiProvider, template),
 		Destination:         destination,

--- a/internal/sync/secret_sync.go
+++ b/internal/sync/secret_sync.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sync
 
 import (
+	"cmp"
 	"context"
 	"encoding/base64"
 	"strconv"
@@ -24,6 +25,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
 
 	turtlesv1 "github.com/rancher/turtles/api/v1alpha1"
 )
@@ -70,6 +73,10 @@ func (SecretSync) Template(capiProvider *turtlesv1.CAPIProvider) client.Object {
 // up <- Status.
 func (s *SecretSync) Sync(_ context.Context) error {
 	s.SyncObjects()
+
+	s.Source.Spec.ProviderSpec.ConfigSecret = cmp.Or(s.Source.Spec.ProviderSpec.ConfigSecret, &operatorv1.SecretReference{
+		Name: s.Source.Name,
+	})
 
 	return nil
 }

--- a/internal/sync/secret_sync.go
+++ b/internal/sync/secret_sync.go
@@ -20,6 +20,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/base64"
+	"maps"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -106,7 +107,7 @@ func (s *SecretSync) SyncObjects() {
 
 func setVariables(capiProvider *turtlesv1.CAPIProvider) {
 	if capiProvider.Spec.Variables != nil {
-		capiProvider.Status.Variables = capiProvider.Spec.Variables
+		maps.Copy(capiProvider.Status.Variables, capiProvider.Spec.Variables)
 	}
 }
 

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -27,6 +27,9 @@ var (
 	//go:embed data/capi-operator/capi-providers.yaml
 	CapiProviders []byte
 
+	//go:embed data/capi-operator/capi-providers-legacy.yaml
+	CapiProvidersLegacy []byte
+
 	//go:embed data/capi-operator/capv-provider.yaml
 	CapvProvider []byte
 

--- a/test/e2e/data/capi-operator/capa-variables.yaml
+++ b/test/e2e/data/capi-operator/capa-variables.yaml
@@ -7,7 +7,7 @@ metadata:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: full-variables
+  name: aws
   namespace: capa-system
 type: Opaque
 stringData:

--- a/test/e2e/data/capi-operator/capi-providers-legacy.yaml
+++ b/test/e2e/data/capi-operator/capi-providers-legacy.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capd-system
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: docker
+  namespace: capd-system
+spec:
+  name: docker
+  type: infrastructure
+  configSecret:
+    name: variables
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-bootstrap-system
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: kubeadm-bootstrap
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  name: kubeadm
+  type: bootstrap
+  configSecret:
+    name: variables
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-control-plane-system
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: kubeadm-control-plane
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  name: kubeadm
+  type: controlPlane
+  configSecret:
+    name: variables

--- a/test/e2e/data/capi-operator/capi-providers.yaml
+++ b/test/e2e/data/capi-operator/capi-providers.yaml
@@ -10,10 +10,7 @@ metadata:
   name: docker
   namespace: capd-system
 spec:
-  name: docker
   type: infrastructure
-  configSecret:
-    name: variables
 ---
 apiVersion: v1
 kind: Namespace
@@ -28,8 +25,6 @@ metadata:
 spec:
   name: kubeadm
   type: bootstrap
-  configSecret:
-    name: variables
 ---
 apiVersion: v1
 kind: Namespace
@@ -44,5 +39,3 @@ metadata:
 spec:
   name: kubeadm
   type: controlPlane
-  configSecret:
-    name: variables

--- a/test/e2e/data/capi-operator/capv-provider.yaml
+++ b/test/e2e/data/capi-operator/capv-provider.yaml
@@ -5,11 +5,4 @@ metadata:
   name: vsphere
   namespace: capv-system
 spec:
-  name: vsphere
   type: infrastructure
-  configSecret:
-    name: vsphere-variables
-  variables:
-    CLUSTER_TOPOLOGY: "true"
-    EXP_CLUSTER_RESOURCE_SET: "true"
-    EXP_MACHINE_POOL: "true"

--- a/test/e2e/data/capi-operator/full-providers.yaml
+++ b/test/e2e/data/capi-operator/full-providers.yaml
@@ -6,9 +6,6 @@ metadata:
   namespace: capa-system
 spec:
   type: infrastructure
-  name: aws
-  configSecret:
-    name: full-variables
   variables:
     EXP_MACHINE_POOL: "true"
     EXP_EXTERNAL_RESOURCE_GC: "true"
@@ -23,11 +20,3 @@ metadata:
   namespace: capz-system
 spec:
   type: infrastructure
-  name: azure
-  configSecret:
-    name: azure-variables
-  variables:
-    CLUSTER_TOPOLOGY: "true"
-    EXP_CLUSTER_RESOURCE_SET: "true"
-    EXP_MACHINE_POOL: "true"
-    EXP_AKS_RESOURCE_HEALTH: "true"

--- a/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
+++ b/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Chart upgrade functionality should work", Label(e2e.ShortTestL
 			BootstrapClusterProxy:        setupClusterResult.BootstrapClusterProxy,
 			HelmBinaryPath:               e2eConfig.GetVariable(e2e.HelmBinaryPathVar),
 			TurtlesChartPath:             "https://rancher.github.io/turtles",
-			CAPIProvidersYAML:            e2e.CapiProviders,
+			CAPIProvidersYAML:            e2e.CapiProvidersLegacy,
 			Namespace:                    framework.DefaultRancherTurtlesNamespace,
 			Version:                      "v0.6.0",
 			WaitDeploymentsReadyInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This change improves the process of `CAPIProvider` creation. Users don’t need to specify `spec.configSecret` at all times, in order to get default set of enabled features, such as ClusterClasses or MachinePools, + provider specific features.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #787

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests
