### PR TITLE
Switch CAPD+Kubeadm test to clusterclass in e2e

### DIFF
--- a/test/e2e/data/cluster-templates/docker-kubeadm.yaml
+++ b/test/e2e/data/cluster-templates/docker-kubeadm.yaml
@@ -1,59 +1,46 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: DockerCluster
-metadata:
-  name: ${CLUSTER_NAME}
-  namespace: "${NAMESPACE}"
-  annotations:
-    "helm.sh/resource-policy": keep
-spec:
-  failureDomains:
-    fd1:
-      controlPlane: true
-    fd2:
-      controlPlane: true
-    fd3:
-      controlPlane: true
-    fd4:
-      controlPlane: false
-    fd5:
-      controlPlane: false
-    fd6:
-      controlPlane: false
-    fd7:
-      controlPlane: false
-    fd8:
-      controlPlane: false
----
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  labels:
-    cni: ${CLUSTER_NAME}-crs-0
   name: ${CLUSTER_NAME}
-  namespace: "${NAMESPACE}"
+  namespace: ${NAMESPACE}
+  labels:
+    cni: kindnet
 spec:
   clusterNetwork:
     pods:
       cidrBlocks:
         - 10.1.0.0/16
+    serviceDomain: cluster.local
     services:
       cidrBlocks:
         - 10.10.0.0/16
   topology:
     class: ${CLUSTER_CLASS_NAME}
+    controlPlane:
+      metadata: {}
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     version: ${KUBERNETES_VERSION}
     workers:
       machineDeployments:
         - class: default-worker
-          name: ${CLUSTER_NAME}-worker
+          name: md-0
+          replicas: ${WORKER_MACHINE_COUNT}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
   name: ${CLUSTER_CLASS_NAME}
-  namespace: "${NAMESPACE}"
+  namespace: ${NAMESPACE}
 spec:
   controlPlane:
+    machineHealthCheck:
+      unhealthyConditions:
+        - status: Unknown
+          timeout: 300s
+          type: Ready
+        - status: "False"
+          timeout: 300s
+          type: Ready
     machineInfrastructure:
       ref:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -68,6 +55,28 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: DockerClusterTemplate
       name: ${CLUSTER_NAME}-cluster
+  workers:
+    machineDeployments:
+      - class: default-worker
+        machineHealthCheck:
+          unhealthyConditions:
+            - status: Unknown
+              timeout: 300s
+              type: Ready
+            - status: "False"
+              timeout: 300s
+              type: Ready
+        template:
+          bootstrap:
+            ref:
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              kind: KubeadmConfigTemplate
+              name: ${CLUSTER_NAME}-default-worker-bootstraptemplate
+          infrastructure:
+            ref:
+              apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+              kind: DockerMachineTemplate
+              name: ${CLUSTER_NAME}-default-worker-machinetemplate
   patches:
     - definitions:
         - jsonPatches:
@@ -238,43 +247,24 @@ spec:
                 mode. One of privileged, baseline, restricted.
               type: string
           type: object
-  workers:
-    machineDeployments:
-      - class: default-worker
-        template:
-          bootstrap:
-            ref:
-              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-              kind: KubeadmConfigTemplate
-              name: ${CLUSTER_NAME}-default-worker-bootstraptemplate
-          infrastructure:
-            ref:
-              apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-              kind: DockerMachineTemplate
-              name: ${CLUSTER_NAME}-default-worker-machinetemplate
+
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate
 metadata:
   name: ${CLUSTER_NAME}-cluster
-  namespace: "${NAMESPACE}"
+  namespace: ${NAMESPACE}
 spec:
   template:
-    metadata:
-      annotations:
-        "helm.sh/resource-policy": keep
     spec: {}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlaneTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
-  namespace: "${NAMESPACE}"
+  namespace: ${NAMESPACE}
 spec:
   template:
-    metadata:
-      annotations:
-        "helm.sh/resource-policy": keep
     spec:
       kubeadmConfigSpec:
         clusterConfiguration:
@@ -296,7 +286,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
-  namespace: "${NAMESPACE}"
+  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -308,7 +298,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-default-worker-machinetemplate
-  namespace: "${NAMESPACE}"
+  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -320,7 +310,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-default-worker-bootstraptemplate
-  namespace: "${NAMESPACE}"
+  namespace: ${NAMESPACE}
 spec:
   template:
     spec:

--- a/test/e2e/data/cluster-templates/docker-kubeadm.yaml
+++ b/test/e2e/data/cluster-templates/docker-kubeadm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
   labels:
-    cni: kindnet
+    cni: ${CLUSTER_NAME}-crs-0
 spec:
   clusterNetwork:
     pods:

--- a/test/e2e/data/cluster-templates/docker-kubeadm.yaml
+++ b/test/e2e/data/cluster-templates/docker-kubeadm.yaml
@@ -35,120 +35,294 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-      - 10.1.0.0/16
-    serviceDomain: cluster.local
+        - 10.1.0.0/16
     services:
       cidrBlocks:
-      - 10.10.0.0/16
-  controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-    kind: KubeadmControlPlane
-    name: ${CLUSTER_NAME}-control-plane
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: DockerCluster
-    name: ${CLUSTER_NAME}
+        - 10.10.0.0/16
+  topology:
+    class: ${CLUSTER_CLASS_NAME}
+    version: ${KUBERNETES_VERSION}
+    workers:
+      machineDeployments:
+        - class: default-worker
+          name: ${CLUSTER_NAME}-worker
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: ${CLUSTER_CLASS_NAME}
+  namespace: "${NAMESPACE}"
+spec:
+  controlPlane:
+    machineInfrastructure:
+      ref:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        name: ${CLUSTER_NAME}-control-plane
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlaneTemplate
+      name: ${CLUSTER_NAME}-control-plane
+  infrastructure:
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerClusterTemplate
+      name: ${CLUSTER_NAME}-cluster
+  patches:
+    - definitions:
+        - jsonPatches:
+            - op: add
+              path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/imageRepository
+              valueFrom:
+                variable: imageRepository
+          selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            kind: KubeadmControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+      description: Sets the imageRepository used for the KubeadmControlPlane.
+      enabledIf: '{{ ne .imageRepository "" }}'
+      name: imageRepository
+    - definitions:
+        - jsonPatches:
+            - op: add
+              path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd
+              valueFrom:
+                template: |
+                  local:
+                    imageTag: {{ .etcdImageTag }}
+          selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            kind: KubeadmControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+      description: Sets tag to use for the etcd image in the KubeadmControlPlane.
+      name: etcdImageTag
+    - definitions:
+        - jsonPatches:
+            - op: add
+              path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/dns
+              valueFrom:
+                template: |
+                  imageTag: {{ .coreDNSImageTag }}
+          selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            kind: KubeadmControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+      description: Sets tag to use for the etcd image in the KubeadmControlPlane.
+      name: coreDNSImageTag
+    - definitions:
+        - jsonPatches:
+            - op: add
+              path: /spec/template/spec/customImage
+              valueFrom:
+                template: |
+                  kindest/node:{{ .builtin.machineDeployment.version | replace "+" "_" }}
+          selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: DockerMachineTemplate
+            matchResources:
+              machineDeploymentClass:
+                names:
+                  - default-worker
+        - jsonPatches:
+            - op: add
+              path: /spec/template/spec/customImage
+              valueFrom:
+                template: |
+                  kindest/node:{{ .builtin.controlPlane.version | replace "+" "_" }}
+          selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: DockerMachineTemplate
+            matchResources:
+              controlPlane: true
+      description: Sets the container image that is used for running dockerMachines
+        for the controlPlane and default-worker machineDeployments.
+      name: customImage
+    - definitions:
+        - jsonPatches:
+            - op: add
+              path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs
+              value:
+                admission-control-config-file: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+            - op: add
+              path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes
+              value:
+                - hostPath: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+                  mountPath: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+                  name: admission-pss
+                  pathType: File
+                  readOnly: true
+            - op: add
+              path: /spec/template/spec/kubeadmConfigSpec/files
+              valueFrom:
+                template: |
+                  - content: |
+                      apiVersion: apiserver.config.k8s.io/v1
+                      kind: AdmissionConfiguration
+                      plugins:
+                      - name: PodSecurity
+                        configuration:
+                          apiVersion: pod-security.admission.config.k8s.io/v1{{ if semverCompare "< v1.25" .builtin.controlPlane.version }}beta1{{ end }}
+                          kind: PodSecurityConfiguration
+                          defaults:
+                            enforce: "{{ .podSecurityStandard.enforce }}"
+                            enforce-version: "latest"
+                            audit: "{{ .podSecurityStandard.audit }}"
+                            audit-version: "latest"
+                            warn: "{{ .podSecurityStandard.warn }}"
+                            warn-version: "latest"
+                          exemptions:
+                            usernames: []
+                            runtimeClasses: []
+                            namespaces: [kube-system]
+                    path: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+          selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            kind: KubeadmControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+      description: Adds an admission configuration for PodSecurity to the kube-apiserver.
+      enabledIf: '{{ .podSecurityStandard.enabled }}'
+      name: podSecurityStandard
+  variables:
+    - name: imageRepository
+      required: true
+      schema:
+        openAPIV3Schema:
+          default: ""
+          description: imageRepository sets the container registry to pull images from.
+            If empty, nothing will be set and the from of kubeadm will be used.
+          example: registry.k8s.io
+          type: string
+    - name: etcdImageTag
+      required: true
+      schema:
+        openAPIV3Schema:
+          default: ""
+          description: etcdImageTag sets the tag for the etcd image.
+          example: 3.5.3-0
+          type: string
+    - name: coreDNSImageTag
+      required: true
+      schema:
+        openAPIV3Schema:
+          default: ""
+          description: coreDNSImageTag sets the tag for the coreDNS image.
+          example: v1.8.5
+          type: string
+    - name: podSecurityStandard
+      required: false
+      schema:
+        openAPIV3Schema:
+          properties:
+            audit:
+              default: restricted
+              description: audit sets the level for the audit PodSecurityConfiguration
+                mode. One of privileged, baseline, restricted.
+              type: string
+            enabled:
+              default: true
+              description: enabled enables the patches to enable Pod Security Standard
+                via AdmissionConfiguration.
+              type: boolean
+            enforce:
+              default: baseline
+              description: enforce sets the level for the enforce PodSecurityConfiguration
+                mode. One of privileged, baseline, restricted.
+              type: string
+            warn:
+              default: restricted
+              description: warn sets the level for the warn PodSecurityConfiguration
+                mode. One of privileged, baseline, restricted.
+              type: string
+          type: object
+  workers:
+    machineDeployments:
+      - class: default-worker
+        template:
+          bootstrap:
+            ref:
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              kind: KubeadmConfigTemplate
+              name: ${CLUSTER_NAME}-default-worker-bootstraptemplate
+          infrastructure:
+            ref:
+              apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+              kind: DockerMachineTemplate
+              name: ${CLUSTER_NAME}-default-worker-machinetemplate
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: DockerMachineTemplate
+kind: DockerClusterTemplate
 metadata:
-  name: ${CLUSTER_NAME}-control-plane
+  name: ${CLUSTER_NAME}-cluster
   namespace: "${NAMESPACE}"
 spec:
   template:
-    spec:
-      extraMounts:
-      - containerPath: /var/run/docker.sock
-        hostPath: /var/run/docker.sock
+    metadata:
+      annotations:
+        "helm.sh/resource-policy": keep
+    spec: {}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-kind: KubeadmControlPlane
+kind: KubeadmControlPlaneTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
   namespace: "${NAMESPACE}"
-  annotations:
-    "helm.sh/resource-policy": keep
 spec:
-  kubeadmConfigSpec:
-    clusterConfiguration:
-      apiServer:
-        certSANs:
-        - localhost
-        - 127.0.0.1
-        - 0.0.0.0
-        - host.docker.internal
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
-    initConfiguration:
-      nodeRegistration:
-        criSocket: unix:///var/run/containerd/containerd.sock
-        kubeletExtraArgs:
-          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-    joinConfiguration:
-      nodeRegistration:
-        criSocket: unix:///var/run/containerd/containerd.sock
-        kubeletExtraArgs:
-          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: DockerMachineTemplate
-      name: ${CLUSTER_NAME}-control-plane
-  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
-  version: ${KUBERNETES_VERSION}
+  template:
+    metadata:
+      annotations:
+        "helm.sh/resource-policy": keep
+    spec:
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          apiServer:
+            certSANs:
+              - localhost
+              - 127.0.0.1
+              - 0.0.0.0
+              - host.docker.internal
+          controllerManager:
+            extraArgs:
+              enable-hostpath-provisioner: "true"
+        initConfiguration:
+          nodeRegistration: {}
+        joinConfiguration:
+          nodeRegistration: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}-control-plane
   namespace: "${NAMESPACE}"
 spec:
   template:
     spec:
       extraMounts:
-      - containerPath: /var/run/docker.sock
-        hostPath: /var/run/docker.sock
+        - containerPath: /var/run/docker.sock
+          hostPath: /var/run/docker.sock
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-default-worker-machinetemplate
+  namespace: "${NAMESPACE}"
+spec:
+  template:
+    spec:
+      extraMounts:
+        - containerPath: /var/run/docker.sock
+          hostPath: /var/run/docker.sock
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}-default-worker-bootstraptemplate
   namespace: "${NAMESPACE}"
-  annotations:
-    "helm.sh/resource-policy": keep
 spec:
   template:
     spec:
       joinConfiguration:
-        nodeRegistration:
-          criSocket: unix:///var/run/containerd/containerd.sock
-          kubeletExtraArgs:
-            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
----
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: MachineDeployment
-metadata:
-  name: ${CLUSTER_NAME}-md-0
-  namespace: "${NAMESPACE}"
-  annotations:
-    "helm.sh/resource-policy": keep
-spec:
-  clusterName: ${CLUSTER_NAME}
-  replicas: ${WORKER_MACHINE_COUNT}
-  selector:
-    matchLabels: null
-  template:
-    spec:
-      bootstrap:
-        configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-          kind: KubeadmConfigTemplate
-          name: ${CLUSTER_NAME}-md-0
-      clusterName: ${CLUSTER_NAME}
-      failureDomain: fd4
-      infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: DockerMachineTemplate
-        name: ${CLUSTER_NAME}-md-0
-      version: ${KUBERNETES_VERSION}
+        nodeRegistration: {}

--- a/test/e2e/data/cni/kindnet.yaml
+++ b/test/e2e/data/cni/kindnet.yaml
@@ -127,4 +127,4 @@ spec:
   targets:
   - clusterSelector:
       matchLabels:
-        cni: ${CLUSTER_NAME}-crs-0
+        cni: kindnet

--- a/test/e2e/data/cni/kindnet.yaml
+++ b/test/e2e/data/cni/kindnet.yaml
@@ -127,4 +127,4 @@ spec:
   targets:
   - clusterSelector:
       matchLabels:
-        cni: kindnet
+        cni: ${CLUSTER_NAME}-crs-0

--- a/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
+++ b/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/rancher/turtles/test/testenv"
 )
 
-var _ = FDescribe("[Docker] [Kubeadm]  Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.ShortTestLabel), func() {
+var _ = Describe("[Docker] [Kubeadm]  Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.ShortTestLabel), func() {
 	BeforeEach(func() {
 		komega.SetClient(bootstrapClusterProxy.GetClient())
 		komega.SetContext(ctx)

--- a/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
+++ b/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/rancher/turtles/test/testenv"
 )
 
-var _ = Describe("[Docker] [Kubeadm]  Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.ShortTestLabel), func() {
+var _ = FDescribe("[Docker] [Kubeadm]  Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.ShortTestLabel), func() {
 	BeforeEach(func() {
 		komega.SetClient(bootstrapClusterProxy.GetClient())
 		komega.SetContext(ctx)

--- a/test/e2e/suites/import-gitops-v3/suite_test.go
+++ b/test/e2e/suites/import-gitops-v3/suite_test.go
@@ -25,12 +25,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rancher/turtles/test/e2e"
-	"github.com/rancher/turtles/test/testenv"
 	"k8s.io/apimachinery/pkg/util/json"
 	capiframework "sigs.k8s.io/cluster-api/test/framework"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/rancher/turtles/test/e2e"
+	"github.com/rancher/turtles/test/testenv"
 )
 
 // Test suite global vars.


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->
kind/refactor
**What this PR does / why we need it**:
This PR switches CAPD+kubeadm cluster test to use clusterclass.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1152 

**Special notes for your reviewer**:
One problem that needs to be addressed is that after the git repo is deleted, all dependent resources except ClusterClass are deleted. I am not sure yet why ClusterClass is retained.


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests
