### PR TITLE
Replace deprecated `installCRDs` option with new Helm options

### DIFF
--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -76,7 +76,7 @@ jobs:
         run: helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
 
       - name: Install cert-manager
-        run: helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version ${{ env.CERT_MANAGER_VERSION }} --set installCRDs=true --wait
+        run: helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version ${{ env.CERT_MANAGER_VERSION }} --set crds.enabled=true --set crds.keep=true --wait
 
       - name: Install Rancher
         run: helm install rancher rancher-latest/rancher --namespace cattle-system --create-namespace --set bootstrapPassword=rancheradmin --set replicas=1 --set hostname="e2e.dev.rancher" --set 'extraEnv[0].name=CATTLE_FEATURES' --version ${{ env.RANCHER_VERSION }} --wait

--- a/test/testenv/rancher.go
+++ b/test/testenv/rancher.go
@@ -212,7 +212,8 @@ func DeployRancher(ctx context.Context, input DeployRancherInput) PreRancherInst
 			Wait: true,
 		}
 		_, err = certManagerChart.Run(map[string]string{
-			"installCRDs": "true",
+			"crds.enabled": "true",
+			"crds.keep":    "true",
 		})
 		Expect(err).ToNot(HaveOccurred())
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
While installing Cert-Manager, I noticed deprecation warnings in the lint test chart due to the use of the deprecated [installCRDs](https://cert-manager.io/docs/releases/release-notes/release-notes-1.15/#other-cleanup-or-flake-1) option.

This patch replaces `installCRDs=true` with the recommended `crds.enabled=true` and `crds.keep=true` options, ensuring:

- CRDs are installed as part of the Helm deployment (`crds.enabled=true`).
- CRDs remain in the cluster even after Cert-Manager is uninstalled (`crds.keep=true`), maintaining the previous behavior of `installCRDs=true`.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
