### PR TITLE
Use deterministic tag for e2e-images and cleanup after use

### DIFF
--- a/.github/workflows/e2e-short.yaml
+++ b/.github/workflows/e2e-short.yaml
@@ -11,6 +11,7 @@ concurrency:
 env:
   MANAGEMENT_CLUSTER_ENVIRONMENT: "isolated-kind"
   GINKGO_LABEL_FILTER: "short"
+  TAG: v0.0.1
 
 jobs:
   e2e:

--- a/.github/workflows/run-e2e-suite.yaml
+++ b/.github/workflows/run-e2e-suite.yaml
@@ -54,6 +54,7 @@ env:
   GINKGO_LABEL_FILTER: full 
   GINKGO_TESTS: ${{ github.workspace }}/${{ inputs.test_suite }}
   GINKGO_NODES: 5
+  TAG: v${{ github.run_number }}.${{ github.run_attempt }}
 
 jobs:
   run_e2e_tests:
@@ -122,6 +123,11 @@ jobs:
           age-in-hours: 6
           resource-label-key: ${{ secrets.GCP_LABEL_KEY }}
           resource-label-value: ${{ secrets.GCP_LABEL_VALUE }}
+      - name: Cleanup e2e test image
+        if: always()
+        run: |
+        IMAGE_URL="$(gh api /orgs/rancher/packages/container/turtles-e2e/versions | jq ".[] | select( .metadata.container.tags | contains([\"$TAG\"])) | .url" | sed 's/\"//g')"
+        gh api -X DELETE "$IMAGE_URL"
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v2.0.0

--- a/Makefile
+++ b/Makefile
@@ -594,8 +594,8 @@ test-e2e-push-image: $(GINKGO) $(HELM) $(CLUSTERCTL) kubectl e2e-image-push
 .PHONY: e2e-image
 e2e-image: ## Build and push the image for e2e tests
 	CONTROLLER_IMG=$(REGISTRY)/$(ORG)/turtles-e2e $(MAKE) e2e-image-build
-	RELEASE_TAG=v0.0.1 CONTROLLER_IMG=$(REGISTRY)/$(ORG)/turtles-e2e \
-	CONTROLLER_IMAGE_VERSION=v0.0.1 \
+	RELEASE_TAG=$(TAG) CONTROLLER_IMG=$(REGISTRY)/$(ORG)/turtles-e2e \
+	CONTROLLER_IMAGE_VERSION=$(TAG) \
 	$(MAKE) build-chart
 
 .PHONY: e2e-image-build-and-push
@@ -608,11 +608,11 @@ e2e-image-build: ## Build the image for e2e tests
 		--build-arg builder_image=$(GO_CONTAINER_IMAGE) \
 		--build-arg goproxy=$(GOPROXY) \
 		--build-arg package=. \
-		--build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG):v0.0.1
+		--build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG):$(TAG)
 
 .PHONY: e2e-image-push
 e2e-image-push: ## Push the image for e2e tests
-	docker push $(CONTROLLER_IMG):v0.0.1
+	docker push $(CONTROLLER_IMG):$(TAG)
 
 .PHONY: compile-e2e
 e2e-compile: ## Test e2e compilation


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #907 

This PR should automatically cleanup the e2e test images after the job is done.
Note that the images are deleted even in case of job failure. I can change the behavior and keep them in case of failure for further investigation when job fails, I just not find it worth it since you can easily rebuild them.

Also the images will be tagged with the job number and attempt, instead that just `v0.0.1`, so that they can be referenced.