### PR TITLE
Build and push e2e images

### DIFF
--- a/.github/workflows/run-e2e-suite.yaml
+++ b/.github/workflows/run-e2e-suite.yaml
@@ -97,6 +97,9 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+      - name: Build and push e2e image
+        if: ${{ inputs.MANAGEMENT_CLUSTER_ENVIRONMENT == 'eks' }}
+        run: make e2e-image-push
       - name: Run e2e tests
         run: CACHE_DIR=/tmp/.buildx-cache make test-e2e
       - name: Collect run artifacts


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

It looks like this was accidentally removed. Building and pushing e2e images is required when EKS is used as a management cluster since it doesn't have a local registry.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
