### PR TITLE
:bug: Fix diff check on secret sync

### DIFF
--- a/internal/controllers/capiprovider_controller_test.go
+++ b/internal/controllers/capiprovider_controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -187,6 +189,14 @@ var _ = Describe("Reconcile CAPIProvider", func() {
 			g.Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(provider), provider)).ToNot(HaveOccurred())
 			g.Expect(conditions.IsTrue(provider, turtlesv1.RancherCredentialsSecretCondition))
 		}).Should(Succeed())
+
+		resourceVersion := ""
+		Eventually(func(g Gomega) {
+			g.Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(doSecret), doSecret)).ToNot(HaveOccurred())
+			previousVersion := resourceVersion
+			resourceVersion = doSecret.GetResourceVersion()
+			g.Expect(previousVersion).To(Equal(resourceVersion))
+		}, time.Minute, 10*time.Second).Should(Succeed())
 	})
 
 	It("Should reflect missing infrastructure digitalocean provider credential secret in the status", func() {

--- a/internal/sync/client.go
+++ b/internal/sync/client.go
@@ -39,7 +39,7 @@ func setKind(cl client.Client, obj client.Object) error {
 }
 
 // Patch will only patch mirror object in the cluster.
-func Patch(ctx context.Context, cl client.Client, obj client.Object) error {
+func Patch(ctx context.Context, cl client.Client, obj client.Object, options ...client.PatchOption) error {
 	log := log.FromContext(ctx)
 
 	obj.SetManagedFields(nil)
@@ -50,10 +50,13 @@ func Patch(ctx context.Context, cl client.Client, obj client.Object) error {
 
 	log.Info(fmt.Sprintf("Updating %s: %s", obj.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(obj)))
 
-	return cl.Patch(ctx, obj, client.Apply, []client.PatchOption{
+	patchOptions := []client.PatchOption{
 		client.ForceOwnership,
 		client.FieldOwner(fieldOwner),
-	}...)
+	}
+	patchOptions = append(patchOptions, options...)
+
+	return cl.Patch(ctx, obj, client.Apply, patchOptions...)
 }
 
 // PatchStatus will only patch the status subresource of the provided object.

--- a/internal/sync/core.go
+++ b/internal/sync/core.go
@@ -22,7 +22,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -60,15 +59,13 @@ func (s *DefaultSynchronizer) Get(ctx context.Context) error {
 }
 
 // Apply applies the destination object to the cluster.
-func (s *DefaultSynchronizer) Apply(ctx context.Context, reterr *error) {
+func (s *DefaultSynchronizer) Apply(ctx context.Context, reterr *error, options ...client.PatchOption) {
 	log := log.FromContext(ctx)
 	uid := s.Destination.GetUID()
 
 	setOwnerReference(s.Source, s.Destination)
 
-	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		return Patch(ctx, s.client, s.Destination)
-	}); err != nil {
+	if err := Patch(ctx, s.client, s.Destination, options...); err != nil {
 		*reterr = kerrors.NewAggregate([]error{*reterr, err})
 		log.Error(*reterr, fmt.Sprintf("Unable to patch object: %s", *reterr))
 	}

--- a/internal/sync/interface.go
+++ b/internal/sync/interface.go
@@ -31,7 +31,7 @@ type Sync interface {
 	Template(source *turtlesv1.CAPIProvider) client.Object
 	Get(ctx context.Context) error
 	Sync(ctx context.Context) error
-	Apply(ctx context.Context, reterr *error)
+	Apply(ctx context.Context, reterr *error, options ...client.PatchOption)
 }
 
 // List contains a list of syncers to apply the syncing logic.

--- a/internal/sync/interface_test.go
+++ b/internal/sync/interface_test.go
@@ -42,7 +42,7 @@ func (m *MockSynchronizer) Sync(ctx context.Context) error {
 	return m.syncronizerr
 }
 
-func (m *MockSynchronizer) Apply(ctx context.Context, reterr *error) {
+func (m *MockSynchronizer) Apply(ctx context.Context, reterr *error, options ...client.PatchOption) {
 	*reterr = m.applyErr
 }
 

--- a/internal/sync/secret_sync.go
+++ b/internal/sync/secret_sync.go
@@ -19,7 +19,6 @@ package sync
 import (
 	"cmp"
 	"context"
-	"encoding/base64"
 	"maps"
 	"strconv"
 
@@ -90,19 +89,6 @@ func (s *SecretSync) SyncObjects() {
 	setFeatures(s.DefaultSynchronizer.Source)
 
 	s.Secret.StringData = s.DefaultSynchronizer.Source.Status.Variables
-
-	allSet := true
-
-	for k, v := range s.DefaultSynchronizer.Source.Status.Variables {
-		if b64value, found := s.Secret.Data[k]; !found || base64.StdEncoding.EncodeToString([]byte(v)) != string(b64value) {
-			allSet = false
-			break
-		}
-	}
-
-	if allSet {
-		s.Secret.StringData = map[string]string{}
-	}
 }
 
 func setVariables(capiProvider *turtlesv1.CAPIProvider) {


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Secret sync and variables sync methods issue SSA patch request to the same resource, but there appears to be an issue with the usage of the SSA patch field owner.

Previously the resource was patched with 2 different patches in the same reconcile loop, but both were using same owner, which caused infinite RV bumps on the provider secrets, as each patch conflicted with another, issued by the same owner.

Using different field owners fixes this issue.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #914

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
