### PR TITLE
Add clusterName in GCPManagedControlPlaneSpec e2e template

### DIFF
--- a/test/e2e/data/cluster-templates/gcp-gke.yaml
+++ b/test/e2e/data/cluster-templates/gcp-gke.yaml
@@ -34,6 +34,7 @@ metadata:
   name: "${CLUSTER_NAME}-control-plane"
   namespace: "${NAMESPACE}"
 spec:
+  clusterName: "${CLUSTER_NAME}"
   project: "${GCP_PROJECT}"
   location: "${GCP_REGION}"
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
As per [CRD](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/main/config/crd/bases/infrastructure.cluster.x-k8s.io_gcpmanagedcontrolplanes.yaml#L69), added this field to name GKE cluster properly.
It would avoid naming of GKE cluster as `capg-*`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
