### PR TITLE
fix: Delete ETCDMachineSnapshot resources if their corresponding snapshot gets deleted

### DIFF
--- a/exp/etcdrestore/controllers/etcdsnapshotsync_controller.go
+++ b/exp/etcdrestore/controllers/etcdsnapshotsync_controller.go
@@ -152,7 +152,7 @@ func (r *EtcdSnapshotSyncReconciler) etcdSnapshotFile(ctx context.Context, clust
 		}
 
 		if o.GetObjectKind().GroupVersionKind() != gvk {
-			log.Error(fmt.Errorf("got a different object"), "objectGVK", o.GetObjectKind().GroupVersionKind().String())
+			log.Error(fmt.Errorf("got a different object"), "unexpected object, will not enqueue request", "objectGVK", o.GetObjectKind().GroupVersionKind().String())
 			return nil
 		}
 

--- a/exp/etcdrestore/main.go
+++ b/exp/etcdrestore/main.go
@@ -224,12 +224,19 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 	setupLog.Info("enabling ETCDMachineSnapshot controller")
 
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &snapshotrestorev1.ETCDMachineSnapshot{}, "spec.clusterName", func(o client.Object) []string {
+		return []string{o.(*snapshotrestorev1.ETCDMachineSnapshot).Spec.ClusterName}
+	}); err != nil {
+		setupLog.Error(err, "unable to create field indexer for ETCDMachineSnapshot")
+		os.Exit(1)
+	}
+
 	if err := (&expcontrollers.ETCDMachineSnapshotReconciler{
 		Client:           mgr.GetClient(),
 		Tracker:          tracker,
 		WatchFilterValue: watchFilterValue,
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: concurrencyNumber}); err != nil {
-		setupLog.Error(err, "unable to create EtcdMachineSnapshot controller")
+		setupLog.Error(err, "unable to create ETCDMachineSnapshot controller")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Currently, when a snapshot gets deleted from the cluster, the corresponding `ETCDMachineSnapshot` resource is left behind with a status of `Done`. This PR aims to address that by removing such resources if a corresponding `ETCDSnapshotFile` resource is not found in the downstream cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #719 

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
