### PR TITLE
[WIP] Revert "Disable image override for ASO"

### DIFF
--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -62,7 +62,7 @@ data:
         repository: "registry.suse.com/rancher"
       infrastructure-aws:
         repository: "registry.suse.com/rancher"
-      infrastructure-azure/cluster-api-azure-controller:
+      infrastructure-azure:
         repository: "registry.suse.com/rancher"
       infrastructure-gcp:
         repository: "registry.suse.com/rancher"


### PR DESCRIPTION
Reverts rancher/turtles#1040

Thanks to updated secrets path in `clusterapi-forks`, we are able to push to the correct image name: `azureserviceoperator`.

Nightly run with this change: https://github.com/rancher/turtles/actions/runs/12950199290

Fixes: #990 