### PR TITLE
[WIP] 🌱 Use regular github runner for nightly tests

### DIFF
--- a/.github/workflows/run-e2e-suite.yaml
+++ b/.github/workflows/run-e2e-suite.yaml
@@ -58,7 +58,7 @@ env:
 
 jobs:
   run_e2e_tests:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - name: Install eksctl
         run: |


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

We can run our nightly tests using regular github runner, which will be used to provision EKS cluster in the nightly e2e tests. This change allows to drop provisioning GCP runners for each e2e run, and will no longer be affected by a limit of (8?) machine provisioning from template requests per hour in our current GCP setup, allowing to scale e2e tests further (if needed).

Example run: https://github.com/rancher/turtles/actions/runs/12928650496

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #963 - as we are dropping GCP runner.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
