### PR TITLE
Build image streamline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,6 @@ E2E_CONF_FILE ?= $(ROOT_DIR)/$(TEST_DIR)/e2e/config/operator.yaml
 GINKGO_ARGS ?=
 SKIP_RESOURCE_CLEANUP ?= false
 USE_EXISTING_CLUSTER ?= false
-GITEA_CUSTOM_INGRESS ?= false
 GINKGO_NOCOLOR ?= false
 GINKGO_LABEL_FILTER ?= short
 GINKGO_TESTS ?= $(ROOT_DIR)/$(TEST_DIR)/e2e/suites/...
@@ -195,16 +194,10 @@ RELEASE_TAG ?= $(shell git describe --abbrev=0 --exclude 'test/*' 2>/dev/null)
 # Exclude the current RELEASE_TAG and any tags with the prefix 'test/'
 PREVIOUS_TAG ?= $(shell git describe --abbrev=0 --exclude $(RELEASE_TAG) --exclude 'test/*' 2>/dev/null)
 HELM_CHART_TAG := $(shell echo $(RELEASE_TAG) | cut -c 2-)
-RELEASE_ALIAS_TAG ?= $(PULL_BASE_REF)
 CHART_DIR := charts/rancher-turtles
 RELEASE_DIR ?= out
 CHART_PACKAGE_DIR ?= $(RELEASE_DIR)/package
 CHART_RELEASE_DIR ?= $(RELEASE_DIR)/$(CHART_DIR)
-
-# Repo
-GH_ORG_NAME ?= $ORG
-GH_REPO_NAME ?= turtles
-GH_REPO ?= $(GH_ORG_NAME)/$(GH_REPO_NAME)
 
 # Allow overriding the imagePullPolicy
 PULL_POLICY ?= IfNotPresent

--- a/exp/etcdrestore/Dockerfile
+++ b/exp/etcdrestore/Dockerfile
@@ -18,9 +18,6 @@
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
 
-# Build architecture
-ARG ARCH
-
 # Ignore Hadolint rule "Always tag the version of an image explicitly."
 # It's an invalid finding since the image is explicitly set in the Makefile.
 # https://github.com/hadolint/hadolint/wiki/DL3006
@@ -38,13 +35,12 @@ ENV GOPROXY=$goproxy
 COPY ./ ./
 
 # Build
-ARG ARCH
 ARG ldflags
 
 # Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
+    CGO_ENABLED=0 GOOS=linux \
     sh -c "cd exp/etcdrestore && ls && go build -trimpath -ldflags \"${ldflags} -extldflags '-static'\" -o manager ${package}"
 
 # Production image


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove some unused variables from `Makefile` and etcdrestore image build process.

**Which issue(s) this PR fixes**:
Fixes #824 

**Special notes for your reviewer**:

I simply moved `docker-build` up and `docker-build-etcdrestore` down, so Turtles appears before etcdrestore, and added a sub-section title, but Git got confused and reported all these changes. Essentially it should just be a switch in order.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
