### PR TITLE
Permit using github release or preloaded binary for system-agent

### DIFF
--- a/exp/etcdrestore/webhooks/install.sh
+++ b/exp/etcdrestore/webhooks/install.sh
@@ -30,6 +30,7 @@ fi
 #   - CATTLE_AGENT_UNINSTALL_URL (default: latest GitHub release)
 #   - CATTLE_PRESERVE_WORKDIR (default: false)
 #   - CATTLE_REMOTE_ENABLED (default: true)
+#   - CATTLE_UPSTREAM_ENABLED (default: false)
 #   - CATTLE_LOCAL_ENABLED (default: false)
 #   - CATTLE_AGENT_BINARY_LOCAL (default: false)
 #   - CATTLE_AGENT_BINARY_LOCAL_LOCATION (default: )
@@ -215,7 +216,7 @@ setup_env() {
         CATTLE_REMOTE_ENABLED=$(echo "${CATTLE_REMOTE_ENABLED}" | tr '[:upper:]' '[:lower:]')
     fi
 
-    if [ "${CATTLE_LOCAL_ENABLED}" = "false" ] && [ "${CATTLE_REMOTE_ENABLED}" = "false" ]; then
+    if [ "${CATTLE_LOCAL_ENABLED}" = "false" ] && [ "${CATTLE_REMOTE_ENABLED}" = "false" ] && [ "${CATTLE_UPSTREAM_ENABLED}" = "false" ]; then
         fatal "Neither local or remote plan support was enabled"
     fi
 

--- a/exp/etcdrestore/webhooks/rke2config_test.go
+++ b/exp/etcdrestore/webhooks/rke2config_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/controllers/remote"
 )
 
 var (
@@ -73,8 +72,7 @@ var _ = Describe("RKE2ConfigWebhook tests", func() {
 		}
 
 		r = &RKE2ConfigWebhook{
-			Client:  cl,
-			Tracker: new(remote.ClusterCacheTracker),
+			Client: cl,
 		}
 	})
 
@@ -163,7 +161,7 @@ var _ = Describe("RKE2ConfigWebhook tests", func() {
 	})
 
 	It("Should add system-agent-install.sh when it's not present", func() {
-		err := r.createSystemAgentInstallScript(ctx, serverUrl, systemAgentVersion, rke2Config)
+		err := r.createSystemAgentInstallScript(ctx, serverUrl, systemAgentVersion, rke2Config, &clusterv1.Cluster{})
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(rke2Config.Spec.Files).To(ContainElement(bootstrapv1.File{
@@ -184,7 +182,7 @@ var _ = Describe("RKE2ConfigWebhook tests", func() {
 			Path: "/opt/system-agent-install.sh",
 		})
 
-		err := r.createSystemAgentInstallScript(ctx, serverUrl, systemAgentVersion, rke2Config)
+		err := r.createSystemAgentInstallScript(ctx, serverUrl, systemAgentVersion, rke2Config, &clusterv1.Cluster{})
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(rke2Config.Spec.Files).To(HaveLen(1))

--- a/test/e2e/data/cluster-templates/docker-rke2.yaml
+++ b/test/e2e/data/cluster-templates/docker-rke2.yaml
@@ -13,6 +13,8 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster 
 metadata:
   name: ${CLUSTER_NAME}
+  annotations:
+    cluster-api.cattle.io/upstream-system-agent: "true"
   labels:
     cni: ${CLUSTER_NAME}-crs-0
 spec:

--- a/test/e2e/suites/etcd-snapshot-restore/etcd_snapshot_restore_test.go
+++ b/test/e2e/suites/etcd-snapshot-restore/etcd_snapshot_restore_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/rancher/turtles/test/e2e/specs"
 )
 
-var _ = Describe("[Docker] [RKE2] Perform an ETCD backup and restore of the cluster", Label(e2e.LocalTestLabel), func() {
+var _ = Describe("[Docker] [RKE2] Perform an ETCD backup and restore of the cluster", Label(e2e.ShortTestLabel), func() {
 	BeforeEach(func() {
 		SetClient(bootstrapClusterProxy.GetClient())
 		SetContext(ctx)

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -31,6 +31,10 @@ const (
 	NoCreatorRBACAnnotation = "field.cattle.io/no-creator-rbac"
 	// EtcdAutomaticSnapshot represents automatically generated etcd snapshot.
 	EtcdAutomaticSnapshot = "etcd.turtles.cattle.io/automatic-snapshot"
+	// UpstreamSystemAgentAnnotation is a cluster annotation, allowing to pull the agent binary from the github repo instead of rancher url.
+	UpstreamSystemAgentAnnotation = "cluster-api.cattle.io/upstream-system-agent"
+	// LocalSystemAgentAnnotation is a cluster annotation, allowing to specify agent binary location from the node in the airgapped environment.
+	LocalSystemAgentAnnotation = "cluster-api.cattle.io/local-system-agent"
 )
 
 // HasClusterImportAnnotation returns true if the object has the `imported` annotation.


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

We need to allow alternative installation methods for the rancher `system-agent` binary. Users may want either:
- Pre-load system agent in the image manually via cloud-config or other means in the air-gapped installation scenario
- Use github release to download agent binary

This change allows to perform both via added annotations on the CAPI `Cluster` object.

Examples:
```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster 
metadata:
  name: rke2-cluster
  annotations:
    cluster-api.cattle.io/upstream-system-agent: "true" # Install agent binary from github repo release
```

```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster 
metadata:
  name: rke2-cluster
  annotations:
    cluster-api.cattle.io/local-system-agent: "/usr/local/bin/rancher-system-agent" # Use existing agent binary located at /usr/local/bin/rancher-system-agent
```

Depends on #987 

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #975 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
