### PR TITLE
Enable CAAPF by default

### DIFF
--- a/charts/rancher-turtles/questions.yml
+++ b/charts/rancher-turtles/questions.yml
@@ -59,7 +59,7 @@ questions:
     label: Propagate CAPI Labels
     group: "Rancher Turtles Features Settings"
   - variable: rancherTurtles.features.addon-provider-fleet.enabled
-    default: false
+    default: true
     description: "Enable Fleet Addon Provider functionality in Rancher Turtles"
     type: boolean
     label: Seamless integration with Fleet and CAPI

--- a/charts/rancher-turtles/templates/addon-provider-fleet.yaml
+++ b/charts/rancher-turtles/templates/addon-provider-fleet.yaml
@@ -35,10 +35,17 @@ data:
       cluster:
         patchResource: true
         setOwnerReferences: true
+        hostNetwork: true
         selector:
           matchLabels:
             cluster-api.cattle.io/rancher-auto-import: "true"
+          matchExpressions:
+            - key: cluster-api.cattle.io/disable-fleet-auto-import
+              operator: DoesNotExist
         namespaceSelector:
           matchLabels:
             cluster-api.cattle.io/rancher-auto-import: "true"
+          matchExpressions:
+            - key: cluster-api.cattle.io/disable-fleet-auto-import
+              operator: DoesNotExist
 {{- end }}

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -25,7 +25,7 @@ rancherTurtles:
       imageVersion: v0.0.0
       imagePullPolicy: IfNotPresent
     addon-provider-fleet:
-      enabled: false
+      enabled: true
     agent-tls-mode:
       enabled: false
 cluster-api-operator:

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -47,6 +47,6 @@ func init() {
 var defaultGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	RancherKubeSecretPatch: {Default: false, PreRelease: featuregate.Beta},
 	PropagateLabels:        {Default: false, PreRelease: featuregate.Beta},
-	ExternalFleet:          {Default: false, PreRelease: featuregate.Beta},
+	ExternalFleet:          {Default: true, PreRelease: featuregate.Beta},
 	AgentTLSMode:           {Default: false, PreRelease: featuregate.Beta},
 }

--- a/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
+++ b/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
@@ -23,7 +23,6 @@ import (
 	_ "embed"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 
 	"github.com/rancher/turtles/test/e2e"
@@ -33,7 +32,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	turtlesframework "github.com/rancher/turtles/test/framework"
 	capiframework "sigs.k8s.io/cluster-api/test/framework"
 )
 
@@ -61,8 +59,6 @@ var _ = Describe("Chart upgrade functionality should work", Label(e2e.ShortTestL
 
 		testenv.DeployChartMuseum(ctx, chartMuseumDeployInput)
 
-		rtInput.AdditionalValues["rancherTurtles.features.addon-provider-fleet.enabled"] = "true"
-
 		upgradeInput := testenv.UpgradeRancherTurtlesInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			AdditionalValues:      rtInput.AdditionalValues,
@@ -78,9 +74,6 @@ var _ = Describe("Chart upgrade functionality should work", Label(e2e.ShortTestL
 					Namespace: e2e.RancherTurtlesNamespace,
 				}},
 			}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
-
-			By("Setting the CAAPF config to use hostNetwork")
-			Expect(turtlesframework.Apply(ctx, bootstrapClusterProxy, e2e.AddonProviderFleetHostNetworkPatch)).To(Succeed())
 		})
 
 		upgradeInput.PostUpgradeSteps = append(upgradeInput.PostUpgradeSteps, func() {

--- a/test/e2e/suites/import-gitops-v3/suite_test.go
+++ b/test/e2e/suites/import-gitops-v3/suite_test.go
@@ -74,16 +74,12 @@ var _ = SynchronizedBeforeSuite(
 		testenv.DeployRancherTurtles(ctx, testenv.DeployRancherTurtlesInput{
 			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
 			CAPIProvidersYAML:     e2e.CapiProviders,
-			AdditionalValues: map[string]string{
-				"rancherTurtles.features.addon-provider-fleet.enabled": "true",
-			},
 			WaitForDeployments: append(
 				testenv.DefaultDeployments,
 				testenv.NamespaceName{
 					Name:      "caapf-controller-manager",
 					Namespace: e2e.RancherTurtlesNamespace,
 				}),
-			ConfigurationPatches: [][]byte{e2e.AddonProviderFleetHostNetworkPatch},
 		})
 
 		if !shortTestOnly() && !localTestOnly() {

--- a/test/e2e/suites/import-gitops/suite_test.go
+++ b/test/e2e/suites/import-gitops/suite_test.go
@@ -79,9 +79,6 @@ var _ = SynchronizedBeforeSuite(
 			testenv.DeployRancherTurtles(ctx, testenv.DeployRancherTurtlesInput{
 				BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
 				CAPIProvidersYAML:     e2e.CapiProviders,
-				AdditionalValues: map[string]string{
-					"rancherTurtles.features.addon-provider-fleet.enabled": "true",
-				},
 				WaitForDeployments: append(
 					testenv.DefaultDeployments,
 					testenv.NamespaceName{
@@ -89,7 +86,6 @@ var _ = SynchronizedBeforeSuite(
 						Namespace: e2e.RancherTurtlesNamespace,
 					},
 				),
-				ConfigurationPatches: [][]byte{e2e.AddonProviderFleetHostNetworkPatch},
 			})
 		} else {
 			testenv.DeployRancherTurtles(ctx, testenv.DeployRancherTurtlesInput{


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Enable CAAPF by default for all imported CAPI clusters.

Cluster or namespace may specify `cluster-api.cattle.io/disable-fleet-auto-import` label to exclude it from automatic import process with fleet.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1002 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
