### PR TITLE
Remove docker build for clusterclass manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,35 +392,6 @@ docker-build-and-push: buildx-machine docker-pull-prerequisites ## Run docker-bu
 			--build-arg package=. \
 			--build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG):$(TAG)
 
-## --------------------------------------
-## Docker - clusterclass
-## --------------------------------------
-
-.PHONY: docker-build-clusterclass ## Build the docker image for clusterclass
-docker-build-clusterclass: buildx-machine docker-pull-prerequisites ## Build docker image for a specific architecture
-	## reads Dockerfile from stdin to avoid an incorrectly cached Dockerfile (https://github.com/moby/buildkit/issues/1368)
-	# buildx does not support using local registry for multi-architecture images
-	cat $(EXP_CLUSTERCLASS_DIR)/Dockerfile | DOCKER_BUILDKIT=1 BUILDX_BUILDER=$(MACHINE) docker buildx build $(ADDITIONAL_COMMANDS) \
-			--platform $(ARCH) \
-			--load \
-			--build-arg builder_image=$(GO_CONTAINER_IMAGE) \
-			--build-arg goproxy=$(GOPROXY) \
-			--build-arg package=./exp/clusterclass \
-			--build-arg ldflags="$(LDFLAGS)" . -t $(CLUSTERCLASS_IMG):$(TAG) --file - --progress=plain
-
-.PHONY: docker-build-and-push-clusterclass
-docker-build-and-push-clusterclass: buildx-machine docker-pull-prerequisites ## Run docker-build-and-push-clusterclass targets for all architectures
-	cat $(EXP_CLUSTERCLASS_DIR)/Dockerfile | DOCKER_BUILDKIT=1 BUILDX_BUILDER=$(MACHINE) docker buildx build $(ADDITIONAL_COMMANDS) \
-			--platform $(TARGET_PLATFORMS) \
-			--push \
-			--sbom=true \
-			--attest type=provenance,mode=max \
-			--iidfile=$(IID_FILE) \
-			--build-arg builder_image=$(GO_CONTAINER_IMAGE) \
-			--build-arg goproxy=$(GOPROXY) \
-			--build-arg package=./exp/clusterclass \
-			--build-arg ldflags="$(LDFLAGS)" . -t $(CLUSTERCLASS_IMG):$(TAG) --file - --progress=plain
-
 docker-list-all:
 	@echo $(CONTROLLER_IMG):${TAG}
 

--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -25,8 +25,6 @@ RANCHER_IMAGE=${RANCHER_IMAGE:-rancher/rancher:$RANCHER_VERSION}
 CLUSTER_NAME=${CLUSTER_NAME:-capi-test}
 ETCD_CONTROLLER_IMAGE=${ETCD_CONTROLLER_IMAGE:-ghcr.io/rancher/turtles}
 ETCD_CONTROLLER_IMAGE_TAG=${ETCD_CONTROLLER_IMAGE_TAG:-dev}
-CC_CONTROLLER_IMAGE=${CC_CONTROLLER_IMAGE:-ghcr.io/rancher/turtles-clusterclass-operations}
-CC_CONTROLLER_IMAGE_TAG=${CC_CONTROLLER_IMAGE_TAG:-dev}
 USE_TILT_DEV=${USE_TILT_DEV:-true}
 
 BASEDIR=$(dirname "$0")
@@ -81,10 +79,6 @@ install_local_rancher_turtles_chart() {
     make docker-build
     # Load the etcdrestore controller image into the kind cluster
     kind load docker-image $ETCD_CONTROLLER_IMAGE:$ETCD_CONTROLLER_IMAGE_TAG --name $CLUSTER_NAME
-    # Build the clusterclass controller image
-    make docker-build-clusterclass
-    # Load the clusterclass controller image into the kind cluster
-    kind load docker-image $CC_CONTROLLER_IMAGE:$CC_CONTROLLER_IMAGE_TAG --name $CLUSTER_NAME
     # Install the Rancher Turtles using a local chart with 'etcd-snapshot-restore' feature flag enabled
     # to run etcdrestore controller
     helm upgrade --install rancher-turtles out/charts/rancher-turtles \


### PR DESCRIPTION
**What this PR does / why we need it**:

@salasberryfin I noticed the `exp/clusterclass/Dockerfile` was cleaned up, so I think it makes sense to not try to build and use the docker image at this stage. `make dev-env` shows an error when trying to build the image and may be confusing for users.

That said, the clusterclass manager is correctly loaded by tilt, so it's still available in the development environment.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
