### PR TITLE
fix: Make dev cluster name configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ PULL_POLICY ?= IfNotPresent
 
 # Development config
 RANCHER_HOSTNAME ?= my.hostname.dev
+CLUSTER_NAME ?= capi-test
 
 CACHE_DIR ?= .buildx-cache/
 CACHE_COMMANDS = "--cache-from type=local,src=$(CACHE_DIR) --cache-to type=local,dest=$(CACHE_DIR),mode=max"
@@ -662,4 +663,4 @@ clean-release: ## Remove the release folder
 
 .PHOHY: clean-dev-env
 clean-dev-env: ## Remove the dev env
-	kind delete cluster --name=capi-test
+	kind delete cluster --name=$(CLUSTER_NAME)

--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -29,16 +29,16 @@ USE_TILT_DEV=${USE_TILT_DEV:-true}
 
 BASEDIR=$(dirname "$0")
 
-kind create cluster --config "$BASEDIR/kind-cluster-with-extramounts.yaml"
+kind create cluster --config "$BASEDIR/kind-cluster-with-extramounts.yaml" --name $CLUSTER_NAME
 docker pull $RANCHER_IMAGE
 kind load docker-image $RANCHER_IMAGE --name $CLUSTER_NAME
 
 kubectl rollout status deployment coredns -n kube-system --timeout=90s
 
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
-helm repo add capi-operator https://kubernetes-sigs.github.io/cluster-api-operator
-helm repo add jetstack https://charts.jetstack.io
-helm repo add ngrok https://charts.ngrok.com
+helm repo add rancher-latest https://releases.rancher.com/server-charts/latest --force-update
+helm repo add capi-operator https://kubernetes-sigs.github.io/cluster-api-operator --force-update
+helm repo add jetstack https://charts.jetstack.io --force-update
+helm repo add ngrok https://charts.ngrok.com --force-update
 helm repo update
 
 helm install cert-manager jetstack/cert-manager \
@@ -46,7 +46,9 @@ helm install cert-manager jetstack/cert-manager \
     --create-namespace \
     --set crds.enabled=true
 
-helm upgrade ngrok ngrok/kubernetes-ingress-controller \
+helm upgrade ngrok ngrok/ngrok-operator \
+    --namespace ngrok \
+    --create-namespace \
     --install \
     --wait \
     --timeout 5m \


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

`make dev-env`  and `make clean-dev-env`  default to using `capi-test`. This PR allows a different name to be used, if set. Also, updated to use ngrok-operator and eliminated a couple of errors from Helm.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
