### PR TITLE
Download Rancher image only once

### DIFF
--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -21,6 +21,7 @@ if [ -z "$RANCHER_HOSTNAME" ]; then
 fi
 
 RANCHER_VERSION=${RANCHER_VERSION:-v2.10.0}
+RANCHER_IMAGE=${RANCHER_IMAGE:-rancher/rancher:$RANCHER_VERSION}
 CLUSTER_NAME=${CLUSTER_NAME:-capi-test}
 ETCD_CONTROLLER_IMAGE=${ETCD_CONTROLLER_IMAGE:-ghcr.io/rancher/turtles}
 ETCD_CONTROLLER_IMAGE_TAG=${ETCD_CONTROLLER_IMAGE_TAG:-dev}
@@ -31,6 +32,8 @@ USE_TILT_DEV=${USE_TILT_DEV:-true}
 BASEDIR=$(dirname "$0")
 
 kind create cluster --config "$BASEDIR/kind-cluster-with-extramounts.yaml"
+docker pull $RANCHER_IMAGE
+kind load docker-image $RANCHER_IMAGE --name $CLUSTER_NAME
 
 kubectl rollout status deployment coredns -n kube-system --timeout=90s
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR pulls Rancher image once and re-use it in the dev setup created using `make dev-env`. Currently, if a developer does `make dev-env` the Rancher image is pulled as a part of `helm install rancher`. If the developer deletes the `kind` cluster created using `make dev-env` and creates a new one, Rancher image will be pulled again because this pulling happens inside the kind node. Hence, the need to "cache" it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: N/A

**Special notes for your reviewer**:
Please let me know if there's a better way to do this, or if there's already a way to do it that I'm not aware of. 🙂 

On the flip side, if you think we could cache more images like this, I'd be happy to add them!

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
