### PR TITLE
✨ Populate fleet external annotation on management clusters

### DIFF
--- a/charts/rancher-turtles/templates/deployment.yaml
+++ b/charts/rancher-turtles/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - args:
         - --leader-elect
-        - --feature-gates=propagate-labels={{ index .Values "rancherTurtles" "features" "propagate-labels" "enabled"}},managementv3-cluster={{ index .Values "rancherTurtles" "features" "managementv3-cluster" "enabled"}},rancher-kube-secret-patch={{ index .Values "rancherTurtles" "features" "rancher-kubeconfigs" "label"}}
+        - --feature-gates=propagate-labels={{ index .Values "rancherTurtles" "features" "propagate-labels" "enabled"}},managementv3-cluster={{ index .Values "rancherTurtles" "features" "managementv3-cluster" "enabled"}},rancher-kube-secret-patch={{ index .Values "rancherTurtles" "features" "rancher-kubeconfigs" "label"}},addon-provider-fleet={{ index .Values "rancherTurtles" "features" "addon-provider-fleet" "enabled"}}
         {{- range .Values.rancherTurtles.managerArguments }}
         - {{ . }}
         {{- end }}  

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -32,6 +32,11 @@ const (
 	// PropagateLabels is used to enable copying the labels from the CAPI cluster
 	// to the Rancher cluster.
 	PropagateLabels featuregate.Feature = "propagate-labels"
+
+	// ExternalFleet allows to disable in-tree management of the Fleet clusters
+	// in the imported rancher clusters, by setting "provisioning.cattle.io/externally-managed"
+	// annotation.
+	ExternalFleet featuregate.Feature = "addon-provider-fleet"
 )
 
 func init() {
@@ -42,4 +47,5 @@ var defaultGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	RancherKubeSecretPatch: {Default: false, PreRelease: featuregate.Beta},
 	ManagementV3Cluster:    {Default: false, PreRelease: featuregate.Beta},
 	PropagateLabels:        {Default: false, PreRelease: featuregate.Beta},
+	ExternalFleet:          {Default: false, PreRelease: featuregate.Beta},
 }

--- a/internal/controllers/helpers.go
+++ b/internal/controllers/helpers.go
@@ -51,6 +51,7 @@ const (
 	capiClusterOwner          = "cluster-api.cattle.io/capi-cluster-owner"
 	capiClusterOwnerNamespace = "cluster-api.cattle.io/capi-cluster-owner-ns"
 	v1ClusterMigrated         = "cluster-api.cattle.io/migrated"
+	externalFleetAnnotation   = "provisioning.cattle.io/externally-managed"
 
 	defaultRequeueDuration = 1 * time.Minute
 	trueAnnotationValue    = "true"

--- a/internal/controllers/import_controller_v3.go
+++ b/internal/controllers/import_controller_v3.go
@@ -252,7 +252,7 @@ func (r *CAPIImportManagementV3Reconciler) reconcile(ctx context.Context, capiCl
 
 	defer func() {
 		// As the rancherCluster is created inside reconcileNormal, we can only patch existing object
-		// Skipping non-existent cluster or returnted error
+		// Skipping non-existent cluster or returned error
 		if reterr != nil || rancherCluster == nil {
 			return
 		}

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -54,6 +54,7 @@ var (
 func init() {
 	utilruntime.Must(feature.MutableGates.SetFromMap(map[string]bool{
 		string(feature.PropagateLabels): true,
+		string(feature.ExternalFleet):   true,
 	}))
 }
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

With introduction of https://github.com/rancher/rancher/pull/46672 `managementv3` clusters annotated with `provisioning.cattle.io/externally-managed` will omit creating fleet cluster automatically with the instance. This allows `CAAPF` to fully manage fleet cluster lifecycle workflow, which will no longer be [duplicated](https://github.com/rancher/turtles/issues/622).

This PR allows to gauge the setting under the `addon-provider-fleet` feature gate.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
