### PR TITLE
feat: Alow user to enable/disable day 2 operations from Rancher UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -556,9 +556,9 @@ release: clean-release $(RELEASE_DIR)  ## Builds and push container images using
 .PHONY: build-chart
 build-chart: $(HELM) $(KUSTOMIZE) $(RELEASE_DIR) $(CHART_RELEASE_DIR) $(CHART_PACKAGE_DIR) ## Builds the chart to publish with a release
 	$(KUSTOMIZE) build ./config/chart > $(CHART_DIR)/templates/rancher-turtles-components.yaml
-	$(KUSTOMIZE) build ./exp/day2/config/default > $(CHART_DIR)/templates/rancher-turtles-exp-day2-components.yaml
+	$(KUSTOMIZE) build ./exp/day2/config/chart > $(CHART_DIR)/templates/rancher-turtles-exp-day2-components.yaml
 	$(KUSTOMIZE) build ./exp/clusterclass/config/default > $(CHART_DIR)/templates/rancher-turtles-exp-clusterclass-components.yaml
-	./scripts/process-manifests.sh day2-operations $(CHART_DIR)/templates/rancher-turtles-exp-day2-components.yaml
+	./scripts/process-manifests.sh day2operations $(CHART_DIR)/templates/rancher-turtles-exp-day2-components.yaml
 	./scripts/process-manifests.sh clusterclass-operations $(CHART_DIR)/templates/rancher-turtles-exp-clusterclass-components.yaml
 	cp -rf $(CHART_DIR)/* $(CHART_RELEASE_DIR)
 
@@ -566,9 +566,9 @@ build-chart: $(HELM) $(KUSTOMIZE) $(RELEASE_DIR) $(CHART_RELEASE_DIR) $(CHART_PA
 	sed -i'' -e 's@imageVersion: .*@imageVersion: '"$(RELEASE_TAG)"'@' $(CHART_RELEASE_DIR)/values.yaml
 	sed -i'' -e 's@imagePullPolicy: .*@imagePullPolicy: '"$(PULL_POLICY)"'@' $(CHART_RELEASE_DIR)/values.yaml
 
-	sed -i'' -e '/day2-operations:/,/image:/ s@image: .*@image: '"$(CONTROLLER_IMG)"'@' $(CHART_RELEASE_DIR)/values.yaml
-	sed -i'' -e '/day2-operations:/,/imageVersion:/ s@imageVersion: .*@imageVersion: '"$(RELEASE_TAG)"'@' $(CHART_RELEASE_DIR)/values.yaml
-	sed -i'' -e '/day2-operations:/,/imagePullPolicy:/ s@imagePullPolicy: .*@imagePullPolicy: '"$(PULL_POLICY)"'@' $(CHART_RELEASE_DIR)/values.yaml
+	sed -i'' -e '/day2operations:/,/image:/ s@image: .*@image: '"$(CONTROLLER_IMG)"'@' $(CHART_RELEASE_DIR)/values.yaml
+	sed -i'' -e '/day2operations:/,/imageVersion:/ s@imageVersion: .*@imageVersion: '"$(RELEASE_TAG)"'@' $(CHART_RELEASE_DIR)/values.yaml
+	sed -i'' -e '/day2operations:/,/imagePullPolicy:/ s@imagePullPolicy: .*@imagePullPolicy: '"$(PULL_POLICY)"'@' $(CHART_RELEASE_DIR)/values.yaml
 
 	sed -i'' -e '/clusterclass:/,/image:/ s@image: .*@image: '"$(CONTROLLER_IMG)"'@' $(CHART_RELEASE_DIR)/values.yaml
 	sed -i'' -e '/clusterclass:/,/imageVersion:/ s@imageVersion: .*@imageVersion: '"$(RELEASE_TAG)"'@' $(CHART_RELEASE_DIR)/values.yaml

--- a/charts/rancher-turtles/questions.yml
+++ b/charts/rancher-turtles/questions.yml
@@ -11,11 +11,11 @@ questions:
       - variable: cluster-api-operator.cert-manager.enabled
         default: false
         type: boolean
-        description: "Flag to enable or disable installation of cert-manager. If set to false then you will need to install cert-manager manually"
+        description: "Flag to enable or disable installation of cert-manager. If set to false then you will need to install cert-manager manually."
         label: "Enable Cert Manager"
       - variable: rancherTurtles.cluster-api-operator.cleanup
         default: true
-        description: "Specify that the CAPI Operator post-delete cleanup job will be performed"
+        description: "Specify that the CAPI Operator post-delete cleanup job will be performed."
         type: boolean
         label: Cleanup CAPI Operator installation
         group: "CAPI Operator cleanup settings"
@@ -26,19 +26,30 @@ questions:
         type: boolean
       - variable: rancherTurtles.features.addon-provider-fleet.enabled
         default: true
-        description: "[BETA] Enable Fleet Addon Provider functionality in Rancher Turtles"
+        description: "[BETA] Enable Fleet Addon Provider functionality in Rancher Turtles."
         type: boolean
         label: Seamless integration with Fleet and CAPI
         group: "Rancher Turtles Features Settings"
       - variable: rancherTurtles.features.agent-tls-mode.enabled
         default: false
-        description: "[ALPHA] If enabled Turtles will use the agent-tls-mode setting to determine CA cert trust mode for importing clusters"
+        description: "[ALPHA] If enabled Turtles will use the agent-tls-mode setting to determine CA cert trust mode for importing clusters."
         type: boolean
         label: Enable Agent TLS Mode
         group: "Rancher Turtles Features Settings"
       - variable: rancherTurtles.kubectlImage
         default: "registry.k8s.io/kubernetes/kubectl:v1.30.0"
-        description: "Specify the image to use when running kubectl in jobs"
+        description: "Specify the image to use when running kubectl in jobs."
         type: string
         label: Kubectl Image
         group: "Rancher Turtles Features Settings"
+      - variable: rancherTurtles.features.day2operations.enabled
+        label: "Enable Day 2 Operations functionality in Rancher Turtles"
+        description: "Use this setting to configure Day 2 Operations functionality in Rancher Turtles, such as enabling ETCD Backup and Restore."
+        type: boolean
+        group: "Rancher Turtles Features Settings"
+      - variable: rancherTurtles.features.day2operations.etcdBackupRestore.enabled
+        label: "Enable ETCD Backup and Restore"
+        description: "[ALPHA] Enable ETCD Backup and Restore functionality in Rancher Turtles."
+        type: boolean
+        group: "ETCD Backup and Restore Settings"
+        show_if: "rancherTurtles.features.day2operations.enabled"

--- a/charts/rancher-turtles/templates/rancher-turtles-exp-day2-components.yaml
+++ b/charts/rancher-turtles/templates/rancher-turtles-exp-day2-components.yaml
@@ -1,4 +1,4 @@
-{{- if index .Values "rancherTurtles" "features" "day2-operations" "enabled" }}
+{{- if index .Values "rancherTurtles" "features" "day2operations" "enabled" }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -311,20 +311,6 @@ spec:
     subresources:
       status: {}
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: rancher-turtles
-    app.kubernetes.io/instance: controller-manager-sa
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/part-of: rancher-turtles
-    turtles-capi.cattle.io: day2-operations
-  name: rancher-turtles-day2-operations-manager
-  namespace: {{ index .Values "rancherTurtles" "namespace" }}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -562,93 +548,6 @@ spec:
     targetPort: webhook-server
   selector:
     turtles-capi.cattle.io: day2-operations
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    control-plane: controller-manager
-    turtles-capi.cattle.io: day2-operations
-  name: rancher-turtles-day2-operations-controller-manager
-  namespace: {{ index .Values "rancherTurtles" "namespace" }}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      control-plane: controller-manager
-      turtles-capi.cattle.io: day2-operations
-  template:
-    metadata:
-      annotations:
-        kubectl.kubernetes.io/default-container: manager
-      labels:
-        control-plane: controller-manager
-        turtles-capi.cattle.io: day2-operations
-    spec:
-      containers:
-      - args:
-        - --leader-elect
-        command:
-        - ./turtles-day2-operations
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_UID
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.uid
-        {{- $imageVersion := index .Values "rancherTurtles" "features" "day2-operations" "imageVersion" -}}
-        {{- if contains "sha256:" $imageVersion }}
-        image: {{ index .Values "rancherTurtles" "features" "day2-operations" "image" }}@{{ index .Values "rancherTurtles" "features" "day2-operations" "imageVersion" }}
-        {{- else }}
-        image: {{ index .Values "rancherTurtles" "features" "day2-operations" "image" }}:{{ index .Values "rancherTurtles" "features" "day2-operations" "imageVersion" }}
-        {{- end }}
-        imagePullPolicy: '{{ index .Values "rancherTurtles" "features" "day2-operations" "imagePullPolicy" }}'
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 9440
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        name: manager
-        ports:
-        - containerPort: 9443
-          name: webhook-server
-          protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 9440
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
-      serviceAccountName: rancher-turtles-day2-operations-manager
-      terminationGracePeriodSeconds: 10
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-      volumes:
-      - name: cert
-        secret:
-          secretName: rancher-turtles-day2-operations-webhook-service-cert
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/rancher-turtles/templates/rancher-turtles-exp-day2-deployment.yaml
+++ b/charts/rancher-turtles/templates/rancher-turtles-exp-day2-deployment.yaml
@@ -1,0 +1,106 @@
+{{- if index .Values "rancherTurtles" "features" "day2operations" "enabled" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+    turtles-capi.cattle.io: day2-operations
+  name: rancher-turtles-day2-operations-controller-manager
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      turtles-capi.cattle.io: day2-operations
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+        turtles-capi.cattle.io: day2-operations
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --feature-gates=etcd-backup-restore={{ .Values.rancherTurtles.features.day2operations.etcdBackupRestore.enabled }}
+        command:
+        - ./turtles-day2-operations
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        {{- if (contains "sha256:" .Values.rancherTurtles.features.day2operations.imageVersion) }}
+        image: '{{ .Values.rancherTurtles.features.day2operations.image }}@{{ .Values.rancherTurtles.features.day2operations.imageVersion }}'
+        {{- else }}
+        image: '{{ .Values.rancherTurtles.features.day2operations.image }}:{{ .Values.rancherTurtles.features.day2operations.imageVersion }}'
+        {{- end }}
+        imagePullPolicy: '{{ .Values.rancherTurtles.features.day2operations.imagePullPolicy }}'
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9440
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 9440
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        volumeMounts:
+        {{- if .Values.rancherTurtles.features.day2operations.etcdBackupRestore.enabled }}
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        {{- end }}
+      serviceAccountName: rancher-turtles-day2-operations-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      {{- if .Values.rancherTurtles.features.day2operations.etcdBackupRestore.enabled }}
+      - name: cert
+        secret:
+          secretName: rancher-turtles-day2-operations-webhook-service-cert
+      {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: rancher-turtles
+    app.kubernetes.io/instance: controller-manager-sa
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/part-of: rancher-turtles
+    turtles-capi.cattle.io: day2-operations
+  name: rancher-turtles-day2-operations-manager
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
+{{- end }}

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -8,11 +8,13 @@ rancherTurtles:
   rancherInstalled: true
   kubectlImage: registry.k8s.io/kubernetes/kubectl:v1.30.0
   features:
-    day2-operations:
+    day2operations:
       enabled: false
       image: controller
       imageVersion: v0.0.0
       imagePullPolicy: IfNotPresent
+      etcdBackupRestore:
+        enabled: false
     # beta feature, see documentation for more information on feature stages
     addon-provider-fleet:
       enabled: true

--- a/exp/day2/config/chart/kustomization.yaml
+++ b/exp/day2/config/chart/kustomization.yaml
@@ -1,0 +1,176 @@
+# Adds namespace to all resources.
+namespace: rancher-turtles-system
+
+namePrefix: rancher-turtles-day2-operations-
+
+commonLabels:
+  turtles-capi.cattle.io: "day2-operations"
+
+bases:
+- ../crd
+- ../rbac
+- ../webhook
+- ../certmanager
+
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, please comment the following line.
+patchesStrategicMerge:
+- webhookcainjection_patch.yaml
+- manager_role_aggregation_patch.yaml
+
+# The deployment for day2 operations references a service account
+# so both of these objects are applied, if enabled via the Helm values.
+# The patches below remove the service account as it gets applied with 
+# the deployment and also update the role and cluster role bindings accordingly.
+patches:
+- target:
+    kind: ServiceAccount
+  patch: |
+    $patch: delete
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: rancher-turtles-day2-operations-manager
+- target:
+    kind: RoleBinding
+    labelSelector: "app.kubernetes.io/instance=leader-election-rolebinding"
+  patch: |-
+    - op: replace
+      path: /subjects/0/name
+      value: rancher-turtles-day2-operations-manager
+    - op: replace
+      path: /subjects/0/namespace
+      value: rancher-turtles-system
+- target:
+    kind: ClusterRoleBinding
+    labelSelector: "app.kubernetes.io/instance=manager-rolebinding"
+  patch: |-
+    - op: replace
+      path: /subjects/0/name
+      value: rancher-turtles-day2-operations-manager
+    - op: replace
+      path: /subjects/0/namespace
+      value: rancher-turtles-system
+
+# patchesStrategicMerge:
+# - manager_role_aggregation_patch.yaml
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+# - path: manager_webhook_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+# 'CERTMANAGER' needs to be enabled to use ca injection
+# - path: webhookcainjection_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+# Uncomment the following replacements to add the cert-manager CA injection annotations
+replacements:
+ - source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+     kind: Certificate
+     group: cert-manager.io
+     version: v1
+     name: serving-cert # this name should match the one in certificate.yaml
+     fieldPath: .metadata.namespace # namespace of the certificate CR
+   targets:
+     - select:
+         kind: ValidatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 0
+         create: true
+     - select:
+         kind: MutatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 0
+         create: true
+     - select:
+         kind: CustomResourceDefinition
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 0
+         create: true
+ - source:
+     kind: Certificate
+     group: cert-manager.io
+     version: v1
+     name: serving-cert # this name should match the one in certificate.yaml
+     fieldPath: .metadata.name
+   targets:
+     - select:
+         kind: ValidatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 1
+         create: true
+     - select:
+         kind: MutatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 1
+         create: true
+     - select:
+         kind: CustomResourceDefinition
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 1
+         create: true
+ - source: # Add cert-manager annotation to the webhook Service
+     kind: Service
+     version: v1
+     name: webhook-service
+     fieldPath: .metadata.name # namespace of the service
+   targets:
+     - select:
+         kind: Certificate
+         group: cert-manager.io
+         version: v1
+       fieldPaths:
+         - .spec.dnsNames.0
+         - .spec.dnsNames.1
+       options:
+         delimiter: '.'
+         index: 0
+         create: true
+ - source:
+     kind: Service
+     version: v1
+     name: webhook-service
+     fieldPath: .metadata.namespace # namespace of the service
+   targets:
+     - select:
+         kind: Certificate
+         group: cert-manager.io
+         version: v1
+       fieldPaths:
+         - .spec.dnsNames.0
+         - .spec.dnsNames.1
+       options:
+         delimiter: '.'
+         index: 1
+         create: true
+
+vars:
+  - name: SERVICE_NAME
+    objref:
+      kind: Service
+      version: v1
+      name: webhook-service
+
+configurations:
+  - kustomizeconfig.yaml

--- a/exp/day2/config/chart/kustomizeconfig.yaml
+++ b/exp/day2/config/chart/kustomizeconfig.yaml
@@ -1,0 +1,3 @@
+varReference:
+- kind: Deployment
+  path: spec/template/spec/volumes/secret/secretName

--- a/exp/day2/config/chart/manager_role_aggregation_patch.yaml
+++ b/exp/day2/config/chart/manager_role_aggregation_patch.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+  labels:
+    rancher-turtles-exp/aggregate-to-manager: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aggregated-manager-role

--- a/exp/day2/config/chart/webhookcainjection_patch.yaml
+++ b/exp/day2/config/chart/webhookcainjection_patch.yaml
@@ -1,0 +1,8 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/exp/day2/feature/feature.go
+++ b/exp/day2/feature/feature.go
@@ -1,0 +1,35 @@
+/*
+Copyright © 2023 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package feature
+
+import (
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+	// EtcdBackupRestore is a feature gate for ETCD Backup and Restore functionality.
+	EtcdBackupRestore featuregate.Feature = "etcd-backup-restore"
+)
+
+func init() {
+	utilruntime.Must(MutableGates.Add(defaultGates))
+}
+
+var defaultGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	EtcdBackupRestore: {Default: false, PreRelease: featuregate.Alpha},
+}

--- a/exp/day2/feature/gates.go
+++ b/exp/day2/feature/gates.go
@@ -1,0 +1,35 @@
+/*
+Copyright © 2023 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package feature
+
+import (
+	"k8s.io/component-base/featuregate"
+
+	"sigs.k8s.io/cluster-api/feature"
+)
+
+var (
+	// MutableGates is a mutable version of DefaultFeatureGate.
+	// Only top-level commands/options setup and the k8s.io/component-base/featuregate/testing package should make use of this.
+	// Tests that need to modify featuregate gates for the duration of their test should use
+	// defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.<FeatureName>, <value>)().
+	MutableGates featuregate.MutableFeatureGate = feature.MutableGates
+
+	// Gates is a shared global FeatureGate.
+	// Top-level commands/options setup that needs to modify this featuregate gate should use DefaultMutableFeatureGate.
+	Gates featuregate.FeatureGate = MutableGates
+)

--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -91,8 +91,8 @@ install_local_rancher_turtles_chart() {
         -n rancher-turtles-system \
         --set cluster-api-operator.enabled=true \
         --set cluster-api-operator.cluster-api.enabled=false \
-        --set rancherTurtles.features.day2-operations.enabled=true \
-        --set rancherTurtles.features.day2-operations.imageVersion=dev \
+        --set rancherTurtles.features.day2operations.enabled=true \
+        --set rancherTurtles.features.day2operations.imageVersion=dev \
         --set rancherTurtles.features.clusterclass-operations.enabled=true \
         --set rancherTurtles.features.clusterclass-operations.imageVersion=dev \
         --set rancherTurtles.imageVersion=dev \

--- a/test/e2e/suites/etcd-snapshot-restore/suite_test.go
+++ b/test/e2e/suites/etcd-snapshot-restore/suite_test.go
@@ -76,7 +76,8 @@ var _ = SynchronizedBeforeSuite(
 			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
 			CAPIProvidersYAML:     e2e.CapiProviders,
 			AdditionalValues: map[string]string{
-				"rancherTurtles.features.day2-operations.enabled": "true", // enable day2-operations feature
+				"rancherTurtles.features.day2operations.enabled":                   "true", // enable day2operations feature
+				"rancherTurtles.features.day2operations.etcdBackupRestore.enabled": "true", // enable etcdBackupRestore feature
 			},
 			WaitForDeployments: testenv.DefaultDeployments,
 		})


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR updates `questions.yaml` in order to allow a user to enable/disable the ETCD Backup/Restore functionality from the Rancher UI. 
There are now two new checkboxes available during Turtles installation:
- `Enable Day 2 Operations functionality in Rancher Turtles` which is used to deploy the day 2 operations deployment and associated service account
- `Enable ETCD Backup and Restore` which is used to deploy the CRDs, RBAC and webhooks needed for the ETCD backup/restore functionality. 

The idea is to be able to deploy a subset of the day 2 operations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #849 

**Special notes for your reviewer**:
For some reason, the `show_if` conditional part of the UI did not work when the field was set to `day2-operations`, hence the (seemingly unrelated) change to that field.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
