### PR TITLE
Fix rke2 cluster reset invocation command

### DIFF
--- a/exp/day2/controllers/planner.go
+++ b/exp/day2/controllers/planner.go
@@ -178,10 +178,10 @@ func RKE2KillAll() Instruction {
 func ETCDRestore(snapshot *snapshotrestorev1.ETCDMachineSnapshotFile) Instruction {
 	return Instruction{
 		Name:    "etcd-restore",
-		Command: "/bin/sh",
+		Command: "rke2",
 		Args: []string{
-			"-c",
-			"rke2 server --cluster-reset",
+			"server",
+			"--cluster-reset",
 			fmt.Sprintf("--cluster-reset-restore-path=%s", strings.TrimPrefix(snapshot.Location, "file://")),
 		},
 		SaveOutput: true,


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Previous `rke2 server --cluster-reset` command was not performed correctly, but the part of it which was called returned success error code. Cluster wasn’t  restored to the snapshot, which left objects unchanged.

Updated command to pass arguments correctly one by one and directly to `rke2` binary.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
