### PR TITLE
test: disable docker/rke2 e2e scenario

### DIFF
--- a/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
+++ b/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
@@ -62,7 +62,7 @@ var _ = Describe("[Docker] [Kubeadm] - [management.cattle.io/v3] Create and dele
 	})
 })
 
-var _ = Describe("[Docker] [RKE2] - [management.cattle.io/v3] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.FullTestLabel), func() {
+var _ = Describe("[Docker] [RKE2] - [management.cattle.io/v3] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.LocalTestLabel), func() {
 	BeforeEach(func() {
 		komega.SetClient(setupClusterResult.BootstrapClusterProxy.GetClient())
 		komega.SetContext(ctx)


### PR DESCRIPTION
**What this PR does / why we need it**:

Nightly E2E tests are systematically failing and the common issue is the Docker+RKE2 test case. This may be related to some memory limits (@Danil-Grigorev noticed something similar in short E2E test executions) because I've had the tests passing locally in multiple tries.

For now, I suggest we disable this specific scenario, as **it is adding noise to our nightly tests which we no longer can rely on for detecting unexpected failures**. Let's see if disabling this improves the health of these tests. I'd say there's no harm in disabling this, as testing CAPD scenarios is not that relevant in nightly E2E.

**Which issue(s) this PR fixes**:
Fixes #755

**Special notes for your reviewer**:

My suggestion is to try to stabilize tests and, once we accomplish this, let's focus on cleaning up test suites that are becoming less relevant. For example:
- reduce (or even remove) v1 import validation
- rethink if it is required to test the embedded capi disabled scenario (this should be covered by any of the other scenarios).

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
