### PR TITLE
Use RKE2ControlPlane.spec.machineTemplate

### DIFF
--- a/test/e2e/data/cluster-templates/docker-rke2.yaml
+++ b/test/e2e/data/cluster-templates/docker-rke2.yaml
@@ -71,11 +71,17 @@ spec:
   agentConfig:
     nodeAnnotations:
       test: "true"
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerMachineTemplate
+      name:  ${CLUSTER_NAME}-control-plane
+    nodeDrainTimeout: 30s
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: DockerMachineTemplate
     name:  ${CLUSTER_NAME}-control-plane
-  nodeDrainTimeout: 30s
+  nodeDrainTimeout: 30s  
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/test/e2e/data/cluster-templates/vsphere-rke2.yaml
+++ b/test/e2e/data/cluster-templates/vsphere-rke2.yaml
@@ -156,6 +156,12 @@ spec:
               type: File
             name: kubeconfig
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: VSphereMachineTemplate
+      name: vsphere-controlplane
+    nodeDrainTimeout: 2m
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: VSphereMachineTemplate


### PR DESCRIPTION
**What this PR does / why we need it**:

This will change all templates to use `RKE2ControlPlane.spec.machineTemplate`

Related to https://github.com/rancher/cluster-api-provider-rke2/pull/542

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
