### PR TITLE
charts: Replace hardcoded namespaces

### DIFF
--- a/charts/rancher-turtles/templates/post-delete-job.yaml
+++ b/charts/rancher-turtles/templates/post-delete-job.yaml
@@ -41,7 +41,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: post-delete-job
-    namespace: rancher-turtles-system
+    namespace: '{{ .Values.rancherTurtles.namespace }}'
 roleRef:
   kind: ClusterRole
   name: post-delete-job-delete-webhooks

--- a/charts/rancher-turtles/templates/post-upgrade-job.yaml
+++ b/charts/rancher-turtles/templates/post-upgrade-job.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: post-upgrade-job
-  namespace: rancher-turtles-system
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-weight": "1"
@@ -42,7 +42,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: post-upgrade-job
-    namespace: rancher-turtles-system
+    namespace: '{{ .Values.rancherTurtles.namespace }}'
 roleRef:
   kind: ClusterRole
   name: post-upgrade-job-delete-clusters

--- a/charts/rancher-turtles/templates/post-upgrade-job.yaml
+++ b/charts/rancher-turtles/templates/post-upgrade-job.yaml
@@ -52,6 +52,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: post-upgrade-delete-clusters
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-weight": "2"

--- a/charts/rancher-turtles/templates/pre-delete-job.yaml
+++ b/charts/rancher-turtles/templates/pre-delete-job.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: pre-delete-job
-  namespace: rancher-turtles-system
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-2"
@@ -35,7 +35,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: pre-delete-job
-    namespace: rancher-turtles-system
+    namespace: '{{ .Values.rancherTurtles.namespace }}'
 roleRef:
   kind: ClusterRole
   name: pre-delete-job-delete-capiproviders
@@ -45,7 +45,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: rancher-capiprovider-cleanup
-  namespace: rancher-turtles-system
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-1"

--- a/charts/rancher-turtles/templates/pre-install-job.yaml
+++ b/charts/rancher-turtles/templates/pre-install-job.yaml
@@ -59,6 +59,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: rancher-mutatingwebhook-cleanup
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "2"
@@ -81,6 +82,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: rancher-validatingwebhook-cleanup
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "2"

--- a/charts/rancher-turtles/templates/pre-install-job.yaml
+++ b/charts/rancher-turtles/templates/pre-install-job.yaml
@@ -18,7 +18,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: pre-install-job
-  namespace: rancher-turtles-system
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "1"
@@ -49,7 +49,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: pre-install-job
-    namespace: rancher-turtles-system
+    namespace: '{{ .Values.rancherTurtles.namespace }}'
 roleRef:
   kind: ClusterRole
   name: pre-install-job-delete-webhooks


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

Removes the hardcoded namespace values used within the different chart hooks.

**Special notes for your reviewer**:

There are some resources created in the default namespace across the `pre-install-job` and `post-upgrade-job` hooks. Should those be updated as well?
- https://github.com/rancher/turtles/blob/main/charts/rancher-turtles/templates/post-upgrade-job.yaml#L54
- https://github.com/rancher/turtles/blob/main/charts/rancher-turtles/templates/pre-install-job.yaml#L7
- https://github.com/rancher/turtles/blob/main/charts/rancher-turtles/templates/pre-install-job.yaml#L61
- https://github.com/rancher/turtles/blob/main/charts/rancher-turtles/templates/pre-install-job.yaml#L83

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
