### PR TITLE
chore: cleanup cluster-api-operator features in chart values

### DIFF
--- a/charts/rancher-turtles/questions.yml
+++ b/charts/rancher-turtles/questions.yml
@@ -13,7 +13,7 @@ questions:
     type: boolean
     description: "Flag to enable or disable installation of cert-manager. If set to false then you will need to install cert-manager manually"
     label: "Enable Cert Manager"
-  - variable: rancherTurtles.features.cluster-api-operator.cleanup
+  - variable: rancherTurtles.cluster-api-operator.cleanup
     default: true
     description: "Specify that the CAPI Operator post-delete cleanup job will be performed"
     type: boolean
@@ -21,7 +21,7 @@ questions:
     group: "CAPI Operator cleanup settings"
     show_subquestion_if: true
     subquestions:
-    - variable: rancherTurtles.features.cluster-api-operator.kubectlImage
+    - variable: rancherTurtles.cluster-api-operator.kubectlImage
       default: "registry.k8s.io/kubernetes/kubectl:v1.30.0"
       description: "Specify the image to use when cleaning up the Cluster API Operator manifests"
       type: string

--- a/charts/rancher-turtles/templates/post-delete-job.yaml
+++ b/charts/rancher-turtles/templates/post-delete-job.yaml
@@ -1,4 +1,4 @@
-{{- if index .Values "rancherTurtles" "features" "cluster-api-operator" "cleanup" }}
+{{- if index .Values "cluster-api-operator" "cleanup" }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -62,7 +62,7 @@ spec:
       serviceAccountName: post-delete-job
       containers:
         - name: cluster-api-operator-mutatingwebhook-cleanup
-          image: {{ index .Values "rancherTurtles" "features" "cluster-api-operator" "kubectlImage" }}
+          image: {{ index .Values "cluster-api-operator" "kubectlImage" }}
           command: ["kubectl"]
           args:
           - delete
@@ -90,7 +90,7 @@ spec:
       serviceAccountName: post-delete-job
       containers:
         - name: cluster-api-operator-validatingwebhook-cleanup
-          image: {{ index .Values "rancherTurtles" "features" "cluster-api-operator" "kubectlImage" }}
+          image: {{ index .Values "cluster-api-operator" "kubectlImage" }}
           command: ["kubectl"]
           args:
           - delete
@@ -119,7 +119,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: delete-capi-controller-manager
-        image: {{ index .Values "rancherTurtles" "features" "cluster-api-operator" "kubectlImage" }}
+        image: {{ index .Values "cluster-api-operator" "kubectlImage" }}
         command: ["kubectl"]
         args:
         - delete
@@ -128,7 +128,7 @@ spec:
         - {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
         - --ignore-not-found=true
       - name: delete-capi-kubeadm-bootstrap-controller-manager
-        image: {{ index .Values "rancherTurtles" "features" "cluster-api-operator" "kubectlImage" }}
+        image: {{ index .Values "cluster-api-operator" "kubectlImage" }}
         command: ["kubectl"]
         args:
         - delete
@@ -137,7 +137,7 @@ spec:
         - capi-kubeadm-bootstrap-system
         - --ignore-not-found=true
       - name: delete-capi-kubeadm-control-plane-controller-manager
-        image: {{ index .Values "rancherTurtles" "features" "cluster-api-operator" "kubectlImage" }}
+        image: {{ index .Values "cluster-api-operator" "kubectlImage" }}
         command: ["kubectl"]
         args:
         - delete
@@ -146,7 +146,7 @@ spec:
         - capi-kubeadm-control-plane-system
         - --ignore-not-found=true
       - name: delete-rke2-kubeadm-bootstrap-controller-manager
-        image: {{ index .Values "rancherTurtles" "features" "cluster-api-operator" "kubectlImage" }}
+        image: {{ index .Values "cluster-api-operator" "kubectlImage" }}
         command: ["kubectl"]
         args:
         - delete
@@ -155,7 +155,7 @@ spec:
         - {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "bootstrap" "namespace" }}
         - --ignore-not-found=true
       - name: delete-rke2-control-plane-controller-manager
-        image: {{ index .Values "rancherTurtles" "features" "cluster-api-operator" "kubectlImage" }}
+        image: {{ index .Values "cluster-api-operator" "kubectlImage" }}
         command: ["kubectl"]
         args:
         - delete

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -7,9 +7,6 @@ rancherTurtles:
   imagePullSecrets: []
   rancherInstalled: true
   features:
-    cluster-api-operator:
-      cleanup: true
-      kubectlImage: registry.k8s.io/kubernetes/kubectl:v1.30.0
     embedded-capi:
       disabled: true
     rancher-webhook:
@@ -51,6 +48,8 @@ cluster-api-operator:
       - mountPath: /config
         name: clusterctl-config
         readOnly: true
+  cleanup: true
+  kubectlImage: registry.k8s.io/kubernetes/kubectl:v1.30.0
   cluster-api:
     enabled: true
     configSecret:


### PR DESCRIPTION
**What this PR does / why we need it**:

Move `features.cluster-api-operator` under `cluster-api-operator` in `values.yaml` file.

**Which issue(s) this PR fixes**:
Fixes #1022

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
