### PR TITLE
ci: Remove incorrect make target

### DIFF
--- a/.github/workflows/nightly-chart-and-image-publish.yaml
+++ b/.github/workflows/nightly-chart-and-image-publish.yaml
@@ -21,10 +21,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: setupGo
-      uses: actions/setup-go@v5.2.0
-      with:
-        go-version: '=1.22.10'
     - name: Docker login
       uses: docker/login-action@v3
       with:
@@ -34,7 +30,6 @@ jobs:
     - name: Build and push docker images
       run: |
         make docker-build-and-push TAG=${{ env.TAG }} ORG=${{ env.PROD_ORG }}
-        make docker-build-and-push-etcdrestore TAG=${{ env.TAG }} ORG=${{ env.PROD_ORG }}
 
   publish-helm-chart-ghcr:
     name: Publish Helm chart to GHCR
@@ -43,8 +38,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    env:
-      HELM_EXPERIMENTAL_OCI: 1
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Makefile target `docker-build-and-push-etcdrestore` was removed in https://github.com/rancher/turtles/pull/897 . Also `HELM_EXPERIMENTAL_OCI` should not be required for Helm >= 3.8.0 and the Go compiler should not be needed since we're building inside a container.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
