### PR TITLE
🌱 Add CAPZ back to image overrides list

### DIFF
--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -62,6 +62,8 @@ data:
         repository: "registry.suse.com/rancher"
       infrastructure-aws:
         repository: "registry.suse.com/rancher"
+      infrastructure-azure:
+        repository: "registry.suse.com/rancher"
       infrastructure-gcp:
         repository: "registry.suse.com/rancher"
       infrastructure-vsphere:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding `infrastructure-azure` back to image overrides list since `azure-service-operator` prime image should be build and available at `registry.rancher.com/rancher/azure-service-operator:tag` to use.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #894 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
