### PR TITLE
feat: opt out of cluster owner rbac

### DIFF
--- a/internal/controllers/helpers.go
+++ b/internal/controllers/helpers.go
@@ -53,6 +53,7 @@ const (
 	v1ClusterMigrated         = "cluster-api.cattle.io/migrated"
 
 	defaultRequeueDuration = 1 * time.Minute
+	trueAnnotationValue    = "true"
 )
 
 func getClusterRegistrationManifest(ctx context.Context, clusterName, namespace string, cl client.Client,

--- a/internal/controllers/import_controller.go
+++ b/internal/controllers/import_controller.go
@@ -355,7 +355,7 @@ func (r *CAPIImportReconciler) reconcileDelete(ctx context.Context, capiCluster 
 		annotations = map[string]string{}
 	}
 
-	annotations[turtlesannotations.ClusterImportedAnnotation] = "true"
+	annotations[turtlesannotations.ClusterImportedAnnotation] = trueAnnotationValue
 	capiCluster.SetAnnotations(annotations)
 
 	return ctrl.Result{}, nil

--- a/internal/controllers/import_controller_v3_test.go
+++ b/internal/controllers/import_controller_v3_test.go
@@ -29,6 +29,8 @@ import (
 	provisioningv1 "github.com/rancher/turtles/api/rancher/provisioning/v1"
 	"github.com/rancher/turtles/internal/controllers/testdata"
 	"github.com/rancher/turtles/internal/test"
+
+	turtlesannotations "github.com/rancher/turtles/util/annotations"
 	turtlesnaming "github.com/rancher/turtles/util/naming"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -198,6 +200,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 			g.Expect(rancherClusters.Items[0].Name).To(ContainSubstring("c-"))
 			g.Expect(rancherClusters.Items[0].Labels).To(HaveKeyWithValue(testLabelName, testLabelVal))
+			g.Expect(rancherClusters.Items[0].Annotations).To(HaveKey(turtlesannotations.NoCreatorRBACAnnotation))
 			g.Expect(rancherClusters.Items[0].Finalizers).To(ContainElement(managementv3.CapiClusterFinalizer))
 		}).Should(Succeed())
 
@@ -547,5 +550,4 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			Expect(rancherClusters.Items).To(HaveLen(0))
 		}).Should(Succeed())
 	})
-
 })

--- a/test/e2e/specs/import_gitops_mgmtv3.go
+++ b/test/e2e/specs/import_gitops_mgmtv3.go
@@ -44,6 +44,7 @@ import (
 	"github.com/rancher/turtles/test/e2e"
 	turtlesframework "github.com/rancher/turtles/test/framework"
 	"github.com/rancher/turtles/test/testenv"
+	turtlesannotations "github.com/rancher/turtles/util/annotations"
 )
 
 type CreateMgmtV3UsingGitOpsSpecInput struct {
@@ -132,6 +133,9 @@ func CreateMgmtV3UsingGitOpsSpec(ctx context.Context, inputGetter func() CreateM
 			Eventually(komega.Get(rancherCluster), input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(Succeed())
 			return conditions.IsTrue(rancherCluster, managementv3.ClusterConditionReady)
 		}, input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(BeTrue())
+
+		By("Rancher cluster should have the 'NoCreatorRBAC' annotation")
+		Expect(rancherCluster.Annotations).To(HaveKey(turtlesannotations.NoCreatorRBACAnnotation))
 
 		By("Waiting for the CAPI cluster to be connectable using Rancher kubeconfig")
 		turtlesframework.RancherGetClusterKubeconfig(ctx, turtlesframework.RancherGetClusterKubeconfigInput{

--- a/test/e2e/specs/migrate_gitops_provv1_mgmtv3.go
+++ b/test/e2e/specs/migrate_gitops_provv1_mgmtv3.go
@@ -46,6 +46,7 @@ import (
 	"github.com/rancher/turtles/test/e2e"
 	turtlesframework "github.com/rancher/turtles/test/framework"
 	"github.com/rancher/turtles/test/testenv"
+	turtlesannotations "github.com/rancher/turtles/util/annotations"
 	turtlesnaming "github.com/rancher/turtles/util/naming"
 )
 
@@ -175,6 +176,9 @@ func MigrateToV3UsingGitOpsSpec(ctx context.Context, inputGetter func() MigrateT
 			Eventually(komega.Get(rancherCluster), input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(Succeed())
 			return conditions.IsTrue(rancherCluster, managementv3.ClusterConditionReady)
 		}, input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(BeTrue())
+
+		By("Rancher cluster should have the 'NoCreatorRBAC' annotation")
+		Expect(rancherCluster.Annotations).To(HaveKey(turtlesannotations.NoCreatorRBACAnnotation))
 
 		By("Waiting for the CAPI cluster to be connectable using Rancher kubeconfig")
 		turtlesframework.RancherGetClusterKubeconfig(ctx, turtlesframework.RancherGetClusterKubeconfigInput{

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -23,6 +23,12 @@ import (
 const (
 	// ClusterImportedAnnotation represents cluster imported annotation.
 	ClusterImportedAnnotation = "imported"
+	// NoCreatorRBACAnnotation represents no creator rbac annotation.
+	// When it is set the webhook does not set the `field.cattle.io/creatorId` annotation
+	// to clusters because the controllers will no longer be creating RBAC for the creator of the cluster.
+	// This is required so that logs don't get flooded with errors when project handler and cluster handler
+	// attempt to create `ClusterOwner` and `ProjectOwner` roles.
+	NoCreatorRBACAnnotation = "field.cattle.io/no-creator-rbac"
 	// EtcdAutomaticSnapshot represents automatically generated etcd snapshot.
 	EtcdAutomaticSnapshot = "etcd.turtles.cattle.io/automatic-snapshot"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Preparing for new Rancher release that will include a feature that allows to bypass setting a creator owner on the resource. Import controller now adds the annotation `field.cattle.io/no-creator-rbac` on any Rancher clusters it reconciles. This will apply to newly created clusters and to existing ones that are subject to reconciliation.

You can take a look at https://github.com/rancher/rancher/pull/47259, where this new option is introduced.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Also updates E2E and import controller tests to check that clusters are properly annotated.

**After this is merged, we'll have to wait until next Rancher minor release to consider this as done**

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests
