### PR TITLE
fix: long e2e not running

### DIFF
--- a/.github/workflows/run-e2e-suite.yaml
+++ b/.github/workflows/run-e2e-suite.yaml
@@ -96,7 +96,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Run e2e tests
-        run: CACHE_DIR=/tmp/.buildx-cache make test-e2e-push-image
+        run: CACHE_DIR=/tmp/.buildx-cache make test-e2e
       - name: Collect run artifacts
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
**What this PR does / why we need it**:

Nightly E2E are failing and it looks like the `run-e2e-suite.yaml` workflow is not executing the correct `make` command.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
