### PR TITLE
Permit turtles controller to access the cluster

### DIFF
--- a/exp/etcdrestore/webhooks/rbac_test.go
+++ b/exp/etcdrestore/webhooks/rbac_test.go
@@ -103,4 +103,14 @@ var _ = Describe("RBAC tests", func() {
 			},
 		}), cl, "test-cluster", namespace)).ToNot(Succeed())
 	})
+
+	It("should allow turtles controller to access cluster", func() {
+		Expect(validateRBAC(admission.NewContextWithRequest(ctx, admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UserInfo: authenticationv1.UserInfo{
+					Username: "system:serviceaccount:rancher-turtles-system:rancher-turtles-etcdsnapshotrestore-manager",
+				},
+			},
+		}), cl, "test-cluster", namespace)).To(Succeed())
+	})
 })


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Our controller is not currently allowed to create ETCDMachineSnapshot due to lack of permissions from the SAR point of view.

It is easy to identify the controller by the use of our ServiceAccount:

`system:serviceaccount:rancher-turtles-system:rancher-turtles-etcdsnapshotrestore-manager`

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #768 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
