### PR TITLE
Use upstream krew-index for crust-gather

### DIFF
--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -66,8 +66,7 @@ install_plugins() {
     tar zxvf "${KREW}.tar.gz" &&
     ./"${KREW}" install krew
   )
-  kubectl krew index add crust-gather https://github.com/crust-gather/crust-gather.git || true
-  kubectl krew install crust-gather/crust-gather
+  kubectl krew install crust-gather
 }
 
 verify_kubectl_version


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Crust gather now uses upstream krew-index https://github.com/kubernetes-sigs/krew-index/blob/master/plugins/crust-gather.yaml so the old plugin publishing process was removed.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
