### PR TITLE
Add AKS ClusterClass example

### DIFF
--- a/examples/clusterclasses/azure/clusterclass-aks-example.yaml
+++ b/examples/clusterclasses/azure/clusterclass-aks-example.yaml
@@ -1,0 +1,210 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: azure-aks-example
+spec:
+  controlPlane:
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: AzureManagedControlPlaneTemplate
+      name: aks-control-plane
+  infrastructure:
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: AzureManagedClusterTemplate
+      name: aks-cluster
+  workers:
+    machinePools:
+    - class: default-system
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: RKE2ConfigTemplate
+            name: aks-dummy-system
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: AzureManagedMachinePoolTemplate
+            name: aks-default-system
+    - class: default-worker
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: RKE2ConfigTemplate
+            name: aks-dummy-worker
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: AzureManagedMachinePoolTemplate
+            name: aks-default-worker
+  variables:
+    - name: subscriptionID
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: "The Azure Subscription ID where the Cluster will be created."
+          type: string
+    - name: location
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: "The Azure location where the Cluster will be created."
+          type: string
+          enum:
+            - australiaeast
+            - eastus
+            - eastus2
+            - francecentral
+            - germanywestcentral
+            - northcentralus
+            - northeurope
+            - switzerlandnorth
+            - uksouth
+            - westeurope
+            - westus2
+    - name: resourceGroup
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: "The Azure Resource Group where the Cluster will be created."
+          type: string
+    - name: azureClusterIdentityName
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: "The AzureClusterIdentity resource name referencing the credentials to create the Cluster."
+          type: string
+          default: "cluster-identity"
+    - name: autoUpgradeChannel
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: "The Cluster auto-upgrade channel. Use 'none' to disable auto upgrades."
+          type: string
+          enum:
+            - none
+            - patch
+            - stable
+            - rapid
+          default: stable
+    - name: sku
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: "The size of the VMs in the node pool"
+          type: string
+          default: Standard_D2s_v3
+  patches:
+    - name: azureManagedControlPlaneTemplate
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: AzureManagedControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+            - op: add
+              path: "/spec/template/spec/subscriptionID"
+              valueFrom:
+                variable: subscriptionID
+            - op: add
+              path: "/spec/template/spec/location"
+              valueFrom:
+                variable: location
+            - op: add
+              path: "/spec/template/spec/resourceGroupName"
+              valueFrom:
+                variable: resourceGroup
+            - op: add
+              path: "/spec/template/spec/identityRef/name"
+              valueFrom:
+                variable: azureClusterIdentityName
+            - op: add
+              path: "/spec/template/spec/autoUpgradeProfile/upgradeChannel"
+              valueFrom:
+                variable: autoUpgradeChannel
+            # Builtins
+            - op: add
+              path: "/spec/template/spec/version"
+              valueFrom:
+                variable: builtin.cluster.topology.version
+    - name: azureManagedMachinePoolTemplate
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: AzureManagedMachinePoolTemplate
+            matchResources:
+              machinePoolClass:
+                names:
+                  - default-system
+                  - default-worker
+          jsonPatches:
+            - op: add
+              path: "/spec/template/spec/sku"
+              valueFrom:
+                variable: sku
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedControlPlaneTemplate
+metadata:
+  name: aks-control-plane
+spec:
+  template:
+    spec:
+      identityRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureClusterIdentity
+        name: cluster-identity
+      version: "v0.0.0" #To be replaced by patch
+      autoUpgradeProfile:
+        upgradeChannel: none
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedClusterTemplate
+metadata:
+  name: aks-cluster
+spec:
+  template:
+    spec: {}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedMachinePoolTemplate
+metadata:
+  name: aks-default-system
+spec:
+  template:
+    spec:
+      mode: System
+      name: "system" #To be replaced by patch
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedMachinePoolTemplate
+metadata:
+  name: aks-default-worker
+spec:
+  template:
+    spec:
+      mode: User
+      name: "worker" #To be replaced by patch
+--- 
+# These RKE2ConfigTemplates are only referenced to fulfill the CAPI contract.
+# This requires however the cluster-api-provider-rke2 to be installed.
+# It can be replaced by KubeadmConfigTemplates.
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: RKE2ConfigTemplate
+metadata:
+  name: aks-dummy-worker
+spec:
+  template:
+    spec: {}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: RKE2ConfigTemplate
+metadata:
+  name: aks-dummy-system
+spec:
+  template:
+    spec: {}
+

--- a/examples/clusterclasses/azure/clusterclass-example.yaml
+++ b/examples/clusterclasses/azure/clusterclass-example.yaml
@@ -69,6 +69,7 @@ spec:
         openAPIV3Schema:
           description: "The AzureClusterIdentity resource name referencing the credentials to create the Cluster."
           type: string
+          default: "cluster-identity"
     - name: imageGallery
       required: true
       schema:

--- a/test/e2e/data/capi-operator/azure-provider.yaml
+++ b/test/e2e/data/capi-operator/azure-provider.yaml
@@ -6,8 +6,3 @@ metadata:
   namespace: capz-system
 spec:
   type: infrastructure
-  deployment:
-    containers:
-      - name: manager
-        args:
-          "--v": "5" # CAPZ only displays meaningful logs at level 5

--- a/test/e2e/data/cluster-templates/azure-aks-topology.yaml
+++ b/test/e2e/data/cluster-templates/azure-aks-topology.yaml
@@ -1,114 +1,3 @@
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: ClusterClass
-metadata:
-  name: ${CLUSTER_CLASS_NAME}
-  namespace: "${NAMESPACE}"
-spec:
-  controlPlane:
-    ref:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: AzureManagedControlPlaneTemplate
-      name: ${CLUSTER_NAME}-control-plane
-  infrastructure:
-    ref:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: AzureManagedClusterTemplate
-      name: ${CLUSTER_NAME}
-  workers:
-    machinePools:
-    - class: default-system
-      template:
-        bootstrap:
-          ref:
-            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-            kind: RKE2ConfigTemplate
-            name: ${CLUSTER_NAME}-pool0
-        infrastructure:
-          ref:
-            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-            kind: AzureManagedMachinePoolTemplate
-            name: ${CLUSTER_NAME}-pool0
-    - class: default-worker
-      template:
-        bootstrap:
-          ref:
-            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-            kind: RKE2ConfigTemplate
-            name: ${CLUSTER_NAME}-pool1
-        infrastructure:
-          ref:
-            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-            kind: AzureManagedMachinePoolTemplate
-            name: ${CLUSTER_NAME}-pool1
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: AzureManagedControlPlaneTemplate
-metadata:
-  name: ${CLUSTER_NAME}-control-plane
-  namespace: "${NAMESPACE}"
-spec:
-  template:
-    spec:
-      identityRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: AzureClusterIdentity
-        name: cluster-identity
-      location: southcentralus
-      resourceGroupName: highlander-e2e-azure-aks
-      subscriptionID: ${AZURE_SUBSCRIPTION_ID}
-      version: ${KUBERNETES_VERSION}
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: AzureManagedClusterTemplate
-metadata:
-  name: ${CLUSTER_NAME}
-  namespace: "${NAMESPACE}"
-spec:
-  template:
-    spec: {}
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: AzureManagedMachinePoolTemplate
-metadata:
-  name: ${CLUSTER_NAME}-pool0
-  namespace: "${NAMESPACE}"
-spec:
-  template:
-    spec:
-      mode: System
-      name: pool0
-      sku: Standard_D2s_v3
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: AzureManagedMachinePoolTemplate
-metadata:
-  name: ${CLUSTER_NAME}-pool1
-  namespace: "${NAMESPACE}"
-spec:
-  template:
-    spec:
-      mode: User
-      name: pool1
-      sku: Standard_D2s_v3
----
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-kind: RKE2ConfigTemplate
-metadata:
-  name: ${CLUSTER_NAME}-pool0
-  namespace: "${NAMESPACE}"
-spec:
-  template:
-    spec: {}
----
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-kind: RKE2ConfigTemplate
-metadata:
-  name: ${CLUSTER_NAME}-pool1
-  namespace: "${NAMESPACE}"
-spec:
-  template:
-    spec: {}
----
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureClusterIdentity
 metadata:
@@ -138,13 +27,22 @@ spec:
       cidrBlocks:
       - 192.168.0.0/16
   topology:
-    class: ${CLUSTER_CLASS_NAME}
+    class: azure-aks-example
+    variables:
+    - name: subscriptionID
+      value: ${AZURE_SUBSCRIPTION_ID}
+    - name: location
+      value: germanywestcentral
+    - name: resourceGroup
+      value: highlander-e2e-azure-aks
+    - name: azureClusterIdentityName
+      value: cluster-identity
     version: ${KUBERNETES_VERSION}
     workers:
       machinePools:
       - class: default-system
-        name: mp-0
+        name: system-1
         replicas: 1
       - class: default-worker
-        name: mp-1
+        name: worker-1
         replicas: 1

--- a/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
+++ b/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
@@ -132,13 +132,20 @@ var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster clas
 			},
 		})
 
+		// Add the needed ClusterClass
+		fixedNamespace := "creategitops-azure-aks"
+		Expect(turtlesframework.CreateNamespace(ctx, bootstrapClusterProxy, fixedNamespace)).Should(Succeed())
+		clusterClass, err := os.ReadFile("../../../../examples/clusterclasses/azure/clusterclass-aks-example.yaml")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(turtlesframework.Apply(ctx, bootstrapClusterProxy, clusterClass, "-n", fixedNamespace)).Should(Succeed())
+
 		return specs.CreateMgmtV3UsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAzureAKSTopology,
 			ClusterName:                    "cluster-aks",
-			ControlPlaneMachineCount:       ptr.To[int](1),
-			WorkerMachineCount:             ptr.To[int](1),
+			ControlPlaneMachineCount:       ptr.To(1),
+			WorkerMachineCount:             ptr.To(1),
 			GitAddr:                        gitAddress,
 			SkipDeletionTest:               false,
 			LabelNamespace:                 true,
@@ -148,6 +155,7 @@ var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster clas
 			CapiClusterOwnerLabel:          e2e.CapiClusterOwnerLabel,
 			CapiClusterOwnerNamespaceLabel: e2e.CapiClusterOwnerNamespaceLabel,
 			OwnedLabelName:                 e2e.OwnedLabelName,
+			FixedNamespace:                 fixedNamespace,
 		}
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR converts the AKS ClusterClass used for testing, into a slightly configurable example.
Documentation PR: https://github.com/rancher/turtles-docs/pull/262
Test run: https://github.com/rancher/turtles/actions/runs/13952503039 (Some other tests fail for other reasons, but the AKS one succeeds)

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
