### PR TITLE
Fix nightly GHA inputs referenced in e2e_import_gitops_v3 test

### DIFF
--- a/.github/workflows/e2e-long.yaml
+++ b/.github/workflows/e2e-long.yaml
@@ -29,8 +29,8 @@ jobs:
       run_azure_janitor: true
       artifact_name: artifacts_import_gitops_v3
       MANAGEMENT_CLUSTER_ENVIRONMENT: eks
-      skip_resource_cleanup: ${{ inputs.skip_resource_cleanup }}
-      skip_deletion_test: ${{ inputs.skip_deletion_test }}
+      skip_resource_cleanup: ${{ inputs.skip_resource_cleanup != '' && inputs.skip_resource_cleanup || false }}
+      skip_deletion_test: ${{ inputs.skip_deletion_test != '' && inputs.skip_deletion_test || false }}
     secrets: inherit
   e2e_v2prov:
     needs: publish_e2e_image


### PR DESCRIPTION
**What this PR does / why we need it**:
When the current e2e nightly workflow runs automatically via `schedule`, the `inputs` do not exist at all because `schedule` does not support `inputs`. Since `scheduled` runs do not have `inputs`, we need to handle this explicitly to avoid unexpected behavior by setting explicit defaults in workflow. This change ensures `skip_resource_cleanup` and `skip_deletion_test` always have a default value (`false`) when the workflow is triggered automatically (e.g., via `schedule`).

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1217 

**Special notes for your reviewer**:
An example of successful e2e nightly run with this patch: https://github.com/rancher/turtles/actions/runs/14125927364

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
