### PR TITLE
test: Ensure CAPV tests have the correct providers set up

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -77,7 +77,7 @@ This will consequently:
 From the project root directory:
 
 ```bash
-GINKGO_LABEL_FILTER=local make test-e2e
+TAG=v0.0.1 GINKGO_LABEL_FILTER=local make test-e2e
 ```
 
 **Important note:** The vSphere e2e tests require a VPN connection, which makes their integration into the daily e2e CI job challenging. Therefore,

--- a/test/e2e/data/capi-operator/capv-variables.yaml
+++ b/test/e2e/data/capi-operator/capv-variables.yaml
@@ -7,7 +7,7 @@ metadata:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-variables
+  name: vsphere
   namespace: capv-system
 type: Opaque
 stringData:

--- a/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
+++ b/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
@@ -248,7 +248,7 @@ var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster functionali
 			CAPIProvidersSecretsYAML: [][]byte{
 				e2e.VSphereProviderSecret,
 			},
-			CAPIProvidersYAML: [][]byte{e2e.CapvProvider},
+			CAPIProvidersYAML: [][]byte{e2e.CapvProvider, e2e.CapiProviders},
 			WaitForDeployments: []testenv.NamespaceName{
 				{
 					Name:      "capv-controller-manager",
@@ -285,6 +285,22 @@ var _ = Describe("[vSphere] [RKE2] Create and delete CAPI cluster functionality 
 	})
 
 	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+		By("Running local vSphere tests, deploying vSphere infrastructure provider")
+
+		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+			CAPIProvidersSecretsYAML: [][]byte{
+				e2e.VSphereProviderSecret,
+			},
+			CAPIProvidersYAML: [][]byte{e2e.CapvProvider},
+			WaitForDeployments: []testenv.NamespaceName{
+				{
+					Name:      "capv-controller-manager",
+					Namespace: "capv-system",
+				},
+			},
+		})
+
 		return specs.CreateMgmtV3UsingGitOpsSpecInput{
 			E2EConfig:                 e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:     bootstrapClusterProxy,


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Updated CAPV tests to ensure the correct providers are set up before test execution:
- RKE2 test was not setting up CAPV provider.
- Kubeadm test was not setting up Kubeadm bootstrap and control plane providers.

The vSphere secret was also renamed to match provider name otherwise it failed to install. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
