### PR TITLE
Embed example clusterclasses in e2e suite

### DIFF
--- a/examples/examples.go
+++ b/examples/examples.go
@@ -1,0 +1,30 @@
+/*
+Copyright © 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package examples
+
+import _ "embed"
+
+var (
+	//go:embed applications/azure/clusterresourceset-cloud-provider.yaml
+	CAPIAzureCPI []byte
+
+	//go:embed clusterclasses/azure/clusterclass-aks-example.yaml
+	CAPIAzureAKSClusterclass []byte
+
+	//go:embed clusterclasses/azure/clusterclass-example.yaml
+	CAPIAzureRKE2Clusterclass []byte
+)

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -57,16 +57,13 @@ type Setup struct {
 	RancherHostname string
 }
 
-func SetupSpecNamespace(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder string, fixedNamespace string) (*corev1.Namespace, context.CancelFunc) {
+func SetupSpecNamespace(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder string) (*corev1.Namespace, context.CancelFunc) {
 	turtlesframework.Byf("Creating a namespace for hosting the %q test spec", specName)
-	namespaceName := fixedNamespace
-	if namespaceName == "" {
-		namespaceName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
-	}
+
 	namespace, cancelWatches := framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
 		Creator:             clusterProxy.GetClient(),
 		ClientSet:           clusterProxy.GetClientSet(),
-		Name:                namespaceName,
+		Name:                fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
 		LogFolder:           filepath.Join(artifactFolder, "clusters", clusterProxy.GetName()),
 		IgnoreAlreadyExists: true,
 	})

--- a/test/e2e/specs/etcd_snapshot_restore.go
+++ b/test/e2e/specs/etcd_snapshot_restore.go
@@ -76,9 +76,6 @@ type ETCDSnapshotRestoreInput struct {
 
 	SkipCleanup      bool `env:"SKIP_RESOURCE_CLEANUP"`
 	SkipDeletionTest bool `env:"SKIP_DELETION_TEST"`
-
-	// A fixed Namespace to run the spec in, instead of generating a random one.
-	FixedNamespace string
 }
 
 // CreateUsingGitOpsSpec implements a spec that will create a cluster via Fleet and test that it
@@ -147,7 +144,7 @@ func ETCDSnapshotRestore(ctx context.Context, inputGetter func() ETCDSnapshotRes
 		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
 
 		Expect(input.E2EConfig.Variables).To(HaveKey(e2e.KubernetesManagementVersionVar))
-		namespace, cancelWatches = e2e.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, input.FixedNamespace)
+		namespace, cancelWatches = e2e.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
 		repoName = e2e.CreateRepoName(specName)
 
 		capiClusterCreateWait = input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), input.CAPIClusterCreateWaitName)

--- a/test/e2e/specs/import_gitops_mgmtv3.go
+++ b/test/e2e/specs/import_gitops_mgmtv3.go
@@ -89,9 +89,6 @@ type CreateMgmtV3UsingGitOpsSpecInput struct {
 
 	// IsGCPCluster is used to substitute GCP-specific values from secrets
 	IsGCPCluster bool
-
-	// A fixed Namespace to run the spec in, instead of generating a random one.
-	FixedNamespace string
 }
 
 // CreateMgmtV3UsingGitOpsSpec implements a spec that will create a cluster via Fleet and test that it
@@ -184,7 +181,7 @@ func CreateMgmtV3UsingGitOpsSpec(ctx context.Context, inputGetter func() CreateM
 		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
 
 		Expect(input.E2EConfig.Variables).To(HaveKey(e2e.KubernetesManagementVersionVar))
-		namespace, cancelWatches = e2e.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, input.FixedNamespace)
+		namespace, cancelWatches = e2e.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
 		repoName = e2e.CreateRepoName(specName)
 
 		capiClusterCreateWait = input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), input.CAPIClusterCreateWaitName)

--- a/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
+++ b/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
@@ -20,19 +20,15 @@ limitations under the License.
 package import_gitops_v3
 
 import (
-	"os"
-
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 
 	"k8s.io/utils/ptr"
 
+	"github.com/rancher/turtles/examples"
 	"github.com/rancher/turtles/test/e2e"
 	"github.com/rancher/turtles/test/e2e/specs"
 	"github.com/rancher/turtles/test/testenv"
-
-	turtlesframework "github.com/rancher/turtles/test/framework"
 )
 
 var _ = Describe("[Docker] [Kubeadm]  Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.ShortTestLabel), func() {
@@ -130,17 +126,11 @@ var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster clas
 			},
 		})
 
-		// Add the needed ClusterClass
-		fixedNamespace := "creategitops-azure-aks"
-		Expect(turtlesframework.CreateNamespace(ctx, bootstrapClusterProxy, fixedNamespace)).Should(Succeed())
-		clusterClass, err := os.ReadFile("../../../../examples/clusterclasses/azure/clusterclass-aks-example.yaml")
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(turtlesframework.Apply(ctx, bootstrapClusterProxy, clusterClass, "-n", fixedNamespace)).Should(Succeed())
-
 		return specs.CreateMgmtV3UsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAzureAKSTopology,
+			AdditionalTemplates:            [][]byte{examples.CAPIAzureAKSClusterclass},
 			ClusterName:                    "cluster-aks",
 			ControlPlaneMachineCount:       ptr.To(1),
 			WorkerMachineCount:             ptr.To(1),
@@ -152,7 +142,6 @@ var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster clas
 			CapiClusterOwnerLabel:          e2e.CapiClusterOwnerLabel,
 			CapiClusterOwnerNamespaceLabel: e2e.CapiClusterOwnerNamespaceLabel,
 			OwnedLabelName:                 e2e.OwnedLabelName,
-			FixedNamespace:                 fixedNamespace,
 		}
 	})
 })
@@ -180,20 +169,11 @@ var _ = Describe("[Azure] [RKE2] - [management.cattle.io/v3] Create and delete C
 			},
 		})
 
-		// Add the needed ClusterClass and ClusterResourceSet
-		fixedNamespace := "creategitops-azure-rke2"
-		Expect(turtlesframework.CreateNamespace(ctx, bootstrapClusterProxy, fixedNamespace)).Should(Succeed())
-		clusterClass, err := os.ReadFile("../../../../examples/clusterclasses/azure/clusterclass-example.yaml")
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(turtlesframework.Apply(ctx, bootstrapClusterProxy, clusterClass, "-n", fixedNamespace)).Should(Succeed())
-		cloudProvider, err := os.ReadFile("../../../../examples/applications/azure/clusterresourceset-cloud-provider.yaml")
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(turtlesframework.Apply(ctx, bootstrapClusterProxy, cloudProvider, "-n", fixedNamespace)).Should(Succeed())
-
 		return specs.CreateMgmtV3UsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAzureRKE2Topology,
+			AdditionalTemplates:            [][]byte{examples.CAPIAzureRKE2Clusterclass, examples.CAPIAzureCPI},
 			ClusterName:                    "cluster-azure-rke2",
 			ControlPlaneMachineCount:       ptr.To(1),
 			WorkerMachineCount:             ptr.To(1),
@@ -206,7 +186,6 @@ var _ = Describe("[Azure] [RKE2] - [management.cattle.io/v3] Create and delete C
 			CapiClusterOwnerLabel:          e2e.CapiClusterOwnerLabel,
 			CapiClusterOwnerNamespaceLabel: e2e.CapiClusterOwnerNamespaceLabel,
 			OwnedLabelName:                 e2e.OwnedLabelName,
-			FixedNamespace:                 fixedNamespace,
 		}
 
 	})


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Embed example clusterclasses in e2e suite, this should the code more readable

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
