### PR TITLE
Fix panic in webhook for CC clusters

### DIFF
--- a/exp/etcdrestore/controllers/etcdsnapshotsync_controller.go
+++ b/exp/etcdrestore/controllers/etcdsnapshotsync_controller.go
@@ -87,7 +87,7 @@ func (r *EtcdSnapshotSyncReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	// Only reconcile RKE2 clusters
-	if cluster.Spec.ControlPlaneRef.Kind != RKE2ControlPlaneKind { // TODO: Move to predicate
+	if cluster.Spec.ControlPlaneRef == nil || cluster.Spec.ControlPlaneRef.Kind != RKE2ControlPlaneKind { // TODO: Move to predicate
 		log.Info("Cluster is not an RKE2 cluster, skipping reconciliation")
 		return ctrl.Result{RequeueAfter: 3 * time.Minute}, nil
 	}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

A panic occurred during testing ClusterClass usage together with exp. EtcdSnapshot controller running, which may be forgotten later. This is a small fix to address that.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
