### PR TITLE
Use correct binary path for snapshot/restore, adapt Tilt config

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -64,6 +64,7 @@ projects = {
         ],
         "kustomize_dir": "config/default",
         "label": "turtles-etcdsnapshotrestore",
+        "command": ["/manager"],
         "binary_name" : "etcd-snapshot-restore"
     },
     "turtles-capiproviders": {

--- a/charts/rancher-turtles/templates/rancher-turtles-exp-etcdrestore-components.yaml
+++ b/charts/rancher-turtles/templates/rancher-turtles-exp-etcdrestore-components.yaml
@@ -589,7 +589,7 @@ spec:
       - args:
         - --leader-elect
         command:
-        - /manager
+        - ./etcd-snapshot-restore
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/exp/etcdrestore/config/default/manager_image_patch.yaml
+++ b/exp/etcdrestore/config/default/manager_image_patch.yaml
@@ -9,3 +9,4 @@ spec:
       containers:
         - image: ghcr.io/rancher/turtles-etcd-snapshot-restore:dev
           name: manager
+          command: ["./etcd-snapshot-restore"]

--- a/tilt/project/Tiltfile
+++ b/tilt/project/Tiltfile
@@ -131,6 +131,8 @@ def update_manager(yaml, containerName, debug, env, name, project):
                     continue
                 if name != "turtles": # use custom image for projects except turtles
                     c["image"] = project.get("image")
+                if project.get("command"):
+                    c["command"] = project.get("command")
 
                 cmd = ["sh", "/start.sh", "/manager"]
                 if debug != {}:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Tilt uses own process for building docker images, which does involve overriding built image `CMD`. This overlaps with the model etcd snapshot restore is currently following, where the image is the part of the regular turtles image, running under different `CMD`.

This discrepancy causes e2e to fail, and `Tiltfile` based build to work without issues.

Current change ensures that both `tilt up` and `GINKGO_LABEL_FILTER=local make test-e2e` work without issues.

```

  RESOURCE NAME                                                                     CONTAINER •  UPDATE STATUS  •    AS OF 
▶ ● (Tiltfile) ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ N/A             • <45s ago 
  ● turtles_controller ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ Running • OK       (7.1s) • <30s ago 
  ● turtles-etcdsnapshotrestore_controller ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ Running • OK       (7.2s) • <30s ago 
  ● turtles-clusterclass-operations_controller ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ Running • OK       (1.2s) • <30s ago 
    HISTORY: FIRST BUILD                                                                        OK       (1.2s) • <30s ago 
    K8S POD: rancher-turtles-clusterclass-controller-manager-59f5fcc9bb6lj8h                          1 restart •  AGE 45m 
  ● turtles_binary ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ OK       (2.8s) • <45s ago 
  ● turtles-etcdsnapshotrestore_binary ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ OK       (2.9s) • <45s ago 
  ● turtles-clusterclass-operations_binary ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ OK       (0.5s) • <30s ago
```

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #974 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
