### PR TITLE
fix: Show S3 snapshots in ETCDMachineSnapshot status

### DIFF
--- a/exp/day2/controllers/snapshotters/rke2snapshotter.go
+++ b/exp/day2/controllers/snapshotters/rke2snapshotter.go
@@ -64,16 +64,6 @@ func (s *RKE2Snapshotter) Sync(ctx context.Context) error {
 			continue
 		}
 
-		machineName, err := s.findMachineForSnapshot(ctx, snapshotFile.Spec.NodeName)
-		if err != nil {
-			return fmt.Errorf("failed to find machine to take a snapshot: %w", err)
-		}
-
-		if machineName == "" {
-			log.V(5).Info("Machine not found to take a snapshot, skipping. Will try again later.")
-			continue
-		}
-
 		if snapshotFile.Spec.S3 != nil {
 			s3Snapshots = append(s3Snapshots, snapshotrestorev1.S3SnapshotFile{
 				Name:         snapshotFile.Name,
@@ -81,6 +71,16 @@ func (s *RKE2Snapshotter) Sync(ctx context.Context) error {
 				CreationTime: snapshotFile.Status.CreationTime,
 			})
 		} else {
+			machineName, err := s.findMachineForSnapshot(ctx, snapshotFile.Spec.NodeName)
+			if err != nil {
+				return fmt.Errorf("failed to find machine to take a snapshot: %w", err)
+			}
+
+			if machineName == "" {
+				log.V(5).Info("Machine not found to take a snapshot, skipping. Will try again later.")
+				continue
+			}
+
 			snapshots = append(snapshots, snapshotrestorev1.ETCDMachineSnapshotFile{
 				Name:         snapshotFile.Name,
 				Location:     snapshotFile.Spec.Location,

--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -93,6 +93,7 @@ install_local_rancher_turtles_chart() {
         --set cluster-api-operator.cluster-api.enabled=false \
         --set rancherTurtles.features.day2operations.enabled=true \
         --set rancherTurtles.features.day2operations.imageVersion=dev \
+        --set rancherTurtles.features.day2operations.etcdBackupRestore.enabled=true \
         --set rancherTurtles.features.clusterclass-operations.enabled=true \
         --set rancherTurtles.features.clusterclass-operations.imageVersion=dev \
         --set rancherTurtles.imageVersion=dev \


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

The `ETCDSnapshotFile` resources that represent S3 snapshots do not have a node/machine name in their spec.



**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
