### PR TITLE
Add ability to leverage agent tls mode setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ KUSTOMIZE_BIN := kustomize
 KUSTOMIZE := $(abspath $(TOOLS_BIN_DIR)/$(KUSTOMIZE_BIN)-$(KUSTOMIZE_VER))
 KUSTOMIZE_PKG := sigs.k8s.io/kustomize/kustomize/v4
 
-SETUP_ENVTEST_VER := v0.0.0-20240522175850-2e9781e9fc60
+SETUP_ENVTEST_VER := release-0.19
 SETUP_ENVTEST_BIN := setup-envtest
 SETUP_ENVTEST := $(abspath $(TOOLS_BIN_DIR)/$(SETUP_ENVTEST_BIN)-$(SETUP_ENVTEST_VER))
 SETUP_ENVTEST_PKG := sigs.k8s.io/controller-runtime/tools/setup-envtest

--- a/api/rancher/management/v3/setting.go
+++ b/api/rancher/management/v3/setting.go
@@ -20,6 +20,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // Setting is the struct representing a Rancher Setting.
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
 type Setting struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/rancher-turtles/questions.yml
+++ b/charts/rancher-turtles/questions.yml
@@ -76,3 +76,9 @@ questions:
     type: boolean
     label: Seamless integration with Fleet and CAPI
     group: "Rancher Turtles Features Settings"
+  - variable: rancherTurtles.features.agent-tls-mode.enabled
+    default: false
+    description: "If enabled Turtles will use the agent-tls-mode setting to determine CA cert trust mode for importing clusters"
+    type: boolean
+    label: Enable Agent TLS Mode
+    group: "Rancher Turtles Features Settings"

--- a/charts/rancher-turtles/templates/deployment.yaml
+++ b/charts/rancher-turtles/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - args:
         - --leader-elect
-        - --feature-gates=propagate-labels={{ index .Values "rancherTurtles" "features" "propagate-labels" "enabled"}},managementv3-cluster={{ index .Values "rancherTurtles" "features" "managementv3-cluster" "enabled"}},rancher-kube-secret-patch={{ index .Values "rancherTurtles" "features" "rancher-kubeconfigs" "label"}},addon-provider-fleet={{ index .Values "rancherTurtles" "features" "addon-provider-fleet" "enabled"}}
+        - --feature-gates=propagate-labels={{ index .Values "rancherTurtles" "features" "propagate-labels" "enabled"}},managementv3-cluster={{ index .Values "rancherTurtles" "features" "managementv3-cluster" "enabled"}},rancher-kube-secret-patch={{ index .Values "rancherTurtles" "features" "rancher-kubeconfigs" "label"}},addon-provider-fleet={{ index .Values "rancherTurtles" "features" "addon-provider-fleet" "enabled"}},agent-tls-mode={{ index .Values "rancherTurtles" "features" "agent-tls-mode" "enabled"}}
         {{- range .Values.rancherTurtles.managerArguments }}
         - {{ . }}
         {{- end }}  

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -30,6 +30,8 @@ rancherTurtles:
       imagePullPolicy: IfNotPresent
     addon-provider-fleet:
       enabled: false
+    agent-tls-mode:
+      enabled: false
 cluster-api-operator:
   enabled: true
   cert-manager:

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -37,6 +37,10 @@ const (
 	// in the imported rancher clusters, by setting "provisioning.cattle.io/externally-managed"
 	// annotation.
 	ExternalFleet featuregate.Feature = "addon-provider-fleet"
+
+	// AgentTLSMode if enabled Turtles will use the agent-tls-mode setting to determine
+	// CA cert trust mode for importing clusters.
+	AgentTLSMode featuregate.Feature = "agent-tls-mode"
 )
 
 func init() {
@@ -48,4 +52,5 @@ var defaultGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ManagementV3Cluster:    {Default: false, PreRelease: featuregate.Beta},
 	PropagateLabels:        {Default: false, PreRelease: featuregate.Beta},
 	ExternalFleet:          {Default: false, PreRelease: featuregate.Beta},
+	AgentTLSMode:           {Default: false, PreRelease: featuregate.Beta},
 }

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	golang.org/x/tools v0.26.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/controllers/helpers_test.go
+++ b/internal/controllers/helpers_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright © 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	managementv3 "github.com/rancher/turtles/api/rancher/management/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("getTrustedCAcert", func() {
+	var (
+		ctx                 context.Context
+		fakeClient          client.Client
+		cacertsSetting      *managementv3.Setting
+		agentTLSModeSetting *managementv3.Setting
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		fakeClient = fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+
+		cacertsSetting = &managementv3.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cacerts",
+			},
+			Value: "cert-data",
+		}
+
+		agentTLSModeSetting = &managementv3.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "agent-tls-mode",
+			},
+			Value: "strict",
+		}
+	})
+
+	It("should return error when agent-tls-mode setting is not found", func() {
+		result, err := getTrustedCAcert(ctx, fakeClient, true)
+		Expect(err).To(HaveOccurred())
+		Expect(result).To(BeNil())
+	})
+
+	It("should return nil when agent-tls-mode is set to system-store", func() {
+		agentTLSModeSetting.Value = "system-store"
+		Expect(fakeClient.Create(ctx, agentTLSModeSetting)).To(Succeed())
+
+		result, err := getTrustedCAcert(ctx, fakeClient, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil())
+	})
+
+	It("should return CA certs when agent-tls-mode is strict and cacerts is set", func() {
+		Expect(fakeClient.Create(ctx, agentTLSModeSetting)).To(Succeed())
+		Expect(fakeClient.Create(ctx, cacertsSetting)).To(Succeed())
+
+		result, err := getTrustedCAcert(ctx, fakeClient, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal([]byte("cert-data")))
+	})
+
+	It("should return error when agent-tls-mode is strict and cacerts is empty", func() {
+		cacertsSetting.Value = ""
+		Expect(fakeClient.Create(ctx, agentTLSModeSetting)).To(Succeed())
+		Expect(fakeClient.Create(ctx, cacertsSetting)).To(Succeed())
+
+		result, err := getTrustedCAcert(ctx, fakeClient, true)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("ca-certs setting value is empty"))
+		Expect(result).To(BeNil())
+	})
+
+	It("should return error for invalid agent-tls-mode value", func() {
+		agentTLSModeSetting.Value = "invalid"
+		Expect(fakeClient.Create(ctx, agentTLSModeSetting)).To(Succeed())
+
+		result, err := getTrustedCAcert(ctx, fakeClient, true)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid agent-tls-mode setting value"))
+		Expect(result).To(BeNil())
+	})
+})

--- a/internal/controllers/import_controller.go
+++ b/internal/controllers/import_controller.go
@@ -265,8 +265,15 @@ func (r *CAPIImportReconciler) reconcileNormal(ctx context.Context, capiCluster 
 		return ctrl.Result{}, nil
 	}
 
+	// Get custom CAcert if agentTLSMode feature is enabled
+	caCert, err := getTrustedCAcert(ctx, r.Client, feature.Gates.Enabled(feature.AgentTLSMode))
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("error getting CA cert: %w", err)
+	}
+
 	// get the registration manifest
-	manifest, err := getClusterRegistrationManifest(ctx, rancherCluster.Status.ClusterName, capiCluster.Namespace, r.RancherClient, r.InsecureSkipVerify)
+	manifest, err := getClusterRegistrationManifest(ctx, rancherCluster.Status.ClusterName, capiCluster.Namespace, r.RancherClient,
+		caCert, r.InsecureSkipVerify)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/import_controller_v3.go
+++ b/internal/controllers/import_controller_v3.go
@@ -321,8 +321,14 @@ func (r *CAPIImportManagementV3Reconciler) reconcileNormal(ctx context.Context, 
 		return ctrl.Result{}, nil
 	}
 
+	// Get custom CAcert if agentTLSMode feature is enabled
+	caCert, err := getTrustedCAcert(ctx, r.Client, feature.Gates.Enabled(feature.AgentTLSMode))
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("error getting CA cert: %w", err)
+	}
+
 	// get the registration manifest
-	manifest, err := getClusterRegistrationManifest(ctx, rancherCluster.Name, rancherCluster.Name, r.RancherClient, r.InsecureSkipVerify)
+	manifest, err := getClusterRegistrationManifest(ctx, rancherCluster.Name, rancherCluster.Name, r.RancherClient, caCert, r.InsecureSkipVerify)
 	if err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

After merging this PR, users can leverage CA certs stored in Rancher setting to import CAPI clusters.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher/turtles/issues/847

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
