### PR TITLE
[updatecli] Bump CAPI Providers versions

### DIFF
--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -11,7 +11,7 @@ data:
     providers:
     # Cluster API core provider
     - name:         "cluster-api"
-      url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.7.7/core-components.yaml"
+      url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.8.4/core-components.yaml"
       type:         "CoreProvider"
 
     # Infrastructure providers
@@ -36,7 +36,7 @@ data:
 
     # Bootstrap providers
     - name:         "kubeadm"
-      url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.7.7/bootstrap-components.yaml"
+      url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.8.4/bootstrap-components.yaml"
       type:         "BootstrapProvider"
     - name:         "rke2"
       url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.8.0/bootstrap-components.yaml"
@@ -44,7 +44,7 @@ data:
 
     # ControlPlane providers
     - name:         "kubeadm"
-      url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.7.7/control-plane-components.yaml"
+      url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.8.4/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
     - name:         "rke2"
       url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.8.0/control-plane-components.yaml"

--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -39,7 +39,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.8.4/bootstrap-components.yaml"
       type:         "BootstrapProvider"
     - name:         "rke2"
-      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.8.0/bootstrap-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.9.0/bootstrap-components.yaml"
       type:         "BootstrapProvider"
 
     # ControlPlane providers
@@ -47,7 +47,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.8.4/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
     - name:         "rke2"
-      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.8.0/control-plane-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.9.0/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
 
     # Addon providers

--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -31,7 +31,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api-provider-elemental/releases/v0.7.0/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "docker"
-      url:          "https://github.com/kubernetes-sigs/cluster-api/releases/v1.7.7/infrastructure-components-development.yaml"
+      url:          "https://github.com/kubernetes-sigs/cluster-api/releases/v1.8.4/infrastructure-components-development.yaml"
       type:         "InfrastructureProvider"
 
     # Bootstrap providers

--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -52,7 +52,7 @@ data:
 
     # Addon providers
     - name:         "fleet"
-      url:          "https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/v0.3.1/addon-components.yaml"
+      url:          "https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/v0.4.0/addon-components.yaml"
       type:         "AddonProvider"
 
     # Image overrides

--- a/internal/sync/provider_sync_test.go
+++ b/internal/sync/provider_sync_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	CAPIVersion = "v1.7.7"
+	CAPIVersion = "v1.8.4"
 )
 
 var _ = Describe("Provider sync", func() {

--- a/internal/sync/provider_sync_test.go
+++ b/internal/sync/provider_sync_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sync_test
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -346,7 +347,7 @@ var _ = Describe("Provider sync", func() {
 			g.Expect(capiProvider.Status.Conditions).To(HaveLen(2))
 			g.Expect(conditions.IsTrue(capiProvider, turtlesv1.LastAppliedConfigurationTime)).To(BeTrue())
 			g.Expect(conditions.IsTrue(capiProvider, turtlesv1.CheckLatestVersionTime)).To(BeTrue())
-			g.Expect(conditions.Get(capiProvider, turtlesv1.CheckLatestVersionTime).Message).To(Equal("Updated to latest v1.7.7 version"))
+			g.Expect(conditions.Get(capiProvider, turtlesv1.CheckLatestVersionTime).Message).To(Equal(fmt.Sprintf("Updated to latest %s version", CAPIVersion)))
 			g.Expect(conditions.Get(capiProvider, turtlesv1.LastAppliedConfigurationTime).LastTransitionTime.After(
 				appliedCondition.LastTransitionTime.Time)).To(BeTrue())
 		}).Should(Succeed())

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -183,5 +183,5 @@ const (
 )
 
 const (
-	CAPIVersion = "v1.7.7"
+	CAPIVersion = "v1.8.4"
 )


### PR DESCRIPTION



<Actions>
    <action id="de1864defccec55be9eca14576e5f510cb8e6dff35da988bd035728bd05d2e38">
        <h3>Bump CAPI providers version</h3>
        <details id="3ed7f6a16f7c5ae011028e586a98d12d2cf04c6ccd3bb2388b934a8dcc15f28a">
            <summary>bump core capi</summary>
            <p>1 file(s) updated with &#34;https://github.com/rancher-sandbox/cluster-api/releases/v1.8.4/&#34;:&#xA;&#x9;* ./internal/controllers/clusterctl/config.yaml&#xA;</p>
            <details>
                <summary>v1.8.4</summary>
                <pre>&#xA;Release published on the 2024-10-31 18:53:46 +0000 UTC at the url https://github.com/rancher-sandbox/cluster-api/releases/tag/v1.8.4&#xA;&#xA;Release v1.8.4</pre>
            </details>
        </details>
        <details id="6398ece5782b168b1428bef95905202626692569f08c8d33ea956f7249f94562">
            <summary>bump core capi in tests package</summary>
            <p>1 file(s) updated with &#34;CAPIVersion = \&#34;v1.8.4\&#34;&#34;:&#xA;&#x9;* ./internal/sync/provider_sync_test.go&#xA;</p>
            <details>
                <summary>v1.8.4</summary>
                <pre>&#xA;Release published on the 2024-10-31 18:53:46 +0000 UTC at the url https://github.com/rancher-sandbox/cluster-api/releases/tag/v1.8.4&#xA;&#xA;Release v1.8.4</pre>
            </details>
        </details>
        <details id="c9f2b647755acd01b4b54c32e9949a113002245a755e0571f0f9c3bf0a24a954">
            <summary>bump core capi in e2e package</summary>
            <p>1 file(s) updated with &#34;CAPIVersion = \&#34;v1.8.4\&#34;&#34;:&#xA;&#x9;* ./test/e2e/const.go&#xA;</p>
            <details>
                <summary>v1.8.4</summary>
                <pre>&#xA;Release published on the 2024-10-31 18:53:46 +0000 UTC at the url https://github.com/rancher-sandbox/cluster-api/releases/tag/v1.8.4&#xA;&#xA;Release v1.8.4</pre>
            </details>
        </details>
        <details id="d27b055df09f6e71ade8d6c02e5f839321a97ecb74fff31cff118664510a7200">
            <summary>bump docker capi</summary>
            <p>1 file(s) updated with &#34;https://github.com/kubernetes-sigs/cluster-api/releases/v1.8.4/&#34;:&#xA;&#x9;* ./internal/controllers/clusterctl/config.yaml&#xA;</p>
            <details>
                <summary>v1.8.4</summary>
                <pre>&#xA;Release published on the 2024-10-31 18:53:46 +0000 UTC at the url https://github.com/rancher-sandbox/cluster-api/releases/tag/v1.8.4&#xA;&#xA;Release v1.8.4</pre>
            </details>
        </details>
        <details id="e1d739ebed42a7c2c424488c1567a75dd26d77459838ba265c14f9f3524093b4">
            <summary>bump capi fleet addon provider</summary>
            <p>1 file(s) updated with &#34;https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/v0.4.0/&#34;:&#xA;&#x9;* ./internal/controllers/clusterctl/config.yaml&#xA;</p>
            <details>
                <summary>v0.4.0</summary>
                <pre>&#xA;Release published on the 2024-11-28 09:21:47 +0000 UTC at the url https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/tag/v0.4.0&#xA;&#xA;## What&#39;s Changed&#xD;&#xA;* Fix: allow patch disable for cluster class by @Danil-Grigorev in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/86&#xD;&#xA;* Filter duplicate events from ClusterGroup reconcile by @Danil-Grigorev in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/87&#xD;&#xA;* Perform only patch or create+update, improve error handling by @Danil-Grigorev in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/88&#xD;&#xA;* chore(deps): Bump tonic from 0.11.0 to 0.12.1 by @dependabot in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/81&#xD;&#xA;* chore(deps): Bump serde_json from 1.0.120 to 1.0.121 by @dependabot in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/83&#xD;&#xA;* chore(deps): Bump tokio from 1.38.1 to 1.39.2 by @dependabot in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/82&#xD;&#xA;* Update fleet version by @Danil-Grigorev in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/101&#xD;&#xA;* Provide option to specify fleet api_server_url and api_server_ca via `fleet-addon-config` by @Danil-Grigorev in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/105&#xD;&#xA;* Automate fleet helm chart install by @Danil-Grigorev in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/109&#xD;&#xA;* Use upstream CRDs by @Danil-Grigorev in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/110&#xD;&#xA;* chore(deps): Bump opentelemetry-otlp from 0.16.0 to 0.26.0 by @dependabot in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/114&#xD;&#xA;* chore(deps): Bump actix-web from 4.8.0 to 4.9.0 by @dependabot in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/96&#xD;&#xA;* Bump kube, thiserr and API to latest by @Danil-Grigorev in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/117&#xD;&#xA;* Release 0.4 prep by @Danil-Grigorev in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/119&#xD;&#xA;* Fix image name and tag for release by @Danil-Grigorev in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/120&#xD;&#xA;* Fix: Collect image meta by @Danil-Grigorev in https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/pull/121&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/compare/v0.3.0...v0.4.0</pre>
            </details>
        </details>
        <details id="e836474b596dc03da75f26e8c2aaef07573a32a4ac951bd27d5e12a45dbff7c3">
            <summary>bump caprke2 provider</summary>
            <p>1 file(s) updated with &#34;https://github.com/rancher/cluster-api-provider-rke2/releases/v0.9.0/&#34;:&#xA;&#x9;* ./internal/controllers/clusterctl/config.yaml&#xA;</p>
            <details>
                <summary>v0.9.0</summary>
                <pre>&#xA;Release published on the 2024-11-28 10:08:31 +0000 UTC at the url https://github.com/rancher/cluster-api-provider-rke2/releases/tag/v0.9.0&#xA;&#xA;&lt;!-- Release notes generated using configuration in .github/release.yml at v0.9.0 --&gt;&#xD;&#xA;&#xD;&#xA;## What&#39;s Changed&#xD;&#xA;### 🐛 Bugs&#xD;&#xA;* fix: remove deprecated grpc.WithBlock by @salasberryfin in https://github.com/rancher/cluster-api-provider-rke2/pull/490&#xD;&#xA;* Set control plane version in status by @alexander-demicev in https://github.com/rancher/cluster-api-provider-rke2/pull/503&#xD;&#xA;### 📖 Docs&#xD;&#xA;* docs: Fix file references by @yiannistri in https://github.com/rancher/cluster-api-provider-rke2/pull/491&#xD;&#xA;* Fix 00_introduction.md bad Developer Guide link by @ron1 in https://github.com/rancher/cluster-api-provider-rke2/pull/492&#xD;&#xA;### Other Changes&#xD;&#xA;* ci: Check for broken links in MD files by @yiannistri in https://github.com/rancher/cluster-api-provider-rke2/pull/494&#xD;&#xA;* chore: Prepare main branch for v0.9 development by @furkatgofurov7 in https://github.com/rancher/cluster-api-provider-rke2/pull/484&#xD;&#xA;* chore(deps): Bump github.com/onsi/gomega from 1.34.1 to 1.35.1 by @dependabot in https://github.com/rancher/cluster-api-provider-rke2/pull/495&#xD;&#xA;* chore(deps): Bump actions/cache from 4.1.1 to 4.1.2 by @dependabot in https://github.com/rancher/cluster-api-provider-rke2/pull/486&#xD;&#xA;* chore(deps): Bump engineerd/setup-kind from 0.5.0 to 0.6.2 by @dependabot in https://github.com/rancher/cluster-api-provider-rke2/pull/497&#xD;&#xA;* chore(deps): Bump github.com/onsi/ginkgo/v2 from 2.20.1 to 2.21.0 by @dependabot in https://github.com/rancher/cluster-api-provider-rke2/pull/496&#xD;&#xA;* chore(deps): Bump github.com/coreos/butane from 0.19.0 to 0.22.0 by @dependabot in https://github.com/rancher/cluster-api-provider-rke2/pull/444&#xD;&#xA;* chore(deps): Bump github.com/coreos/ignition/v2 from 2.18.0 to 2.20.0 by @dependabot in https://github.com/rancher/cluster-api-provider-rke2/pull/485&#xD;&#xA;* Bump CAPI to v1.8.5 by @furkatgofurov7 in https://github.com/rancher/cluster-api-provider-rke2/pull/477&#xD;&#xA;* Use upstream krew-index for crust-gather by @alexander-demicev in https://github.com/rancher/cluster-api-provider-rke2/pull/505&#xD;&#xA;* Pass component configuration as slice by @alexander-demicev in https://github.com/rancher/cluster-api-provider-rke2/pull/504&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @ron1 made their first contribution in https://github.com/rancher/cluster-api-provider-rke2/pull/492&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/rancher/cluster-api-provider-rke2/compare/v0.8.0...v0.9.0</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

