### PR TITLE
Remove specific versions in dev script

### DIFF
--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -48,10 +48,10 @@ export CLUSTER_TOPOLOGY=true
 
 helm install capi-operator capi-operator/cluster-api-operator \
     --create-namespace -n capi-operator-system \
-    --set infrastructure=docker:v1.7.7 \
-    --set core=cluster-api:v1.7.7 \
-    --set controlPlane=rke2:v0.8.0 \
-    --set bootstrap=rke2:v0.8.0 \
+    --set infrastructure=docker \
+    --set core=cluster-api \
+    --set controlPlane=rke2 \
+    --set bootstrap=rke2 \
     --timeout 90s --wait
 
 kubectl rollout status deployment capi-operator-cluster-api-operator -n capi-operator-system --timeout=180s


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Dev script requires specific versions for CAPI providers.

This PR proposes removing specific version requirements. Current pinned version (v1.7.7) of CAPRKE2 is not compatible with turtles, as agent install command causes continuous remediation of CP machines. This problem was fixed with latest.

Additionally, a pinned version requires regular bumps with `updatecli`, which increases complexity of the automation, focused only on maintaining dev environment.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
