### PR TITLE
fix: sign updatecli commits

### DIFF
--- a/updatecli/updatecli.d/manifest.yaml
+++ b/updatecli/updatecli.d/manifest.yaml
@@ -12,6 +12,7 @@ scms:
       token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
       branch: main
+      commitusingapi: true
 
 # retrieve latest provider release
 sources:


### PR DESCRIPTION
**What this PR does / why we need it**:

Updatecli is not signing automatically generated commits which goes against Turtles' requirements. Simply by committing changes using GitHub API, which updatecli allows via `commitusingapi`, all commits created by the bot are automatically signed: https://github.com/updatecli/updatecli/pull/2046

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
