### PR TITLE
[updatecli] Perform replacement of `CAPIVersion` in tests and e2e

### DIFF
--- a/internal/sync/provider_sync_test.go
+++ b/internal/sync/provider_sync_test.go
@@ -35,6 +35,10 @@ import (
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
 )
 
+const (
+	CAPIVersion = "v1.7.7"
+)
+
 var _ = Describe("Provider sync", func() {
 	var (
 		err                          error
@@ -160,7 +164,7 @@ var _ = Describe("Provider sync", func() {
 		s := sync.NewProviderSync(testEnv, capiProvider.DeepCopy())
 
 		expected := capiProvider.DeepCopy()
-		expected.Spec.Version = "v1.7.7"
+		expected.Spec.Version = CAPIVersion
 
 		Eventually(func(g Gomega) {
 			g.Expect(s.Get(ctx)).To(Succeed())
@@ -254,7 +258,7 @@ var _ = Describe("Provider sync", func() {
 		s := sync.NewProviderSync(testEnv, capiProvider.DeepCopy())
 
 		expected := capiProvider.DeepCopy()
-		expected.Spec.Version = "v1.7.7"
+		expected.Spec.Version = CAPIVersion
 
 		Eventually(func(g Gomega) {
 			g.Expect(s.Get(ctx)).To(Succeed())

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -173,3 +173,7 @@ const (
 	CapiClusterOwnerNamespaceLabel = "cluster-api.cattle.io/capi-cluster-owner-ns"
 	OwnedLabelName                 = "cluster-api.cattle.io/owned"
 )
+
+const (
+	CAPIVersion = "v1.7.7"
+)

--- a/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
+++ b/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
@@ -104,21 +104,21 @@ var _ = Describe("Chart upgrade functionality should work", Label(e2e.ShortTestL
 		upgradeInput.PostUpgradeSteps = append(upgradeInput.PostUpgradeSteps, func() {
 			framework.WaitForCAPIProviderRollout(ctx, framework.WaitForCAPIProviderRolloutInput{
 				Getter:    setupClusterResult.BootstrapClusterProxy.GetClient(),
-				Version:   "v1.7.7",
+				Version:   e2e.CAPIVersion,
 				Name:      "cluster-api",
 				Namespace: "capi-system",
 			}, e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers")...)
 		}, func() {
 			framework.WaitForCAPIProviderRollout(ctx, framework.WaitForCAPIProviderRolloutInput{
 				Getter:    setupClusterResult.BootstrapClusterProxy.GetClient(),
-				Version:   "v1.7.7",
+				Version:   e2e.CAPIVersion,
 				Name:      "kubeadm-control-plane",
 				Namespace: "capi-kubeadm-control-plane-system",
 			}, e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers")...)
 		}, func() {
 			framework.WaitForCAPIProviderRollout(ctx, framework.WaitForCAPIProviderRolloutInput{
 				Getter:    setupClusterResult.BootstrapClusterProxy.GetClient(),
-				Version:   "v1.7.7",
+				Version:   e2e.CAPIVersion,
 				Name:      "docker",
 				Namespace: "capd-system",
 			}, e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers")...)

--- a/test/e2e/suites/update-labels/suite_test.go
+++ b/test/e2e/suites/update-labels/suite_test.go
@@ -161,7 +161,7 @@ var _ = BeforeSuite(func() {
 		Tag:                          e2eConfig.GetVariable(e2e.TurtlesVersionVar),
 		WaitDeploymentsReadyInterval: e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers"),
 		AdditionalValues: map[string]string{
-			"cluster-api-operator.cluster-api.version":          "v1.7.7",
+			"cluster-api-operator.cluster-api.version":          e2e.CAPIVersion,
 			"rancherTurtles.features.rancher-kubeconfigs.label": "true", // force to be true even if the default in the chart changes
 		},
 	}

--- a/updatecli/updatecli.d/manifest.yaml
+++ b/updatecli/updatecli.d/manifest.yaml
@@ -98,6 +98,24 @@ targets:
       replacepattern: 'https://github.com/rancher-sandbox/cluster-api/releases/{{ source "capirelease" }}/'
     scmid: turtles
     sourceid: capirelease # Will be ignored as `replacepattern` is specified
+  bumpcapi-tests:
+    name: bump core capi in tests package
+    kind: file
+    spec:
+      file: ./internal/sync/provider_sync_test.go
+      matchpattern: 'CAPIVersion = .*'
+      replacepattern: CAPIVersion = "{{ source "capirelease" }}"
+    scmid: turtles
+    sourceid: capirelease # Will be ignored as `replacepattern` is specified
+  bumpcapi-e2e:
+    name: bump core capi in e2e package
+    kind: file
+    spec:
+      file: ./test/e2e/const.go
+      matchpattern: 'CAPIVersion = .*'
+      replacepattern: CAPIVersion = "{{ source "capirelease" }}"
+    scmid: turtles
+    sourceid: capirelease # Will be ignored as `replacepattern` is specified
   bumpcaprke2:
     name: bump caprke2 provider
     kind: file


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Based on observed failure during CI execution in #835.

We perform e2e tests and integration tests, which ensure that a new turtles release will update `latest` target for provider, and will perform upgrade if the `latest` is set on `CAPIProvider`.

Current updatecli PRs don’t modify these values, which leads to CI failures after any `core` provider version changes.

Testing is performed on https://github.com/Danil-Grigorev/rancher-turtles/pull/5, which is created using `make updatecli-apply`

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
