### PR TITLE
🌱 Remove retry usages across the code

### DIFF
--- a/internal/controllers/import_controller_v3.go
+++ b/internal/controllers/import_controller_v3.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	errorutils "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -184,13 +183,8 @@ func (r *CAPIImportManagementV3Reconciler) Reconcile(ctx context.Context, req ct
 		errs = append(errs, fmt.Errorf("error reconciling cluster: %w", err))
 	}
 
-	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		if err := r.Client.Patch(ctx, capiCluster, patchBase); err != nil {
-			errs = append(errs, fmt.Errorf("failed to patch cluster: %w", err))
-		}
-		return nil
-	}); err != nil {
-		return ctrl.Result{}, err
+	if err := r.Client.Patch(ctx, capiCluster, patchBase); err != nil {
+		errs = append(errs, fmt.Errorf("failed to patch cluster: %w", err))
 	}
 
 	if len(errs) > 0 {

--- a/internal/sync/core.go
+++ b/internal/sync/core.go
@@ -22,7 +22,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -66,9 +65,7 @@ func (s *DefaultSynchronizer) Apply(ctx context.Context, reterr *error) {
 
 	setOwnerReference(s.Source, s.Destination)
 
-	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		return Patch(ctx, s.client, s.Destination)
-	}); err != nil {
+	if err := Patch(ctx, s.client, s.Destination); err != nil {
 		*reterr = kerrors.NewAggregate([]error{*reterr, err})
 		log.Error(*reterr, fmt.Sprintf("Unable to patch object: %s", *reterr))
 	}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This change remove usages of retry from the code, which improves situation with stuck tests on general timeout in local and CI runs. The object which is retried with patch is using `MergeFromWithOptimisticLock` and the object is never updated, so this retry will never succeed.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #912 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
