### PR TITLE
feat: switch capv+cabpk test to clusterclass

### DIFF
--- a/examples/clusterclasses/vsphere/clusterclass-kubeadm-example.yaml
+++ b/examples/clusterclasses/vsphere/clusterclass-kubeadm-example.yaml
@@ -1,0 +1,455 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereClusterTemplate
+metadata:
+  name: 'vsphere-kubeadm-example'
+spec:
+  template:
+    spec: {}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: 'vsphere-kubeadm-example'
+spec:
+  controlPlane:
+    machineInfrastructure:
+      ref:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        name: vsphere-kubeadm-example-template
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlaneTemplate
+      name: vsphere-kubeadm-example-controlplane
+  infrastructure:
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: VSphereClusterTemplate
+      name: 'vsphere-kubeadm-example'
+  patches:
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files
+        value: []
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/postKubeadmCommands
+        value: []
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/files
+        value: []
+      - op: add
+        path: /spec/template/spec/postKubeadmCommands
+        value: []
+      selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - vsphere-kubeadm-example-worker
+    name: createEmptyArrays
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/users
+        valueFrom:
+          template: |
+            - name: capv
+              sshAuthorizedKeys:
+              - '{{ .sshKey }}'
+              sudo: ALL=(ALL) NOPASSWD:ALL
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/users
+        valueFrom:
+          template: |
+            - name: capv
+              sshAuthorizedKeys:
+              - '{{ .sshKey }}'
+              sudo: ALL=(ALL) NOPASSWD:ALL
+      selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - vsphere-kubeadm-example-worker
+    enabledIf: '{{ if .sshKey }}true{{end}}'
+    name: enableSSHIntoNodes
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/controlPlaneEndpoint
+        valueFrom:
+          template: |
+            host: '{{ .controlPlaneIpAddr }}'
+            port: {{ .controlPlanePort }}
+      - op: add
+        path: /spec/template/spec/identityRef
+        valueFrom:
+          template: |
+            kind: Secret
+            name: '{{ .credsSecretName }}'
+      - op: add
+        path: /spec/template/spec/server
+        valueFrom:
+          variable: infraServer.url
+      - op: add
+        path: /spec/template/spec/thumbprint
+        valueFrom:
+          variable: infraServer.thumbprint
+      selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereClusterTemplate
+        matchResources:
+          infrastructureCluster: true
+    name: infraClusterSubstitutions
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: |-
+            owner: "root:root"
+            path: "/etc/kubernetes/manifests/kube-vip.yaml"
+            content: {{ printf "%q" (regexReplaceAll "(name: address\n +value:).*" .kubeVipPodManifest (printf "$1 %s" .controlPlaneIpAddr)) }}
+            permissions: "0644"
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: |
+            content: 127.0.0.1 localhost kubernetes
+            owner: root:root
+            path: /etc/kube-vip.hosts
+            permissions: "0644"
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: |
+            content: |
+              #!/bin/bash
+
+              # Copyright 2020 The Kubernetes Authors.
+              #
+              # Licensed under the Apache License, Version 2.0 (the "License");
+              # you may not use this file except in compliance with the License.
+              # You may obtain a copy of the License at
+              #
+              #     http://www.apache.org/licenses/LICENSE-2.0
+              #
+              # Unless required by applicable law or agreed to in writing, software
+              # distributed under the License is distributed on an "AS IS" BASIS,
+              # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+              # See the License for the specific language governing permissions and
+              # limitations under the License.
+
+              set -e
+
+              # Configure the workaround required for kubeadm init with kube-vip:
+              # xref: https://github.com/kube-vip/kube-vip/issues/684
+
+              # Nothing to do for kubernetes < v1.29
+              KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
+              if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
+                exit 0
+              fi
+
+              IS_KUBEADM_INIT="false"
+
+              # cloud-init kubeadm init
+              if [[ -f /run/kubeadm/kubeadm.yaml ]]; then
+                IS_KUBEADM_INIT="true"
+              fi
+
+              # ignition kubeadm init
+              if [[ -f /etc/kubeadm.sh ]] && grep -q -e "kubeadm init" /etc/kubeadm.sh; then
+                IS_KUBEADM_INIT="true"
+              fi
+
+              if [[ "$IS_KUBEADM_INIT" == "true" ]]; then
+                sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
+                  /etc/kubernetes/manifests/kube-vip.yaml
+              fi
+            owner: root:root
+            path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
+            permissions: "0700"
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    name: kubeVipPodManifest
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec
+        valueFrom:
+          template: |
+            cloneMode: linkedClone
+            datacenter: '{{ .vsphereDataCenter }}'
+            datastore: '{{ .vsphereDataStore }}'
+            diskGiB: 25
+            folder: '{{ .vsphereFolder }}'
+            memoryMiB: 8192
+            network:
+              devices:
+              - dhcp4: true
+                networkName: '{{ .vsphereNetwork }}'
+            numCPUs: 2
+            os: Linux
+            powerOffMode: trySoft
+            resourcePool: '{{ .vsphereResourcePool }}'
+            server: '{{ .vsphereServer }}'
+            storagePolicyName: '{{ .vsphereStorageServer }}'
+            template: '{{ .vsphereTemplate }}'
+      selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          controlPlane: true
+          machineDeploymentClass:
+            names:
+            - vsphere-kubeadm-example-worker
+    name: vsphereMachineTemplateSpec
+  variables:
+  - metadata: {}
+    name: sshKey
+    required: false
+    schema:
+      openAPIV3Schema:
+        description: Public key to SSH onto the cluster nodes.
+        type: string
+  - metadata: {}
+    name: controlPlaneIpAddr
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: Floating VIP for the control plane.
+        type: string
+  - metadata: {}
+    name: controlPlanePort
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: Port for the control plane endpoint.
+        type: integer
+  - metadata: {}
+    name: kubeVipPodManifest
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: kube-vip manifest for the control plane.
+        type: string
+  - metadata: {}
+    name: infraServer
+    required: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          thumbprint:
+            type: string
+          url:
+            type: string
+        type: object
+  - metadata: {}
+    name: credsSecretName
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: Secret containing the credentials for the infra cluster.
+        type: string
+  - metadata: {}
+    name: vsphereDataCenter
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: vSphere data center
+        type: string
+  - metadata: {}
+    name: vsphereDataStore
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: vSphere data store
+        type: string
+  - metadata: {}
+    name: vsphereFolder
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: vSphere folder name
+        type: string
+  - metadata: {}
+    name: vsphereNetwork
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: vSphere network name
+        type: string
+  - metadata: {}
+    name: vsphereResourcePool
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: vSphere resource pool
+        type: string
+  - metadata: {}
+    name: vsphereServer
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: vSphere server
+        type: string
+  - metadata: {}
+    name: vsphereStorageServer
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: vSphere storage server
+        type: string
+  - metadata: {}
+    name: vsphereTemplate
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: vSphere machine template
+        type: string
+  workers:
+    machineDeployments:
+    - class: vsphere-kubeadm-example-worker
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: vsphere-kubeadm-example-worker-bootstrap-template
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: VSphereMachineTemplate
+            name: vsphere-kubeadm-example-worker-machinetemplate
+        metadata: {}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: vsphere-kubeadm-example-template
+spec:
+  template:
+    spec:
+      cloneMode: linkedClone
+      datacenter: 'set-by-patch'
+      datastore: 'set-by-patch'
+      diskGiB: 25
+      folder: 'set-by-patch'
+      memoryMiB: 8192
+      network:
+        devices:
+        - dhcp4: true
+          networkName: 'set-by-patch'
+      numCPUs: 2
+      os: Linux
+      powerOffMode: trySoft
+      resourcePool: 'set-by-patch'
+      server: 'set-by-patch'
+      storagePolicyName: 'set-by-patch'
+      template: 'set-by-patch'
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: vsphere-kubeadm-example-worker-machinetemplate
+spec:
+  template:
+    spec:
+      cloneMode: linkedClone
+      datacenter: 'set-by-patch'
+      datastore: 'set-by-patch'
+      diskGiB: 25
+      folder: 'set-by-patch'
+      memoryMiB: 8192
+      network:
+        devices:
+        - dhcp4: true
+          networkName: 'set-by-patch'
+      numCPUs: 2
+      os: Linux
+      powerOffMode: trySoft
+      resourcePool: 'set-by-patch'
+      server: 'set-by-patch'
+      storagePolicyName: 'set-by-patch'
+      template: 'set-by-patch'
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: vsphere-kubeadm-example-controlplane
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          controllerManager:
+            extraArgs:
+              cloud-provider: external
+        initConfiguration:
+          nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
+            kubeletExtraArgs:
+              cloud-provider: external
+            name: '{{ local_hostname }}'
+        joinConfiguration:
+          nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
+            kubeletExtraArgs:
+              cloud-provider: external
+            name: '{{ local_hostname }}'
+        preKubeadmCommands:
+        - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+        - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6"
+          >/etc/hosts
+        - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
+          localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+        - mkdir -p /etc/pre-kubeadm-commands
+        - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+          do echo "Running script $script"; "$script"; done
+        users:
+        - name: capv
+          sshAuthorizedKeys:
+          - ''
+          sudo: ALL=(ALL) NOPASSWD:ALL
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: vsphere-kubeadm-example-worker-bootstrap-template
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          kubeletExtraArgs:
+            cloud-provider: external
+          name: '{{ local_hostname }}'
+      preKubeadmCommands:
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6"
+        >/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
+        localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+      - mkdir -p /etc/pre-kubeadm-commands
+      - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
+        do echo "Running script $script"; "$script"; done

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -36,4 +36,7 @@ var (
 
 	//go:embed clusterclasses/vsphere/clusterclass-rke2-example.yaml
 	CAPIVSphereRKE2Clusterclass []byte
+
+	//go:embed clusterclasses/vsphere/clusterclass-kubeadm-example.yaml
+	CAPIVsphereKubeadmClusterclass []byte
 )

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -105,8 +105,8 @@ var (
 	//go:embed data/cluster-templates/azure-rke2-topology.yaml
 	CAPIAzureRKE2Topology []byte
 
-	//go:embed data/cluster-templates/vsphere-kubeadm.yaml
-	CAPIvSphereKubeadm []byte
+	//go:embed data/cluster-templates/vsphere-kubeadm-topology.yaml
+	CAPIvSphereKubeadmTopology []byte
 
 	//go:embed data/cluster-templates/vsphere-rke2-topology.yaml
 	CAPIvSphereRKE2Topology []byte

--- a/test/e2e/data/cluster-templates/vsphere-kubeadm-topology.yaml
+++ b/test/e2e/data/cluster-templates/vsphere-kubeadm-topology.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+    cni: calico
   name: '${CLUSTER_NAME}'
   namespace: '${NAMESPACE}'
 spec:
@@ -10,100 +11,16 @@ spec:
     pods:
       cidrBlocks:
       - 192.168.0.0/16
-  controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-    kind: KubeadmControlPlane
-    name: '${CLUSTER_NAME}'
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: VSphereCluster
-    name: '${CLUSTER_NAME}'
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: VSphereCluster
-metadata:
-  name: '${CLUSTER_NAME}'
-  namespace: '${NAMESPACE}'
-spec:
-  controlPlaneEndpoint:
-    host: ${CONTROL_PLANE_ENDPOINT_IP}
-    port: ${CONTROL_PLANE_ENDPOINT_PORT:=6443}
-  identityRef:
-    kind: Secret
-    name: '${CLUSTER_NAME}'
-  server: '${VSPHERE_SERVER}'
-  thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: VSphereMachineTemplate
-metadata:
-  name: '${CLUSTER_NAME}'
-  namespace: '${NAMESPACE}'
-spec:
-  template:
-    spec:
-      cloneMode: linkedClone
-      datacenter: '${VSPHERE_DATACENTER}'
-      datastore: '${VSPHERE_DATASTORE}'
-      diskGiB: 25
-      folder: '${VSPHERE_FOLDER}'
-      memoryMiB: 8192
-      network:
-        devices:
-        - dhcp4: true
-          networkName: '${VSPHERE_NETWORK}'
-      numCPUs: 2
-      os: Linux
-      powerOffMode: trySoft
-      resourcePool: '${VSPHERE_RESOURCE_POOL}'
-      server: '${VSPHERE_SERVER}'
-      storagePolicyName: '${VSPHERE_STORAGE_POLICY}'
-      template: '${VSPHERE_TEMPLATE}'
-      thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: VSphereMachineTemplate
-metadata:
-  name: ${CLUSTER_NAME}-worker
-  namespace: '${NAMESPACE}'
-spec:
-  template:
-    spec:
-      cloneMode: linkedClone
-      datacenter: '${VSPHERE_DATACENTER}'
-      datastore: '${VSPHERE_DATASTORE}'
-      diskGiB: 25
-      folder: '${VSPHERE_FOLDER}'
-      memoryMiB: 8192
-      network:
-        devices:
-        - dhcp4: true
-          networkName: '${VSPHERE_NETWORK}'
-      numCPUs: 2
-      os: Linux
-      powerOffMode: trySoft
-      resourcePool: '${VSPHERE_RESOURCE_POOL}'
-      server: '${VSPHERE_SERVER}'
-      storagePolicyName: '${VSPHERE_STORAGE_POLICY}'
-      template: '${VSPHERE_TEMPLATE}'
-      thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
----
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-kind: KubeadmControlPlane
-metadata:
-  name: '${CLUSTER_NAME}'
-  namespace: '${NAMESPACE}'
-spec:
-  kubeadmConfigSpec:
-    clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
-      controllerManager:
-        extraArgs:
-          cloud-provider: external
-    files:
-    - content: |
+  topology:
+    class: 'vsphere-kubeadm-example'
+    classNamespace: ${TOPOLOGY_NAMESPACE}
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    variables:
+    - name: sshKey
+      value: '${VSPHERE_SSH_AUTHORIZED_KEY}'
+    - name: kubeVipPodManifest
+      value: |
         apiVersion: v1
         kind: Pod
         metadata:
@@ -173,151 +90,48 @@ spec:
               type: File
             name: etchosts
         status: {}
-      owner: root:root
-      path: /etc/kubernetes/manifests/kube-vip.yaml
-      permissions: "0644"
-    - content: 127.0.0.1 localhost kubernetes
-      owner: root:root
-      path: /etc/kube-vip.hosts
-      permissions: "0644"
-    - content: |
-        #!/bin/bash
-
-        # Copyright 2020 The Kubernetes Authors.
-        #
-        # Licensed under the Apache License, Version 2.0 (the "License");
-        # you may not use this file except in compliance with the License.
-        # You may obtain a copy of the License at
-        #
-        #     http://www.apache.org/licenses/LICENSE-2.0
-        #
-        # Unless required by applicable law or agreed to in writing, software
-        # distributed under the License is distributed on an "AS IS" BASIS,
-        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-        # See the License for the specific language governing permissions and
-        # limitations under the License.
-
-        set -e
-
-        # Configure the workaround required for kubeadm init with kube-vip:
-        # xref: https://github.com/kube-vip/kube-vip/issues/684
-
-        # Nothing to do for kubernetes < v1.29
-        KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
-        if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
-          exit 0
-        fi
-
-        IS_KUBEADM_INIT="false"
-
-        # cloud-init kubeadm init
-        if [[ -f /run/kubeadm/kubeadm.yaml ]]; then
-          IS_KUBEADM_INIT="true"
-        fi
-
-        # ignition kubeadm init
-        if [[ -f /etc/kubeadm.sh ]] && grep -q -e "kubeadm init" /etc/kubeadm.sh; then
-          IS_KUBEADM_INIT="true"
-        fi
-
-        if [[ "$IS_KUBEADM_INIT" == "true" ]]; then
-          sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
-            /etc/kubernetes/manifests/kube-vip.yaml
-        fi
-      owner: root:root
-      path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
-      permissions: "0700"
-    initConfiguration:
-      nodeRegistration:
-        criSocket: /var/run/containerd/containerd.sock
-        kubeletExtraArgs:
-          cloud-provider: external
-        name: '{{ local_hostname }}'
-    joinConfiguration:
-      nodeRegistration:
-        criSocket: /var/run/containerd/containerd.sock
-        kubeletExtraArgs:
-          cloud-provider: external
-        name: '{{ local_hostname }}'
-    preKubeadmCommands:
-    - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
-    - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6"
-      >/etc/hosts
-    - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
-      localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
-    - mkdir -p /etc/pre-kubeadm-commands
-    - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
-      do echo "Running script $script"; "$script"; done
-    users:
-    - name: capv
-      sshAuthorizedKeys:
-      - '${VSPHERE_SSH_AUTHORIZED_KEY}'
-      sudo: ALL=(ALL) NOPASSWD:ALL
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: '${CLUSTER_NAME}'
-  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
-  version: '${KUBERNETES_VERSION}'
+    - name: controlPlaneIpAddr
+      value: ${CONTROL_PLANE_ENDPOINT_IP}
+    - name: controlPlanePort
+      value: 6443
+    - name: infraServer
+      value:
+        thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
+        url: '${VSPHERE_SERVER}'
+    - name: credsSecretName
+      value: '${CLUSTER_NAME}'
+    - name: vsphereDataCenter
+      value: '${VSPHERE_DATACENTER}'
+    - name: vsphereDataStore
+      value: '${VSPHERE_DATASTORE}'
+    - name: vsphereFolder
+      value: '${VSPHERE_FOLDER}'
+    - name: vsphereNetwork
+      value: '${VSPHERE_NETWORK}'
+    - name: vsphereResourcePool
+      value: '${VSPHERE_RESOURCE_POOL}'
+    - name: vsphereServer
+      value: '${VSPHERE_SERVER}'
+    - name: vsphereStorageServer
+      value: '${VSPHERE_STORAGE_SERVER}'
+    - name: vsphereTemplate
+      value: '${VSPHERE_TEMPLATE}'
+    version: '${KUBERNETES_VERSION}'
+    workers:
+      machineDeployments:
+      - class: vsphere-kubeadm-example-worker
+        metadata: {}
+        name: md-0
+        replicas: ${WORKER_MACHINE_COUNT}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-kind: KubeadmConfigTemplate
+apiVersion: v1
+kind: Secret
 metadata:
-  name: '${CLUSTER_NAME}-md-0'
+  name: '${CLUSTER_NAME}'
   namespace: '${NAMESPACE}'
-spec:
-  template:
-    spec:
-      joinConfiguration:
-        nodeRegistration:
-          criSocket: /var/run/containerd/containerd.sock
-          kubeletExtraArgs:
-            cloud-provider: external
-          name: '{{ local_hostname }}'
-      preKubeadmCommands:
-      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
-      - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6"
-        >/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
-        localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
-      - mkdir -p /etc/pre-kubeadm-commands
-      - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
-        do echo "Running script $script"; "$script"; done
-      users:
-      - name: capv
-        sshAuthorizedKeys:
-        - '${VSPHERE_SSH_AUTHORIZED_KEY}'
-        sudo: ALL=(ALL) NOPASSWD:ALL
----
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: MachineDeployment
-metadata:
-  labels:
-    cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
-  name: '${CLUSTER_NAME}-md-0'
-  namespace: '${NAMESPACE}'
-spec:
-  clusterName: '${CLUSTER_NAME}'
-  replicas: ${WORKER_MACHINE_COUNT}
-  selector:
-    matchLabels: {}
-  template:
-    metadata:
-      labels:
-        cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
-    spec:
-      bootstrap:
-        configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-          kind: KubeadmConfigTemplate
-          name: '${CLUSTER_NAME}-md-0'
-      clusterName: '${CLUSTER_NAME}'
-      infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: VSphereMachineTemplate
-        name: ${CLUSTER_NAME}-worker
-      version: '${KUBERNETES_VERSION}'
+stringData:
+  password: "${VSPHERE_PASSWORD}"
+  username: "${VSPHERE_USERNAME}"
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
@@ -339,15 +153,6 @@ spec:
     name: cloud-provider-vsphere-credentials
   - kind: ConfigMap
     name: cpi-manifests
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: '${CLUSTER_NAME}'
-  namespace: '${NAMESPACE}'
-stringData:
-  password: "${VSPHERE_PASSWORD}"
-  username: "${VSPHERE_USERNAME}"
 ---
 apiVersion: v1
 kind: Secret
@@ -1488,3 +1293,18 @@ kind: ConfigMap
 metadata:
   name: cpi-manifests
   namespace: '${NAMESPACE}'
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: crs-cni
+  namespace: ${NAMESPACE}
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  resources:
+  - kind: ConfigMap
+    name: calico-cni
+  strategy: ApplyOnce
+---

--- a/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
+++ b/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
@@ -233,7 +233,6 @@ var _ = Describe("[Azure] [RKE2] - [management.cattle.io/v3] Create and delete C
 			OwnedLabelName:                 e2e.OwnedLabelName,
 			TopologyNamespace:              topologyNamespace,
 		}
-
 	})
 })
 
@@ -369,7 +368,7 @@ var _ = Describe("[GCP] [GKE] Create and delete CAPI cluster functionality shoul
 	})
 })
 
-var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.VsphereTestLabel), func() {
+var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster from cluster class", Label(e2e.VsphereTestLabel), func() {
 	BeforeEach(func() {
 		komega.SetClient(bootstrapClusterProxy.GetClient())
 		komega.SetContext(ctx)
@@ -392,20 +391,37 @@ var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster functionali
 			},
 		})
 
+		// Add the needed ClusterClass
+		topologyNamespace := "creategitops-vsphere-kubeadm"
+		err := framework.CreateNamespace(ctx, bootstrapClusterProxy, topologyNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create namespace %q", topologyNamespace)
+
+		By("Applying Vsphere ClusterClasses")
+		turtlesframework.FleetCreateGitRepo(ctx, turtlesframework.FleetCreateGitRepoInput{
+			Name:            "vsphere-cluster-classes-kubeadm",
+			TargetNamespace: topologyNamespace,
+			Paths:           []string{"examples/clusterclasses/vsphere"},
+			ClusterProxy:    bootstrapClusterProxy,
+		})
+
 		return specs.CreateMgmtV3UsingGitOpsSpecInput{
-			E2EConfig:                 e2e.LoadE2EConfig(),
-			BootstrapClusterProxy:     bootstrapClusterProxy,
-			ClusterTemplate:           e2e.CAPIvSphereKubeadm,
-			ClusterName:               "cluster-vsphere-kubeadm",
-			ControlPlaneMachineCount:  ptr.To[int](1),
-			WorkerMachineCount:        ptr.To[int](1),
-			GitAddr:                   gitAddress,
-			LabelNamespace:            true,
-			RancherServerURL:          hostName,
-			CAPIClusterCreateWaitName: "wait-capv-create-cluster",
-			DeleteClusterWaitName:     "wait-vsphere-delete",
+			E2EConfig:                      e2e.LoadE2EConfig(),
+			BootstrapClusterProxy:          bootstrapClusterProxy,
+			ClusterTemplate:                e2e.CAPIvSphereKubeadmTopology,
+			AdditionalTemplates:            [][]byte{e2e.CAPICalico},
+			ClusterName:                    "cluster-vsphere-kubeadm",
+			ControlPlaneMachineCount:       ptr.To(1),
+			WorkerMachineCount:             ptr.To(1),
+			GitAddr:                        gitAddress,
+			LabelNamespace:                 true,
+			RancherServerURL:               hostName,
+			CAPIClusterCreateWaitName:      "wait-capv-create-cluster",
+			DeleteClusterWaitName:          "wait-vsphere-delete",
+			CapiClusterOwnerLabel:          e2e.CapiClusterOwnerLabel,
+			CapiClusterOwnerNamespaceLabel: e2e.CapiClusterOwnerNamespaceLabel,
+			OwnedLabelName:                 e2e.OwnedLabelName,
+			TopologyNamespace:              topologyNamespace,
 			AdditionalTemplateVariables: map[string]string{
-				"NAMESPACE":             "default",
 				"VIP_NETWORK_INTERFACE": "",
 			},
 		}


### PR DESCRIPTION
kind/feature

**What this PR does / why we need it**:

Swithc vSphere + Kubeadm test case to ClusterClass.

**Which issue(s) this PR fixes**:
Fixes #1154

**Special notes for your reviewer**:

vSphere + Kubeadm requires a CNI to be installed for the machines to be functional but installing Calico while on the VPN that gives access to vSphere is problematic because there seems to be a proxy that is redirecting to a different site when trying to reach the Helm repository. This will prevent this test from passing even though the cluster is provisioned. The moment Calico is installed it gets properly imported.

**While we find a solution, this PR uses the "legacy" approach for installing Calico in the workload cluster via `ClusterResourceSet`. This is not the ideal option for re-usability but it's convenient for circumventing the limitations found when connected to the VPN.**

Execution of the existing E2E suites for reference: https://github.com/rancher/turtles/actions/runs/14216708420

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
