### PR TITLE
🌱 Install capi-operator as a turtles dependency in a dev-env

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -35,7 +35,7 @@ if settings.get("trigger_mode") == "manual":
 if settings.get("default_registry") != "":
     default_registry(settings.get("default_registry"))
 
-always_enable_projects = ["turtles", "turtles-etcdsnapshotrestore"]
+always_enable_projects = ["turtles", "turtles-etcdsnapshotrestore", "turtles-capiproviders"]
 
 projects = {
     "turtles": {
@@ -63,6 +63,15 @@ projects = {
         ],
         "kustomize_dir": "config/default",
         "label": "turtles-etcdsnapshotrestore"
+    },
+    "turtles-capiproviders": {
+        "context": ".",
+        "live_reload_deps": [
+            "config"
+        ],
+        "kustomize_dir": "config/capiproviders",
+        "label": "turtles-capiproviders",
+        "op": "apply"
     }
 }
 

--- a/config/capiproviders/bootstrap.yaml
+++ b/config/capiproviders/bootstrap.yaml
@@ -1,0 +1,7 @@
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: rke2-bootstrap
+spec:
+  type: bootstrap
+  name: rke2

--- a/config/capiproviders/controlplane.yaml
+++ b/config/capiproviders/controlplane.yaml
@@ -1,0 +1,7 @@
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: rke2-control-plane
+spec:
+  type: controlPlane
+  name: rke2

--- a/config/capiproviders/core.yaml
+++ b/config/capiproviders/core.yaml
@@ -1,0 +1,6 @@
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: cluster-api
+spec:
+  type: core

--- a/config/capiproviders/docker.yaml
+++ b/config/capiproviders/docker.yaml
@@ -1,0 +1,6 @@
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: docker
+spec:
+  type: infrastructure

--- a/config/capiproviders/kustomization.yaml
+++ b/config/capiproviders/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- core.yaml
+- docker.yaml
+- bootstrap.yaml
+- controlplane.yaml

--- a/tilt-settings.json.example
+++ b/tilt-settings.json.example
@@ -5,11 +5,6 @@
             "continue": true,
             "port": 40000,
             "insecure_skip_verify": "true"
-        },
-        "turtles-etcdsnapshotrestore": {
-            "continue": true,
-            "port": 40000,
-            "insecure_skip_verify": "true"
         }
     }
 }

--- a/tilt/project/Tiltfile
+++ b/tilt/project/Tiltfile
@@ -3,6 +3,18 @@
 load("../k8s/Tiltfile", "k8s_find_object_name")
 load("../io/Tiltfile", "info", "file_write", "dir_create", "prepare_file")
 
+def apply_files(name, project, debug):
+    kustomize_dir = project.get("kustomize_dir", "")
+    if kustomize_dir != "":
+        info("doing kustomization")
+        context = project.get("context")
+        yaml = kustomize(context + '/' + kustomize_dir)
+        yaml_path = context + "/.tiltbuild/files.yaml"
+        prepare_file(yaml_path)
+        for line in str(yaml).splitlines():
+            file_write(yaml_path, line)
+        k8s_yaml(yaml)
+
 def project_enable(name, project, debug):
     """Enable a project in Tilt
 
@@ -36,6 +48,9 @@ def project_enable(name, project, debug):
         fail("you must supply the project name")
     if not project:
         fail("you must supply a project configuration")
+
+    if project.get("op") == "apply":
+        return apply_files(name, project, debug)
 
     label = project.get("label")
     env = project.get("env", {})


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Improves dev environment setup for turtles, making it use actual turtles chart capi-operator as a dependency, as opposed to installing upstream one separately.

This allows to rely on `CAPIProvider` versions when deploying providers, so incompatibility in providers matrix is eliminated based on centralization of the providers version management.

Additionally this makes dev-env adhere to supported configuration described in turtles docs (more closely), and improves development process for etcd snapshot restore and other features.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
