### PR TITLE
Use docker build for e2e image

### DIFF
--- a/.github/workflows/run-e2e-suite.yaml
+++ b/.github/workflows/run-e2e-suite.yaml
@@ -90,18 +90,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - name: Build and push e2e image
         if: ${{ inputs.MANAGEMENT_CLUSTER_ENVIRONMENT == 'eks' }}
-        run: CACHE_DIR=/tmp/.buildx-cache make e2e-image-push
+        run: make e2e-image-push
       - name: Run e2e tests
-        run: CACHE_DIR=/tmp/.buildx-cache make test-e2e
+        run: make test-e2e
       - name: Collect run artifacts
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Use `docker build` instead of `buildx` for e2e because `buildx` takes too much for a test image to build.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher/turtles/issues/893

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
