### PR TITLE
Prevent infinite CAPIProvider reconciliations

### DIFF
--- a/internal/controllers/capiprovider_controller.go
+++ b/internal/controllers/capiprovider_controller.go
@@ -48,6 +48,7 @@ type CAPIProviderReconciler struct {
 // Reconcile reconciles the CAPIProvider object.
 func (r *CAPIProviderReconciler) Reconcile(ctx context.Context, capiProvider *turtlesv1.CAPIProvider) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
+	log.Info("Reconciling CAPIProvider")
 
 	if !capiProvider.DeletionTimestamp.IsZero() {
 		log.Info("Provider is in the process of deletion, skipping reconcile...")

--- a/internal/sync/client.go
+++ b/internal/sync/client.go
@@ -51,12 +51,11 @@ func Patch(ctx context.Context, cl client.Client, obj client.Object, options ...
 	log.Info(fmt.Sprintf("Updating %s: %s", obj.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(obj)))
 
 	patchOptions := []client.PatchOption{
-		client.ForceOwnership,
 		client.FieldOwner(fieldOwner),
 	}
 	patchOptions = append(patchOptions, options...)
 
-	return cl.Patch(ctx, obj, client.Apply, patchOptions...)
+	return cl.Patch(ctx, obj, client.Merge, patchOptions...)
 }
 
 // PatchStatus will only patch the status subresource of the provided object.
@@ -72,8 +71,7 @@ func PatchStatus(ctx context.Context, cl client.Client, obj client.Object) error
 
 	log.Info(fmt.Sprintf("Patching status %s: %s", obj.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(obj)))
 
-	return cl.Status().Patch(ctx, obj, client.Apply, []client.SubResourcePatchOption{
-		client.ForceOwnership,
+	return cl.Status().Patch(ctx, obj, client.Merge, []client.SubResourcePatchOption{
 		client.FieldOwner(fieldOwner),
 	}...)
 }

--- a/internal/sync/client.go
+++ b/internal/sync/client.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -61,13 +60,6 @@ func Patch(ctx context.Context, cl client.Client, obj client.Object, options ...
 // PatchStatus will only patch the status subresource of the provided object.
 func PatchStatus(ctx context.Context, cl client.Client, obj client.Object) error {
 	log := log.FromContext(ctx)
-
-	obj.SetManagedFields(nil)
-	obj.SetFinalizers([]string{metav1.FinalizerDeleteDependents})
-
-	if err := setKind(cl, obj); err != nil {
-		return err
-	}
 
 	log.Info(fmt.Sprintf("Patching status %s: %s", obj.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(obj)))
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/bug
-->

**What this PR does / why we need it**:

The CAPIProvider syncing secret is getting a new `resourceVersion` even on empty patch. This creates an infinite loop where the CAPIProviderReconciler is continuously invoked due to the secret version change.

This PR tries to address this, however further issues escalate after applying it. 
For example there is a conflict between the `rancher-turtles-controller-manager` and the `cluster-api-operator` when it comes to managing some resources. 
For example giving the following bootstrap, there is a conflict in how finalizers are handled:

```yaml
kind: BootstrapProvider
metadata:
  annotations:
    operator.cluster.x-k8s.io/applied-spec-hash: d637e476cb631c683729765c7f6f3fd8c04b5c314254b114aa9500b51b7ed8f1 --> Emptied/Re-filled on a race condition
  creationTimestamp: "2024-12-04T14:21:54Z" 
  finalizers:
  - foregroundDeletion
  - provider.cluster.x-k8s.io --> Deleted/Re-added on a race condition
  generation: 1
  name: rke2
  namespace: default
  ownerReferences:
  - apiVersion: turtles-capi.cattle.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: CAPIProvider
    name: rke2-bootstrap
    uid: bc2f1c0c-9f32-4bab-9859-e18098e9f82d
  resourceVersion: "246785"
  uid: 58a94292-7858-4449-afa1-82edfdbf701c
spec:
  configSecret:
    name: rke2-bootstrap
    namespace: default
  version: v0.9.0
status:
  conditions:
  - lastTransitionTime: "2024-12-04T14:22:38Z"
    reason: MinimumReplicasAvailable
    status: "True"
    type: Ready
  - lastTransitionTime: "2024-12-04T14:22:28Z"
    status: "True"
    type: PreflightCheckPassed
  - lastTransitionTime: "2024-12-04T14:22:27Z"
    status: "True"
    type: ProviderInstalled
  contract: v1beta1
  installedVersion: v0.9.0
  observedGeneration: 1

```

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #892

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
