### PR TITLE
chore: fix trivy timeout

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -36,7 +36,10 @@ jobs:
         run: |
           TAG=${{ github.sha }} make docker-build
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2
+        uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           image-ref: 'ghcr.io/rancher/turtles:${{ github.sha }}'
           format: 'sarif'


### PR DESCRIPTION
**What this PR does / why we need it**:

This is taken from @yiannistri's https://github.com/rancher/aks-operator/pull/718 and since we're also experiencing these issues in Turtles, I thought it's worth adding it here too. 

> @yiannistri:
>
> We frequently get CI failures when scanning with trivy because there have been too many requests to download the vulnerability db from the rancher org (because many of its repos are using it).
>
> This PR updates the Scan workflow to include additional repositories to be used if trivy fails to retrieve the vulnerability db from the primary source.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Source for fix: https://github.com/aquasecurity/trivy/discussions/7668#discussioncomment-10884984

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
