### PR TITLE
Increase manager memory limit

### DIFF
--- a/charts/rancher-turtles/templates/deployment.yaml
+++ b/charts/rancher-turtles/templates/deployment.yaml
@@ -67,10 +67,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 256Mi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 128Mi
       serviceAccountName: rancher-turtles-manager
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,10 +52,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 256Mi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 128Mi
       serviceAccountName: manager
       terminationGracePeriodSeconds: 10
       tolerations:


### PR DESCRIPTION
<!--
kind/bug
-->

**What this PR does / why we need it**:

Deploying a local test environment `make dev-env` I noticed the controller manager could not start:

```
NAMESPACE                   NAME                                                              READY   STATUS              RESTARTS       AGE
rancher-turtles-system      rancher-turtles-controller-manager-d8ff6d887-w6qzq                0/1     OOMKilled           30 (5m6s ago)    5h58m
```

Once I increased the limits (as per PR) it did start correctly and seems to be idling at `223Mi`:

```
> kubectl -n rancher-turtles-system top pods

NAME                                                    CPU(cores)   MEMORY(bytes)   
rancher-turtles-cluster-api-operator-598c6d8cbc-z877q   3m           49Mi            
rancher-turtles-controller-manager-5f58c58cdb-mp8jw     2m           223Mi   
```

I don't exactly know what could have increased the memory usage. So this might not be a proper fix, just mitigation.