### PR TITLE
🐛 Rename `CPI_IMAGE_VERSION` variable to `CPI_IMAGE_K8S_VERSION`

### DIFF
--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -54,7 +54,7 @@ variables:
   TURTLES_PATH: "turtles/rancher-turtles"
   TURTLES_REPO_NAME: "turtles"
   TURTLES_URL: https://rancher.github.io/turtles
-  CPI_IMAGE_VERSION: "v1.31.0"
+  CPI_IMAGE_K8S_VERSION: "v1.31.0"
   RANCHER_REPO_NAME: "rancher-latest"
   RANCHER_ALPHA_REPO_NAME: "rancher-alpha"
   RANCHER_URL: "https://releases.rancher.com/server-charts/latest"


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/rancher/turtles/commit/5526153a15d534d15c3b71e63510c9073e52c8bd renames `CPI_IMAGE_VERSION` env variable defined in `test/e2e/config/operator.yaml` to `CPI_IMAGE_K8S_VERSION` in cluster templates only. This PR renames/updates the variable name in the file where it is defined. 

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
