### PR TITLE
Add Azure + RKE2 ClusterClass e2e test

### DIFF
--- a/examples/applications/azure/clusterresourceset-cloud-provider.yaml
+++ b/examples/applications/azure/clusterresourceset-cloud-provider.yaml
@@ -2,7 +2,6 @@ apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   name: cloud-provider-azure
-  namespace: default
 spec:
   clusterSelector:
     matchLabels:
@@ -16,7 +15,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cloud-provider-azure
-  namespace: default
 data:
   azure-ccm-external.yaml: |
     ---

--- a/examples/clusterclasses/azure/clusterclass-example.yaml
+++ b/examples/clusterclasses/azure/clusterclass-example.yaml
@@ -46,36 +46,17 @@ spec:
           description: "The Azure location where the Cluster will be created."
           type: string
           enum:
+            - australiaeast
             - eastus
             - eastus2
-            - southcentralus
-            - westus2
-            - westus3
-            - australiaeast
-            - southeastasia
-            - northeurope
-            - swedencentral
-            - uksouth
-            - westeurope
-            - centralus
-            - southafricanorth
-            - centralindia
-            - eastasia
-            - japaneast
-            - koreacentral
-            - canadacentral
             - francecentral
             - germanywestcentral
-            - italynorth
-            - norwayeast
-            - polandcentral
-            - spaincentral
+            - northcentralus
+            - northeurope
             - switzerlandnorth
-            - mexicocentral
-            - uaenorth
-            - brazilsouth
-            - israelcentral
-            - qatarcentral
+            - uksouth
+            - westeurope
+            - westus2
     - name: resourceGroup
       required: true
       schema:
@@ -205,7 +186,6 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlaneTemplate
 metadata:
   name: rke2-control-plane
-  namespace: default
 spec:
   template:
     spec:
@@ -228,7 +208,6 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate
 metadata:
   name: rke2-control-plane
-  namespace: default
 spec:
   template:
     spec:

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -99,6 +99,9 @@ var (
 	//go:embed data/cluster-templates/azure-aks-topology.yaml
 	CAPIAzureAKSTopology []byte
 
+	//go:embed data/cluster-templates/azure-rke2-topology.yaml
+	CAPIAzureRKE2Topology []byte
+
 	//go:embed data/cluster-templates/vsphere-kubeadm.yaml
 	CAPIvSphereKubeadm []byte
 

--- a/test/e2e/data/capi-operator/capz-identity-secret.yaml
+++ b/test/e2e/data/capi-operator/capz-identity-secret.yaml
@@ -10,5 +10,5 @@ stringData:
 kind: Secret
 metadata:
   name: cluster-identity-secret
-  namespace: default
+  namespace: capz-system
 type: Opaque

--- a/test/e2e/data/cluster-templates/azure-aks-topology.yaml
+++ b/test/e2e/data/cluster-templates/azure-aks-topology.yaml
@@ -2,7 +2,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
   name: ${CLUSTER_CLASS_NAME}
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   controlPlane:
     ref:
@@ -45,7 +45,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedControlPlaneTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   template:
     spec:
@@ -54,7 +54,7 @@ spec:
         kind: AzureClusterIdentity
         name: cluster-identity
       location: southcentralus
-      resourceGroupName: "${CLUSTER_NAME}"
+      resourceGroupName: highlander-e2e-azure-aks
       subscriptionID: ${AZURE_SUBSCRIPTION_ID}
       version: ${KUBERNETES_VERSION}
 ---
@@ -62,7 +62,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedClusterTemplate
 metadata:
   name: ${CLUSTER_NAME}
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   template:
     spec: {}
@@ -71,7 +71,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePoolTemplate
 metadata:
   name: ${CLUSTER_NAME}-pool0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   template:
     spec:
@@ -83,7 +83,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePoolTemplate
 metadata:
   name: ${CLUSTER_NAME}-pool1
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   template:
     spec:
@@ -95,7 +95,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: RKE2ConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-pool0
-  namespace: default
+  namespace: "${NAMESPACE}"
 spec:
   template:
     spec: {}
@@ -123,7 +123,7 @@ spec:
   clientID: ${AZURE_CLIENT_ID}
   clientSecret:
     name: cluster-identity-secret
-    namespace: default
+    namespace: capz-system
   tenantID: ${AZURE_TENANT_ID}
   type: ServicePrincipal
 ---

--- a/test/e2e/data/cluster-templates/azure-rke2-topology.yaml
+++ b/test/e2e/data/cluster-templates/azure-rke2-topology.yaml
@@ -1,0 +1,53 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureClusterIdentity
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  name: cluster-identity
+  namespace: ${NAMESPACE}
+spec:
+  allowedNamespaces: {}
+  clientID: ${AZURE_CLIENT_ID}
+  clientSecret:
+    name: cluster-identity-secret
+    namespace: capz-system
+  tenantID: ${AZURE_TENANT_ID}
+  type: ServicePrincipal
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cloud-provider: azure
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 10.96.0.0/12
+    services:
+      cidrBlocks:
+      - 10.244.0.0/16
+  topology:
+    class: azure-example
+    controlPlane:
+      replicas: 3
+    variables:
+    - name: subscriptionID
+      value: ${AZURE_SUBSCRIPTION_ID}
+    - name: location
+      value: germanywestcentral
+    - name: resourceGroup
+      value: highlander-e2e-azure-rke2
+    - name: azureClusterIdentityName
+      value: cluster-identity
+    version: v1.31.1+rke2r1
+    workers:
+      machineDeployments:
+      - class: rke2-default-worker
+        name: md-0
+        replicas: 3
+

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -55,13 +55,18 @@ type Setup struct {
 	RancherHostname string
 }
 
-func SetupSpecNamespace(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder string) (*corev1.Namespace, context.CancelFunc) {
+func SetupSpecNamespace(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder string, fixedNamespace string) (*corev1.Namespace, context.CancelFunc) {
 	turtlesframework.Byf("Creating a namespace for hosting the %q test spec", specName)
+	namespaceName := fixedNamespace
+	if namespaceName == "" {
+		namespaceName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+	}
 	namespace, cancelWatches := framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
-		Creator:   clusterProxy.GetClient(),
-		ClientSet: clusterProxy.GetClientSet(),
-		Name:      fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
-		LogFolder: filepath.Join(artifactFolder, "clusters", clusterProxy.GetName()),
+		Creator:             clusterProxy.GetClient(),
+		ClientSet:           clusterProxy.GetClientSet(),
+		Name:                namespaceName,
+		LogFolder:           filepath.Join(artifactFolder, "clusters", clusterProxy.GetName()),
+		IgnoreAlreadyExists: true,
 	})
 
 	return namespace, cancelWatches

--- a/test/e2e/specs/etcd_snapshot_restore.go
+++ b/test/e2e/specs/etcd_snapshot_restore.go
@@ -73,6 +73,9 @@ type ETCDSnapshotRestoreInput struct {
 
 	SkipCleanup      bool `env:"SKIP_RESOURCE_CLEANUP"`
 	SkipDeletionTest bool
+
+	// A fixed Namespace to run the spec in, instead of generating a random one.
+	FixedNamespace string
 }
 
 // CreateUsingGitOpsSpec implements a spec that will create a cluster via Fleet and test that it
@@ -141,7 +144,7 @@ func ETCDSnapshotRestore(ctx context.Context, inputGetter func() ETCDSnapshotRes
 		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
 
 		Expect(input.E2EConfig.Variables).To(HaveKey(e2e.KubernetesManagementVersionVar))
-		namespace, cancelWatches = e2e.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
+		namespace, cancelWatches = e2e.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, input.FixedNamespace)
 		repoName = e2e.CreateRepoName(specName)
 
 		capiClusterCreateWait = input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), input.CAPIClusterCreateWaitName)

--- a/test/e2e/specs/import_gitops_mgmtv3.go
+++ b/test/e2e/specs/import_gitops_mgmtv3.go
@@ -89,6 +89,9 @@ type CreateMgmtV3UsingGitOpsSpecInput struct {
 
 	// IsGCPCluster is used to substitute GCP-specific values from secrets
 	IsGCPCluster bool
+
+	// A fixed Namespace to run the spec in, instead of generating a random one.
+	FixedNamespace string
 }
 
 // CreateMgmtV3UsingGitOpsSpec implements a spec that will create a cluster via Fleet and test that it
@@ -181,7 +184,7 @@ func CreateMgmtV3UsingGitOpsSpec(ctx context.Context, inputGetter func() CreateM
 		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
 
 		Expect(input.E2EConfig.Variables).To(HaveKey(e2e.KubernetesManagementVersionVar))
-		namespace, cancelWatches = e2e.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
+		namespace, cancelWatches = e2e.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, input.FixedNamespace)
 		repoName = e2e.CreateRepoName(specName)
 
 		capiClusterCreateWait = input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), input.CAPIClusterCreateWaitName)

--- a/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
+++ b/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
@@ -20,7 +20,10 @@ limitations under the License.
 package import_gitops_v3
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 
 	"k8s.io/utils/ptr"
@@ -28,6 +31,8 @@ import (
 	"github.com/rancher/turtles/test/e2e"
 	"github.com/rancher/turtles/test/e2e/specs"
 	"github.com/rancher/turtles/test/testenv"
+
+	turtlesframework "github.com/rancher/turtles/test/framework"
 )
 
 var _ = Describe("[Docker] [Kubeadm]  Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.ShortTestLabel), func() {
@@ -144,6 +149,61 @@ var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster clas
 			CapiClusterOwnerNamespaceLabel: e2e.CapiClusterOwnerNamespaceLabel,
 			OwnedLabelName:                 e2e.OwnedLabelName,
 		}
+	})
+})
+
+var _ = Describe("[Azure] [RKE2] - [management.cattle.io/v3] Create and delete CAPI cluster from cluster class", Label(e2e.FullTestLabel), func() {
+	BeforeEach(func() {
+		komega.SetClient(bootstrapClusterProxy.GetClient())
+		komega.SetContext(ctx)
+	})
+
+	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			CAPIProvidersSecretsYAML: [][]byte{
+				e2e.AzureIdentitySecret,
+			},
+			CAPIProvidersYAML: [][]byte{
+				e2e.AzureProvider,
+			},
+			WaitForDeployments: []testenv.NamespaceName{
+				{
+					Name:      "capz-controller-manager",
+					Namespace: "capz-system",
+				},
+			},
+		})
+
+		// Add the needed ClusterClass and ClusterResourceSet
+		fixedNamespace := "creategitops-azure-rke2"
+		Expect(turtlesframework.CreateNamespace(ctx, bootstrapClusterProxy, fixedNamespace)).Should(Succeed())
+		clusterClass, err := os.ReadFile("../../../../examples/clusterclasses/azure/clusterclass-example.yaml")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(turtlesframework.Apply(ctx, bootstrapClusterProxy, clusterClass, "-n", fixedNamespace)).Should(Succeed())
+		cloudProvider, err := os.ReadFile("../../../../examples/applications/azure/clusterresourceset-cloud-provider.yaml")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(turtlesframework.Apply(ctx, bootstrapClusterProxy, cloudProvider, "-n", fixedNamespace)).Should(Succeed())
+
+		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+			E2EConfig:                      e2e.LoadE2EConfig(),
+			BootstrapClusterProxy:          bootstrapClusterProxy,
+			ClusterTemplate:                e2e.CAPIAzureRKE2Topology,
+			ClusterName:                    "cluster-azure-rke2",
+			ControlPlaneMachineCount:       ptr.To(1),
+			WorkerMachineCount:             ptr.To(1),
+			GitAddr:                        gitAddress,
+			SkipDeletionTest:               false,
+			LabelNamespace:                 true,
+			RancherServerURL:               hostName,
+			CAPIClusterCreateWaitName:      "wait-capz-create-cluster",
+			DeleteClusterWaitName:          "wait-aks-delete",
+			CapiClusterOwnerLabel:          e2e.CapiClusterOwnerLabel,
+			CapiClusterOwnerNamespaceLabel: e2e.CapiClusterOwnerNamespaceLabel,
+			OwnedLabelName:                 e2e.OwnedLabelName,
+			FixedNamespace:                 fixedNamespace,
+		}
+
 	})
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds e2e testing for the Azure/RKE2 ClusterClass.

Note that the `v1.31.1+rke2r1` version is hardcoded, as it depends on the Azure cloud provider ClusterResourceSet.
There's no way to make this dynamic at the moment. 

This would need a refactor to use CAAPF for both documentation and testing, maybe.

Test run: https://github.com/rancher/turtles/actions/runs/13918769837

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
