### PR TITLE
🌱 Add image overrides for certified providers

### DIFF
--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -69,3 +69,5 @@ data:
         repository: "registry.suse.com/rancher"
       infrastructure-azure:
         repository: "registry.suse.com/rancher"
+      infrastructure-vsphere:
+        repository: "registry.suse.com/rancher"

--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -54,3 +54,18 @@ data:
     - name:         "fleet"
       url:          "https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/v0.3.1/addon-components.yaml"
       type:         "AddonProvider"
+
+    # Image overrides
+    images:
+      cluster-api:
+        repository: "registry.suse.com/rancher"
+      control-plane-rke2:
+        repository: "registry.suse.com/rancher"
+      bootstrap-rke2:
+        repository: "registry.suse.com/rancher"
+      infrastructure-aws:
+        repository: "registry.suse.com/rancher"
+      infrastructure-gcp:
+        repository: "registry.suse.com/rancher"
+      infrastructure-azure:
+        repository: "registry.suse.com/rancher"

--- a/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
+++ b/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
@@ -103,8 +103,13 @@ var _ = Describe("Chart upgrade functionality should work", Label(e2e.ShortTestL
 
 		upgradeInput.PostUpgradeSteps = append(upgradeInput.PostUpgradeSteps, func() {
 			framework.WaitForCAPIProviderRollout(ctx, framework.WaitForCAPIProviderRolloutInput{
-				Getter:    setupClusterResult.BootstrapClusterProxy.GetClient(),
-				Version:   e2e.CAPIVersion,
+				Getter:  setupClusterResult.BootstrapClusterProxy.GetClient(),
+				Version: e2e.CAPIVersion,
+				Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+					Name:      "capi-controller-manager",
+					Namespace: "capi-system",
+				}},
+				Image:     "registry.suse.com/rancher/cluster-api-controller:",
 				Name:      "cluster-api",
 				Namespace: "capi-system",
 			}, e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers")...)
@@ -114,6 +119,28 @@ var _ = Describe("Chart upgrade functionality should work", Label(e2e.ShortTestL
 				Version:   e2e.CAPIVersion,
 				Name:      "kubeadm-control-plane",
 				Namespace: "capi-kubeadm-control-plane-system",
+			}, e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers")...)
+		}, func() {
+			framework.WaitForCAPIProviderRollout(ctx, framework.WaitForCAPIProviderRolloutInput{
+				Getter:  setupClusterResult.BootstrapClusterProxy.GetClient(),
+				Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+					Name:      "rke2-bootstrap-controller-manager",
+					Namespace: "rke2-bootstrap-system",
+				}},
+				Image:     "registry.suse.com/rancher/cluster-api-provider-rke2-bootstrap:",
+				Name:      "rke2-bootstrap",
+				Namespace: "rke2-bootstrap-system",
+			}, e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers")...)
+		}, func() {
+			framework.WaitForCAPIProviderRollout(ctx, framework.WaitForCAPIProviderRolloutInput{
+				Getter:  setupClusterResult.BootstrapClusterProxy.GetClient(),
+				Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+					Name:      "rke2-control-plane-controller-manager",
+					Namespace: "rke2-control-plane-system",
+				}},
+				Image:     "registry.suse.com/rancher/cluster-api-provider-rke2-controlplane:",
+				Name:      "rke2-control-plane",
+				Namespace: "rke2-control-plane-system",
 			}, e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers")...)
 		}, func() {
 			framework.WaitForCAPIProviderRollout(ctx, framework.WaitForCAPIProviderRolloutInput{

--- a/test/framework/turtles.go
+++ b/test/framework/turtles.go
@@ -56,7 +56,7 @@ func WaitForCAPIProviderRollout(ctx context.Context, input WaitForCAPIProviderRo
 	}
 
 	if input.Deployment != nil && input.Image != "" {
-		Byf("Waiting for Deployemnt %s to contain image %s", client.ObjectKeyFromObject(input.Deployment).String(), input.Image)
+		Byf("Waiting for Deployment %s to contain image %s", client.ObjectKeyFromObject(input.Deployment).String(), input.Image)
 		Eventually(func(g Gomega) {
 			g.Expect(input.Getter.Get(ctx, client.ObjectKeyFromObject(input.Deployment), input.Deployment)).To(Succeed())
 			found := false
@@ -67,7 +67,7 @@ func WaitForCAPIProviderRollout(ctx context.Context, input WaitForCAPIProviderRo
 			}
 			g.Expect(found).To(BeTrue())
 		}, intervals...).Should(Succeed(),
-			"Failed to get Deployemnt %s with image %s. Last observed: %s",
+			"Failed to get Deployment %s with image %s. Last observed: %s",
 			client.ObjectKeyFromObject(input.Deployment).String(), input.Image, klog.KObj(input.Deployment))
 	}
 }

--- a/test/framework/turtles.go
+++ b/test/framework/turtles.go
@@ -18,19 +18,23 @@ package framework
 
 import (
 	"context"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
 	turtlesv1 "github.com/rancher/turtles/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	capiframework "sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/gomega"
 )
 
 type WaitForCAPIProviderRolloutInput struct {
 	capiframework.Getter
-	Name, Namespace, Version string
+	Deployment                      *appsv1.Deployment
+	Name, Namespace, Version, Image string
 }
 
 func WaitForCAPIProviderRollout(ctx context.Context, input WaitForCAPIProviderRolloutInput, intervals ...interface{}) {
@@ -40,13 +44,30 @@ func WaitForCAPIProviderRollout(ctx context.Context, input WaitForCAPIProviderRo
 		Namespace: input.Namespace,
 	}
 
-	Byf("Waiting for CAPIProvider %s to be at version %s", key.String(), input.Version)
+	if input.Version != "" {
+		Byf("Waiting for CAPIProvider %s to be at version %s", key.String(), input.Version)
+		Eventually(func(g Gomega) {
+			g.Expect(input.Getter.Get(ctx, key, capiProvider)).To(Succeed())
+			g.Expect(capiProvider.Status.InstalledVersion).ToNot(BeNil())
+			g.Expect(*capiProvider.Status.InstalledVersion).To(Equal(input.Version))
+		}, intervals...).Should(Succeed(),
+			"Failed to get CAPIProvider %s with version %s. Last observed: %s",
+			key.String(), input.Version, klog.KObj(capiProvider))
+	}
 
-	Eventually(func(g Gomega) {
-		g.Expect(input.Getter.Get(ctx, key, capiProvider)).To(Succeed())
-		g.Expect(capiProvider.Status.InstalledVersion).ToNot(BeNil())
-		g.Expect(*capiProvider.Status.InstalledVersion).To(Equal(input.Version))
-	}, intervals...).Should(Succeed(),
-		"Failed to get CAPIProvider %s with version %s. Last observed: %s",
-		key.String(), input.Version, klog.KObj(capiProvider))
+	if input.Deployment != nil && input.Image != "" {
+		Byf("Waiting for Deployemnt %s to contain image %s", client.ObjectKeyFromObject(input.Deployment).String(), input.Image)
+		Eventually(func(g Gomega) {
+			g.Expect(input.Getter.Get(ctx, client.ObjectKeyFromObject(input.Deployment), input.Deployment)).To(Succeed())
+			found := false
+			for _, container := range input.Deployment.Spec.Template.Spec.Containers {
+				if strings.HasPrefix(container.Image, input.Image) {
+					found = true
+				}
+			}
+			g.Expect(found).To(BeTrue())
+		}, intervals...).Should(Succeed(),
+			"Failed to get Deployemnt %s with image %s. Last observed: %s",
+			client.ObjectKeyFromObject(input.Deployment).String(), input.Image, klog.KObj(input.Deployment))
+	}
 }


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Ensure that every provider in the overrides list has an injected image for the provisioned workloads from the downstream builds. This works on a couple of assumptions:

1. CAPI Operator in installed as a turtles dependency
2. `CAPIProvider` is updated/created/re-created after a version with this patch is used. No in-place update will happen for existing providers, unless a version of the provider changes.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
