### PR TITLE
chore: add capg to list of updatecli providers

### DIFF
--- a/updatecli/updatecli.d/manifest.yaml
+++ b/updatecli/updatecli.d/manifest.yaml
@@ -56,6 +56,16 @@ sources:
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
       typeFilter:
         latest: true
+  capgrelease:
+    kind: githubrelease
+    name: Get the latest CAPI GCP infrastructure provider release
+    spec:
+      owner: "rancher-sandbox"
+      repository: "cluster-api-provider-gcp"
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      typeFilter:
+        latest: true
   capvrelease:
     kind: githubrelease
     name: Get the latest CAPI vSphere infrastructure provider release
@@ -142,6 +152,15 @@ targets:
       replacepattern: 'https://github.com/rancher-sandbox/cluster-api-provider-aws/releases/{{ source "caparelease" }}/'
     scmid: turtles
     sourceid: caparelease # Will be ignored as `replacepattern` is specified
+  bumpcapg:
+    name: bump capg provider
+    kind: file
+    spec:
+      file: ./internal/controllers/clusterctl/config.yaml
+      matchpattern: 'https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/(.*)/'
+      replacepattern: 'https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/{{ source "capgrelease" }}/'
+    scmid: turtles
+    sourceid: capgrelease # Will be ignored as `replacepattern` is specified
   bumpcapv:
     name: bump capv provider
     kind: file


### PR DESCRIPTION
**What this PR does / why we need it**:

Add CAPG to `updatecli`'s configuration so it is automatically bumped.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
