### PR TITLE
fix: remove v1 clusters for migration in post-upgrade job

### DIFF
--- a/charts/rancher-turtles/templates/post-upgrade-job.yaml
+++ b/charts/rancher-turtles/templates/post-upgrade-job.yaml
@@ -23,13 +23,6 @@ rules:
   verbs:
   - list
   - delete
-- apiGroups:
-  - management.cattle.io
-  resources:
-  - clusters
-  verbs:
-  - list
-  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -65,7 +58,7 @@ spec:
           image: {{ index .Values "rancherTurtles" "kubectlImage" }}
           args:
           - delete
-          - clusters.management.cattle.io
+          - clusters.provisioning.cattle.io
           - --selector=cluster-api.cattle.io/owned
           - -A
           - --ignore-not-found=true


### PR DESCRIPTION
**What this PR does / why we need it**:

Now that there's a single method for importing clusters via `clusters.management.cattle.io` (v3) and migration is automatically applied for all `clusters.provisioning.cattle.io` (v1) we no longer have values in the Helm chart that control when Rancher clusters deletion is applied ([this](https://github.com/rancher/turtles/commit/1f6972edaea0c05de2406a9bd3020f8171a67576#diff-c0588fa3a386b0b96a535569bdd77004aa57407c73e52c49502cfd52a46eb23d) is where the changes are introduced).

In this case, as reported by @cpinjani [here](https://github.com/rancher/turtles/issues/1061), CAPI clusters are being un-imported after upgrade because the post-upgrade job deletes all v3 cluster resources and then the controller labels the CAPI cluster `imported=true`. For this to apply only for migration scenarios we should delete v1 clusters only (and eventually remove this action completely?).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
