### PR TITLE
Set `GH_TOKEN` env variable to properly generate `RELEASE_NOTES.md` file

### DIFF
--- a/.github/workflows/nightly-chart-and-image-publish.yaml
+++ b/.github/workflows/nightly-chart-and-image-publish.yaml
@@ -7,6 +7,7 @@ on:
 
 env:
   TAG: v0.0.0-${{ github.sha }}
+  GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   REGISTRY: ghcr.io
   PROD_ORG: rancher
 

--- a/.github/workflows/nightly-test-release.yaml
+++ b/.github/workflows/nightly-test-release.yaml
@@ -7,6 +7,7 @@ on:
 
 env:
   RELEASE_TAG: t9.9.9-fake
+  GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
 jobs:
   nightly-test-release:

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -52,6 +52,7 @@ jobs:
       PROD_ORG: rancher
       RELEASE_DIR: .cr-release-packages
       CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -9,6 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   TAG: v0.0.1
   RELEASE_TAG: v0.0.1
   MANIFEST_IMG: controller


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Set `GH_TOKEN` env variable in all GHAs' where `Package operator chart` step is run (which under the hood runs [make release-chart](https://github.com/rancher/turtles/blob/main/Makefile#L579-L582)) to make sure `RELEASE_NOTES.md` is generated properly
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1084 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
