### PR TITLE
Additional e2e fixes

### DIFF
--- a/.github/workflows/e2e-image-clean.yaml
+++ b/.github/workflows/e2e-image-clean.yaml
@@ -1,0 +1,20 @@
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  TAG: v0.0.1
+
+jobs:
+  clean_e2e_image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup e2e test image
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IMAGE_URL="$(gh api /orgs/rancher/packages/container/turtles-e2e/versions | jq ".[] | select( .metadata.container.tags | contains([\"$TAG\"])) | .url" | sed 's/\"//g')"
+          gh api --method DELETE -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "$IMAGE_URL"

--- a/.github/workflows/e2e-image-publish.yaml
+++ b/.github/workflows/e2e-image-publish.yaml
@@ -1,0 +1,30 @@
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  TAG: v0.0.1
+
+jobs:
+  publish_e2e_image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: setupGo
+        uses: actions/setup-go@v5.2.0
+        with:
+          go-version: "=1.22.10"
+      - name: Docker login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push e2e image
+        run: make e2e-image-build-and-push

--- a/.github/workflows/e2e-long.yaml
+++ b/.github/workflows/e2e-long.yaml
@@ -8,7 +8,11 @@ on:
 concurrency: ci_e2e_tests
 
 jobs:
+  publish_e2e_image:
+    uses: ./.github/workflows/e2e-image-publish.yaml
+    secrets: inherit
   e2e_import_gitops:
+    needs: publish_e2e_image
     uses: ./.github/workflows/run-e2e-suite.yaml
     with:
       test_suite: test/e2e/suites/import-gitops
@@ -18,6 +22,7 @@ jobs:
       MANAGEMENT_CLUSTER_ENVIRONMENT: eks
     secrets: inherit
   e2e_import_gitops_v3:
+    needs: publish_e2e_image
     uses: ./.github/workflows/run-e2e-suite.yaml
     with:
       test_suite: test/e2e/suites/import-gitops-v3
@@ -27,6 +32,7 @@ jobs:
       MANAGEMENT_CLUSTER_ENVIRONMENT: eks
     secrets: inherit
   e2e_v2prov:
+    needs: publish_e2e_image
     uses: ./.github/workflows/run-e2e-suite.yaml
     with:
       test_suite: test/e2e/suites/v2prov
@@ -36,6 +42,7 @@ jobs:
       MANAGEMENT_CLUSTER_ENVIRONMENT: eks
     secrets: inherit
   e2e_update_labels:
+    needs: publish_e2e_image
     uses: ./.github/workflows/run-e2e-suite.yaml
     with:
       test_suite: test/e2e/suites/update-labels
@@ -45,6 +52,7 @@ jobs:
       MANAGEMENT_CLUSTER_ENVIRONMENT: eks
     secrets: inherit
   e2e_embedded_capi_disabled:
+    needs: publish_e2e_image
     uses: ./.github/workflows/run-e2e-suite.yaml
     with:
       test_suite: test/e2e/suites/embedded-capi-disabled
@@ -54,6 +62,7 @@ jobs:
       MANAGEMENT_CLUSTER_ENVIRONMENT: eks
     secrets: inherit
   e2e_embedded_capi_disabled_v3:
+    needs: publish_e2e_image
     uses: ./.github/workflows/run-e2e-suite.yaml
     with:
       test_suite: test/e2e/suites/embedded-capi-disabled-v3
@@ -61,4 +70,9 @@ jobs:
       run_azure_janitor: false
       artifact_name: artifacts_embedded_capi_v3
       MANAGEMENT_CLUSTER_ENVIRONMENT: eks
+    secrets: inherit
+  clean_e2e_image:
+    if: always()
+    needs: [e2e_import_gitops, e2e_import_gitops_v3, e2e_v2prov, e2e_update_labels, e2e_embedded_capi_disabled, e2e_embedded_capi_disabled_v3]
+    uses: ./.github/workflows/e2e-image-clean.yaml
     secrets: inherit

--- a/.github/workflows/run-e2e-suite.yaml
+++ b/.github/workflows/run-e2e-suite.yaml
@@ -31,7 +31,7 @@ on:
 
 permissions:
   contents: read
-  packages: write
+  packages: read
 
 env:
   NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
@@ -54,7 +54,7 @@ env:
   GINKGO_LABEL_FILTER: full 
   GINKGO_TESTS: ${{ github.workspace }}/${{ inputs.test_suite }}
   GINKGO_NODES: 5
-  TAG: v${{ github.run_number }}.${{ github.run_attempt }}
+  TAG: v0.0.1
 
 jobs:
   run_e2e_tests:
@@ -92,9 +92,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push e2e image
-        if: ${{ inputs.MANAGEMENT_CLUSTER_ENVIRONMENT == 'eks' }}
-        run: make e2e-image-build-and-push
       - name: Run e2e tests
         run: make test-e2e
       - name: Collect run artifacts
@@ -123,11 +120,6 @@ jobs:
           age-in-hours: 6
           resource-label-key: ${{ secrets.GCP_LABEL_KEY }}
           resource-label-value: ${{ secrets.GCP_LABEL_VALUE }}
-      - name: Cleanup e2e test image
-        if: always()
-        run: |
-          IMAGE_URL="$(gh api /orgs/rancher/packages/container/turtles-e2e/versions | jq ".[] | select( .metadata.container.tags | contains([\"$TAG\"])) | .url" | sed 's/\"//g')"
-          gh api -X DELETE "$IMAGE_URL"
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v2.0.0


### PR DESCRIPTION
This PR is to fix the e2e workflow and bring some improvements.

The turtles-e2e image is now only built once as pre-requisite job. I kept the `v0.0.1` tag because changing this has further implications down the line and should be propagated better, for example to the helm chart values and the `test/e2e/config/operator.yaml` file. 

The image is also now deleted correctly always, when all parallel jobs end.
See: https://github.com/rancher/turtles/pkgs/container/turtles-e2e

Sample run: https://github.com/rancher/turtles/actions/runs/12595032471