### PR TITLE
🌱 Patch RKE2 config only for CP machines

### DIFF
--- a/exp/etcdrestore/webhooks/rke2config.go
+++ b/exp/etcdrestore/webhooks/rke2config.go
@@ -92,6 +92,11 @@ func (r *RKE2ConfigWebhook) Default(ctx context.Context, obj runtime.Object) err
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a RKE2Config but got a %T", obj))
 	}
 
+	// Deploy agent only on CP machines
+	if _, found := rke2Config.Labels[clusterv1.MachineControlPlaneLabel]; !found {
+		return nil
+	}
+
 	if rke2Config.Annotations == nil {
 		rke2Config.Annotations = map[string]string{}
 	}

--- a/exp/etcdrestore/webhooks/rke2config_test.go
+++ b/exp/etcdrestore/webhooks/rke2config_test.go
@@ -63,7 +63,8 @@ var _ = Describe("RKE2ConfigWebhook tests", func() {
 				UID:       "test-uid",
 				Namespace: ns.Name,
 				Labels: map[string]string{
-					clusterv1.ClusterNameLabel: "rke2",
+					clusterv1.ClusterNameLabel:         "rke2",
+					clusterv1.MachineControlPlaneLabel: "",
 				},
 			},
 			Spec: bootstrapv1.RKE2ConfigSpec{
@@ -85,6 +86,12 @@ var _ = Describe("RKE2ConfigWebhook tests", func() {
 		err := r.Default(ctx, &corev1.Pod{})
 		Expect(err).To(HaveOccurred())
 		Expect(apierrors.IsBadRequest(err)).To(BeTrue())
+	})
+
+	It("Should skip defaulting for non CP machines", func() {
+		delete(rke2Config.Labels, clusterv1.MachineControlPlaneLabel)
+		err := r.Default(ctx, rke2Config)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("Should create secret plan resources without error", func() {


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Deploy system-agent only on RKE2 CP nodes. According to https://docs.rke2.io/backup_restore#restoring-a-snapshot-to-existing-nodes, the process only requires to stop rke2-server on all CP nodes.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #762 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
