### PR TITLE
Bump golangci-lint to v2

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -25,9 +25,9 @@ jobs:
         with:
           go-version: '=1.23.0'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.5.2
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64.5
+          version: v2.0.2
           working-directory: ${{matrix.working-directory}}
           args: --timeout=5m0s
           skip-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,58 +1,57 @@
-# Options for analysis running.
+version: "2"
 run:
   go: "1.23"
   allow-parallel-runners: true
-issues:
-  exclude-files:
-    - ".*_test\\.go$"
-  include:
-    - EXC0012
-    - EXC0014
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - testpackage
-        - gochecknoglobals
-    - path: internal/controllers/import_controller(_v3)?\.go
-      linters:
-        - dupl
-    - path: exp/day2/controllers/.*.go
-      linters:
-        - dupl
-    - text: var-naming
-      linters:
-        - revive
-    - text: ST1003
-      linters: 
-        - stylecheck
-    - linters:
-      - revive
-      text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"
-      path: exp/day2/controllers/.*.go
-    - path: exp/day2/controllers/.*.go
-      linters:
-        - unused
-linters-settings:
-  funlen:
-    lines: 110
-    statements: 60
-  lll:
-    line-length: 150
-  goimports:
-    local-prefixes: github.com/rancher/turtles
-  gci:
-    custom-order: true
-    sections:
-      - "standard"
-      - "blank"
-      - "dot"
-      - "default"
-      - "prefix(sigs.k8s.io/cluster-api)"
-      - "prefix(github.com/rancher/turtles)"
-  importas:
-      no-unaliased: true
+linters:
+  default: all
+  disable:
+    - containedctx
+    - cyclop
+    - depguard
+    - err113
+    - exhaustive
+    - exhaustruct
+    - funlen
+    - gochecknoglobals
+    - gochecknoinits
+    - gocritic
+    - godox
+    - ireturn
+    - mnd
+    - nlreturn
+    - nolintlint
+    - nonamedreturns
+    - paralleltest
+    - rowserrcheck
+    - sqlclosecheck
+    - tagliatelle
+    - varnamelen
+    - wastedassign
+    - wrapcheck
+  settings:
+    funlen:
+      lines: 110
+      statements: 60
+    goheader:
+      values:
+        regexp:
+          copyright_regex: 'Copyright © (\d{4})(?: - (\d{4}))? SUSE LLC'
+      template: |-
+        {{copyright_regex}}
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    importas:
       alias:
-        # Kubernetes
         - pkg: k8s.io/api/core/v1
           alias: corev1
         - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
@@ -65,22 +64,21 @@ linters-settings:
           alias: utilruntime
         - pkg: k8s.io/client-go/kubernetes/scheme
           alias: clientgoscheme
-       # Rancher Turtles
         - pkg: github.com/rancher/turtles/util/naming
           alias: turtlesnaming
         - pkg: github.com/rancher/turtles/api/rancher/provisioning/v1
           alias: provisioningv1
         - pkg: github.com/rancher/turtles/api/rancher/management/v3
           alias: managementv3
-        # Controller Runtime
         - pkg: sigs.k8s.io/controller-runtime
           alias: ctrl
-        # CAPI
         - pkg: sigs.k8s.io/cluster-api/api/v1beta1
           alias: clusterv1
-  revive:
+      no-unaliased: true
+    lll:
+      line-length: 150
+    revive:
       rules:
-        # The following rules are recommended https://github.com/mgechev/revive#recommended-configuration
         - name: blank-imports
         - name: context-as-argument
         - name: context-keys-type
@@ -105,53 +103,70 @@ linters-settings:
         - name: unused-parameter
         - name: unreachable-code
         - name: redefines-builtin-id
-        #
-        # Rules in addition to the recommended configuration above.
-        #
         - name: bool-literal-in-expr
         - name: constant-logical-expr
-  goheader:
-    values:
-      regexp:
-        copyright_regex: "Copyright © (\\d{4})(?: - (\\d{4}))? SUSE LLC"
-    template: |-
-      {{copyright_regex}}
-  
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
-      
-          http://www.apache.org/licenses/LICENSE-2.0
-      
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
-linters:
-  enable-all: true
-  disable:
-    - nolintlint
-    - tagliatelle
-    - exhaustruct
-    - exhaustive
-    - funlen
-    - wrapcheck
-    - goerr113  
-    - paralleltest
-    - varnamelen
-    - cyclop
-    - gochecknoglobals
-    - gochecknoinits
-    - nonamedreturns
-    - gocritic
-    - nlreturn
-    - mnd
-    - ireturn
-    - depguard
-    - containedctx 
-    - godox
-    # Disabled because of generics
-    - rowserrcheck
-    - sqlclosecheck
-    - wastedassign
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gochecknoglobals
+          - testpackage
+        path: _test\.go
+      - linters:
+          - dupl
+        path: internal/controllers/import_controller(_v3)?\.go
+      - linters:
+          - dupl
+        path: exp/day2/controllers/.*.go
+      - linters:
+          - revive
+        text: var-naming
+      - linters:
+          - staticcheck
+        text: ST1003
+      - linters:
+          - revive
+        path: exp/day2/controllers/.*.go
+        text: 'exported: exported method .*\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported'
+      - linters:
+          - unused
+        path: exp/day2/controllers/.*.go
+      - linters:
+          - revive
+        text: 'package-comments: should have a package comment'
+    paths:
+      - examples/examples.go
+      - .*_test\.go$
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - blank
+        - dot
+        - default
+        - prefix(sigs.k8s.io/cluster-api)
+        - prefix(github.com/rancher/turtles)
+      custom-order: true
+    goimports:
+      local-prefixes:
+        - github.com/rancher/turtles
+  exclusions:
+    generated: lax
+    paths:
+      - .*_test\.go$
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ CLUSTERCTL := $(TOOLS_BIN_DIR)/$(CLUSTERCTL_BIN)-$(CLUSTERCTL_VER)
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT_VER := $(shell cat .github/workflows/golangci-lint.yaml | grep [[:space:]]version: | sed 's/.*version: //')
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER))
-GOLANGCI_LINT_PKG := github.com/golangci/golangci-lint/cmd/golangci-lint
+GOLANGCI_LINT_PKG := github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
 NOTES_BIN := notes
 NOTES := $(abspath $(TOOLS_BIN_DIR)/$(NOTES_BIN))

--- a/api/rancher/management/v3/doc.go
+++ b/api/rancher/management/v3/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package rancher contains the rancher provisioning.cattle.io/v1 and
+// Package v3 rancher contains the rancher provisioning.cattle.io/v1 and
 // management.cattle.io/v3 API proxy implementations.
 package v3

--- a/api/rancher/provisioning/v1/doc.go
+++ b/api/rancher/provisioning/v1/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package rancher contains the rancher provisioning.cattle.io/v1 and
+// Package v1 rancher contains the rancher provisioning.cattle.io/v1 and
 // management.cattle.io/v3 API proxy implementations.
 package v1

--- a/internal/controllers/clusterctlconfig_controller.go
+++ b/internal/controllers/clusterctlconfig_controller.go
@@ -76,7 +76,7 @@ func (r *ClusterctlConfigReconciler) SetupWithManager(ctx context.Context, mgr c
 	configMapTemplate := clusterctl.Config()
 	configMapTemplate.Data = nil
 
-	err = r.Client.Patch(ctx, configMapTemplate, client.Apply, []client.PatchOption{
+	err = r.Patch(ctx, configMapTemplate, client.Apply, []client.PatchOption{
 		client.ForceOwnership,
 		client.FieldOwner("clusterctl-controller"),
 	}...)
@@ -113,7 +113,7 @@ func (r *ClusterctlConfigReconciler) Reconcile(ctx context.Context, _ reconcile.
 	configMap := clusterctl.Config()
 	configMap.Data["clusterctl.yaml"] = string(clusterctlYaml)
 
-	if err := r.Client.Patch(ctx, configMap, client.Apply, []client.PatchOption{
+	if err := r.Patch(ctx, configMap, client.Apply, []client.PatchOption{
 		client.ForceOwnership,
 		client.FieldOwner("clusterctlconfig-controller"),
 	}...); err != nil {

--- a/internal/controllers/import_controller_v3.go
+++ b/internal/controllers/import_controller_v3.go
@@ -156,7 +156,7 @@ func (r *CAPIImportManagementV3Reconciler) Reconcile(ctx context.Context, req ct
 
 	log = log.WithValues("cluster", capiCluster.Name)
 
-	if capiCluster.ObjectMeta.DeletionTimestamp.IsZero() && !turtlesannotations.HasClusterImportAnnotation(capiCluster) &&
+	if capiCluster.DeletionTimestamp.IsZero() && !turtlesannotations.HasClusterImportAnnotation(capiCluster) &&
 		controllerutil.AddFinalizer(capiCluster, managementv3.CapiClusterFinalizer) {
 		log.Info("CAPI cluster is marked for import, adding finalizer")
 
@@ -232,7 +232,7 @@ func (r *CAPIImportManagementV3Reconciler) reconcile(ctx context.Context, capiCl
 		rancherCluster = &rancherClusterList.Items[0]
 	}
 
-	if rancherCluster != nil && !rancherCluster.ObjectMeta.DeletionTimestamp.IsZero() {
+	if rancherCluster != nil && !rancherCluster.DeletionTimestamp.IsZero() {
 		if err := r.reconcileDelete(ctx, capiCluster); err != nil {
 			log.Error(err, "Removing CAPI Cluster failed, retrying")
 			return ctrl.Result{}, err
@@ -245,7 +245,7 @@ func (r *CAPIImportManagementV3Reconciler) reconcile(ctx context.Context, capiCl
 		}
 	}
 
-	if !capiCluster.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !capiCluster.DeletionTimestamp.IsZero() {
 		if err := r.deleteDependentRancherCluster(ctx, capiCluster); err != nil {
 			return ctrl.Result{}, fmt.Errorf("error deleting associated managementv3.Cluster resources: %w", err)
 		}

--- a/internal/controllers/uiplugin_controller.go
+++ b/internal/controllers/uiplugin_controller.go
@@ -75,7 +75,7 @@ func (r *UIPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	plugin.SetKind("UIPlugin")
 	plugin.SetAPIVersion("catalog.cattle.io/v1")
 
-	if err := r.Client.Get(ctx, req.NamespacedName, plugin); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, plugin); err != nil {
 		log.Error(err, "Unable to get UIPlugin")
 
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/internal/sync/provider_sync.go
+++ b/internal/sync/provider_sync.go
@@ -124,7 +124,7 @@ func (s *ProviderSync) SyncObjects() {
 }
 
 func (s *ProviderSync) syncStatus() {
-	s.DefaultSynchronizer.Source.SetProviderName()
+	s.Source.SetProviderName()
 
 	switch {
 	case conditions.IsTrue(s.Source, operatorv1.ProviderInstalledCondition):

--- a/internal/sync/secret_mapper_sync.go
+++ b/internal/sync/secret_mapper_sync.go
@@ -289,9 +289,9 @@ func (s *SecretMapperSync) Get(ctx context.Context) error {
 // Sync updates the credentials secret with required values from rancher manager secret.
 func (s *SecretMapperSync) Sync(ctx context.Context) error {
 	log := log.FromContext(ctx)
-	s.SecretSync.Secret.StringData = map[string]string{}
+	s.Secret.StringData = map[string]string{}
 
-	if err := Into(s.Source.ProviderName(), s.RancherSecret.Data, s.SecretSync.Secret.StringData); err != nil {
+	if err := Into(s.Source.ProviderName(), s.RancherSecret.Data, s.Secret.StringData); err != nil {
 		log.Error(err, "failed to map credential keys")
 
 		conditions.Set(s.Source, conditions.FalseCondition(

--- a/internal/sync/secret_sync.go
+++ b/internal/sync/secret_sync.go
@@ -74,7 +74,7 @@ func (SecretSync) Template(capiProvider *turtlesv1.CAPIProvider) client.Object {
 func (s *SecretSync) Sync(_ context.Context) error {
 	s.SyncObjects()
 
-	s.Source.Spec.ProviderSpec.ConfigSecret = cmp.Or(s.Source.Spec.ProviderSpec.ConfigSecret, &operatorv1.SecretReference{
+	s.Source.Spec.ConfigSecret = cmp.Or(s.Source.Spec.ConfigSecret, &operatorv1.SecretReference{
 		Name: s.Source.Name,
 	})
 
@@ -85,10 +85,10 @@ func (s *SecretSync) Sync(_ context.Context) error {
 // Direction of updates:
 // Spec.Features + Spec.Variables -> Status.Variables -> Secret.
 func (s *SecretSync) SyncObjects() {
-	setVariables(s.DefaultSynchronizer.Source)
-	setFeatures(s.DefaultSynchronizer.Source)
+	setVariables(s.Source)
+	setFeatures(s.Source)
 
-	s.Secret.StringData = s.DefaultSynchronizer.Source.Status.Variables
+	s.Secret.StringData = s.Source.Status.Variables
 }
 
 func setVariables(capiProvider *turtlesv1.CAPIProvider) {

--- a/internal/test/helpers/envtest.go
+++ b/internal/test/helpers/envtest.go
@@ -91,7 +91,7 @@ func (t *TestEnvironment) Cleanup(ctx context.Context, objs ...client.Object) er
 	errs := []error{}
 
 	for _, o := range objs {
-		err := t.Client.Delete(ctx, o)
+		err := t.Delete(ctx, o)
 		if apierrors.IsNotFound(err) {
 			continue
 		}
@@ -112,7 +112,7 @@ func (t *TestEnvironment) CreateNamespace(ctx context.Context, generateName stri
 			},
 		},
 	}
-	if err := t.Client.Create(ctx, ns); err != nil {
+	if err := t.Create(ctx, ns); err != nil {
 		return nil, err
 	}
 
@@ -126,7 +126,7 @@ func (t *TestEnvironment) CreateNamespaceWithName(ctx context.Context, name stri
 			Name: name,
 		},
 	}
-	if err := t.Client.Create(ctx, ns); err != nil {
+	if err := t.Create(ctx, ns); err != nil {
 		return nil, err
 	}
 
@@ -200,7 +200,7 @@ func (t *TestEnvironment) StartManager(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	t.cancel = cancel
 
-	return t.Manager.Start(ctx)
+	return t.Start(ctx)
 }
 
 // Stop stops the test environment.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a few issues with the golangci-lint v2 [migration](https://golangci-lint.run/product/migration-guide/).
I ran the `migrate` command to convert the existing config.

Some new rule seem to be added by `staticcheck` linter, which I fixed.

This PR should replace: https://github.com/rancher/turtles/pull/1227
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
