### PR TITLE
chart: core-provider remove inconsistent pre-delete hook

### DIFF
--- a/charts/rancher-turtles/templates/core-provider.yaml
+++ b/charts/rancher-turtles/templates/core-provider.yaml
@@ -54,7 +54,7 @@ metadata:
   name: capi-additional-rbac-roles
   namespace: {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
   annotations:
-    "helm.sh/hook": "post-install, post-upgrade, pre-delete"
+    "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "2"
 data: 
   manifests: |-


### PR DESCRIPTION
**What this PR does / why we need it**:

In #454 the pre-delete hook was removed from the `Namespace` and in #508 it was removed from the `CAPIProvider`

However the pre-delete hook remains on the `ConfigMap`, which means if installation fails for any reason prior to creating the `Namespace` in the `post-install` hook, the chart can become undeletable with an error like:

```
+ helm_v3 uninstall rancher-turtles --namespace rancher-turtles-system --wait Error: warning: Hook pre-delete rancher-turtles/templates/core-provider.yaml failed: 1 error occurred:
	* namespaces "capi-system" not found
```

Note the error above is from the [RKE2 helm controller](https://docs.rke2.io/helm), where the ability to uninstall a chart after any temporary installation error is particularly important, since the `failurePolicy` relies on a default strategy to uninstall then re-install, which cannot happen when a pre-delete hook fails.

kind/bug

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
