### PR TITLE
Revert "Disable e2e verification for NoCreatorRBAC annotation in AWS and Azure"

### DIFF
--- a/test/e2e/specs/import_gitops_mgmtv3.go
+++ b/test/e2e/specs/import_gitops_mgmtv3.go
@@ -44,6 +44,7 @@ import (
 	"github.com/rancher/turtles/test/e2e"
 	turtlesframework "github.com/rancher/turtles/test/framework"
 	"github.com/rancher/turtles/test/testenv"
+	turtlesannotations "github.com/rancher/turtles/util/annotations"
 )
 
 type CreateMgmtV3UsingGitOpsSpecInput struct {
@@ -137,13 +138,12 @@ func CreateMgmtV3UsingGitOpsSpec(ctx context.Context, inputGetter func() CreateM
 		}, input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(BeTrue())
 		By("Waiting for the rancher cluster to be ready")
 
-		// TODO: re-enable the check after rancher 2.10 update and verified existence of the annotation
-		// By("Rancher cluster should have the 'NoCreatorRBAC' annotation")
-		// Eventually(func() bool {
-		// 	Eventually(komega.Get(rancherCluster), input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(Succeed())
-		// 	_, found := rancherCluster.Annotations[turtlesannotations.NoCreatorRBACAnnotation]
-		// 	return found
-		// }, input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(BeTrue())
+		By("Rancher cluster should have the 'NoCreatorRBAC' annotation")
+		Eventually(func() bool {
+			Eventually(komega.Get(rancherCluster), input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(Succeed())
+			_, found := rancherCluster.Annotations[turtlesannotations.NoCreatorRBACAnnotation]
+			return found
+		}, input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(BeTrue())
 
 		By("Waiting for the CAPI cluster to be connectable using Rancher kubeconfig")
 		turtlesframework.RancherGetClusterKubeconfig(ctx, turtlesframework.RancherGetClusterKubeconfigInput{

--- a/test/e2e/specs/migrate_gitops_provv1_mgmtv3.go
+++ b/test/e2e/specs/migrate_gitops_provv1_mgmtv3.go
@@ -46,6 +46,7 @@ import (
 	"github.com/rancher/turtles/test/e2e"
 	turtlesframework "github.com/rancher/turtles/test/framework"
 	"github.com/rancher/turtles/test/testenv"
+	turtlesannotations "github.com/rancher/turtles/util/annotations"
 	turtlesnaming "github.com/rancher/turtles/util/naming"
 )
 
@@ -176,13 +177,12 @@ func MigrateToV3UsingGitOpsSpec(ctx context.Context, inputGetter func() MigrateT
 			return conditions.IsTrue(rancherCluster, managementv3.ClusterConditionReady)
 		}, input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(BeTrue())
 
-		// TODO: re-enable the check after rancher 2.10 update and verified existence of the annotation
-		// By("Rancher cluster should have the 'NoCreatorRBAC' annotation")
-		// Eventually(func() bool {
-		// 	Eventually(komega.Get(rancherCluster), input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(Succeed())
-		// 	_, found := rancherCluster.Annotations[turtlesannotations.NoCreatorRBACAnnotation]
-		// 	return found
-		// }, input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(BeTrue())
+		By("Rancher cluster should have the 'NoCreatorRBAC' annotation")
+		Eventually(func() bool {
+			Eventually(komega.Get(rancherCluster), input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(Succeed())
+			_, found := rancherCluster.Annotations[turtlesannotations.NoCreatorRBACAnnotation]
+			return found
+		}, input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...).Should(BeTrue())
 
 		By("Waiting for the CAPI cluster to be connectable using Rancher kubeconfig")
 		turtlesframework.RancherGetClusterKubeconfig(ctx, turtlesframework.RancherGetClusterKubeconfigInput{


### PR DESCRIPTION
Reverts rancher/turtles#883

Should be passing now, since `eks` e2e tests use built image from the main branch