### PR TITLE
WIP: feat: move to fleet bundles for aws kubeadm

### DIFF
--- a/examples/applications/ccm/aws/fleet-bundle.yaml
+++ b/examples/applications/ccm/aws/fleet-bundle.yaml
@@ -1,0 +1,194 @@
+kind: Bundle
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: aws-cloud-controller-manager
+spec:
+  resources:
+  - content: |
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: aws-cloud-controller-manager
+        namespace: kube-system
+        labels:
+          k8s-app: aws-cloud-controller-manager
+      spec:
+        selector:
+          matchLabels:
+            k8s-app: aws-cloud-controller-manager
+        updateStrategy:
+          type: RollingUpdate
+        template:
+          metadata:
+            labels:
+              k8s-app: aws-cloud-controller-manager
+          spec:
+            tolerations:
+              - key: node.cloudprovider.kubernetes.io/uninitialized
+                value: "true"
+                effect: NoSchedule
+              - key: node-role.kubernetes.io/control-plane
+                effect: NoSchedule
+              - key: node-role.kubernetes.io/master
+                effect: NoSchedule
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node-role.kubernetes.io/control-plane
+                          operator: Exists
+                        - key: node-role.kubernetes.io/master
+                          operator: Exists
+            serviceAccountName: cloud-controller-manager
+            containers:
+              - name: aws-cloud-controller-manager
+                image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.28.3
+                args:
+                  - --v=2
+                  - --cloud-provider=aws
+                  - --use-service-account-credentials=true
+                  - --configure-cloud-routes=false
+                resources:
+                  requests:
+                    cpu: 200m
+            hostNetwork: true
+      ---
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: cloud-controller-manager
+        namespace: kube-system
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: cloud-controller-manager:apiserver-authentication-reader
+        namespace: kube-system
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: extension-apiserver-authentication-reader
+      subjects:
+        - apiGroup: ""
+          kind: ServiceAccount
+          name: cloud-controller-manager
+          namespace: kube-system
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: system:cloud-controller-manager
+      rules:
+      - apiGroups:
+        - ""
+        resources:
+        - events
+        verbs:
+        - create
+        - patch
+        - update
+      - apiGroups:
+        - ""
+        resources:
+        - nodes
+        verbs:
+        - '*'
+      - apiGroups:
+        - ""
+        resources:
+        - nodes/status
+        verbs:
+        - patch
+      - apiGroups:
+        - ""
+        resources:
+        - services
+        verbs:
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ""
+        resources:
+        - services/status
+        verbs:
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ""
+        resources:
+        - serviceaccounts
+        verbs:
+        - create
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ""
+        resources:
+        - persistentvolumes
+        verbs:
+        - get
+        - list
+        - update
+        - watch
+      - apiGroups:
+        - ""
+        resources:
+        - configmaps
+        verbs:
+        - list
+        - watch
+      - apiGroups:
+        - ""
+        resources:
+        - endpoints
+        verbs:
+        - create
+        - get
+        - list
+        - watch
+        - update
+      - apiGroups:
+        - coordination.k8s.io
+        resources:
+        - leases
+        verbs:
+        - create
+        - get
+        - list
+        - watch
+        - update
+      - apiGroups:
+        - ""
+        resources:
+        - serviceaccounts/token
+        verbs:
+        - create
+      ---
+      kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: system:cloud-controller-manager
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:cloud-controller-manager
+      subjects:
+        - apiGroup: ""
+          kind: ServiceAccount
+          name: cloud-controller-manager
+          namespace: kube-system
+    name: aws-ccm.yaml
+  targets:
+  - clusterSelector:
+      matchLabels:
+        cloud-provider: aws
+      matchExpressions:
+      - key: clusterclass-name.fleet.addons.cluster.x-k8s.io
+        operator: In
+        values: [aws-kubeadm-example]

--- a/examples/applications/cni/calico/helm-chart-aws.yaml
+++ b/examples/applications/cni/calico/helm-chart-aws.yaml
@@ -1,0 +1,36 @@
+apiVersion: fleet.cattle.io/v1alpha1
+kind: HelmApp
+metadata:
+  name: calico-cni-aws
+spec:
+  helm:
+    releaseName: projectcalico
+    repo: https://docs.tigera.io/calico/charts
+    chart: tigera-operator
+    templateValues:
+      installation: |-
+        cni:
+          type: Calico
+        calicoNetwork:
+          bgp: Enabled
+          mtu: 1440
+          ipPools:
+            ${- range $cidr := .ClusterValues.Cluster.spec.clusterNetwork.pods.cidrBlocks }
+            - cidr: "${ $cidr }"
+            ${- end}
+  diff:
+    comparePatches:
+    - apiVersion: operator.tigera.io/v1
+      kind: Installation
+      name: default
+      operations:
+      - {"op":"remove", "path":"/spec/kubernetesProvider"}
+  targets:
+  - clusterSelector:
+      matchLabels:
+        cni: calico
+      matchExpressions:
+      - key: clusterclass-name.fleet.addons.cluster.x-k8s.io
+        operator: In
+        values:
+          - aws-kubeadm-example

--- a/examples/applications/csi/aws/helm-chart.yaml
+++ b/examples/applications/csi/aws/helm-chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: fleet.cattle.io/v1alpha1
+kind: HelmApp
+metadata:
+  name: aws-csi-driver
+spec:
+  helm:
+    releaseName: aws-ebs-csi-driver
+    repo: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+    chart: aws-ebs-csi-driver
+    templateValues:
+      node: |-
+        hostNetwork: true
+  insecureSkipTLSVerify: true
+  targets:
+  - clusterSelector:
+      matchLabels:
+        csi: aws-ebs-csi-driver
+      matchExpressions:
+      - key: clusterclass-name.fleet.addons.cluster.x-k8s.io
+        operator: In
+        values: [aws-kubeadm-example]

--- a/examples/clusterclasses/aws/clusterclass-kubeadm-example.yaml
+++ b/examples/clusterclasses/aws/clusterclass-kubeadm-example.yaml
@@ -1,0 +1,214 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: aws-kubeadm-example
+spec:
+  controlPlane:
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlaneTemplate
+      name: aws-kubeadm-example-control-plane
+    machineInfrastructure:
+      ref:
+        kind: AWSMachineTemplate
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        name: aws-kubeadm-example-control-plane
+  infrastructure:
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: AWSClusterTemplate
+      name: aws-kubeadm-example
+  workers:
+    machineDeployments:
+      - class: default-worker
+        template:
+          bootstrap:
+            ref:
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              kind: KubeadmConfigTemplate
+              name: aws-kubeadm-example-worker-bootstraptemplate
+          infrastructure:
+            ref:
+              apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+              kind: AWSMachineTemplate
+              name: aws-kubeadm-example-worker-machinetemplate
+  variables:
+    - name: region
+      required: true
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: us-east-1
+    - name: sshKeyName
+      required: true
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: default
+    - name: controlPlaneMachineType
+      required: true
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: t3.large
+    - name: workerMachineType
+      required: true
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: t3.large
+  patches:
+    - name: region
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+            kind: AWSClusterTemplate
+            matchResources:
+              infrastructureCluster: true
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/region
+              valueFrom:
+                variable: region
+    - name: sshKeyName
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+            kind: AWSClusterTemplate
+            matchResources:
+              infrastructureCluster: true
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/sshKeyName
+              valueFrom:
+                variable: sshKeyName
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+            kind: AWSMachineTemplate
+            matchResources:
+              controlPlane: true
+              machineDeploymentClass:
+                names:
+                  - default-worker
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/sshKeyName
+              valueFrom:
+                variable: sshKeyName
+    - name: controlPlaneMachineType
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+            kind: AWSMachineTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+            - op: replace
+              path: /spec/template/spec/instanceType
+              valueFrom:
+                variable: controlPlaneMachineType
+    - name: workerMachineType
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+            kind: AWSMachineTemplate
+            matchResources:
+              machineDeploymentClass:
+                names:
+                  - default-worker
+          jsonPatches:
+            - op: replace
+              path: /spec/template/spec/instanceType
+              valueFrom:
+                variable: workerMachineType
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSClusterTemplate
+metadata:
+  name: aws-kubeadm-example
+spec:
+  template:
+    spec:
+      network:
+          cni:
+            cniIngressRules:
+              - description: BGP
+                fromPort: 179
+                protocol: tcp
+                toPort: 179
+              - description: IP-in-IP
+                fromPort: 0
+                protocol: ipinip
+                toPort: 0
+              - description: Calico Typha
+                fromPort: 5473
+                protocol: tcp
+                toPort: 5473
+      controlPlaneLoadBalancer:
+        loadBalancerType: nlb
+        healthCheckProtocol: HTTPS
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: aws-kubeadm-example-control-plane
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          apiServer:
+            extraArgs:
+              cloud-provider: external
+          controllerManager:
+            extraArgs:
+              cloud-provider: external
+        initConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              cloud-provider: external
+            name: '{{ ds.meta_data.local_hostname }}'
+        joinConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              cloud-provider: external
+            name: '{{ ds.meta_data.local_hostname }}'
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachineTemplate
+metadata:
+  name: aws-kubeadm-example-control-plane
+spec:
+  template:
+    spec:
+      # instanceType is a required field (OpenAPI schema).
+      instanceType: REPLACEME
+      iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
+      rootVolume:
+        size: 50
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachineTemplate
+metadata:
+  name: aws-kubeadm-example-worker-machinetemplate
+spec:
+  template:
+    spec:
+      # instanceType is a required field (OpenAPI schema).
+      instanceType: REPLACEME
+      iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
+      rootVolume:
+        size: 50
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "aws-kubeadm-example-worker-bootstraptemplate"
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
+          name: '{{ ds.meta_data.local_hostname }}'

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -102,6 +102,9 @@ var (
 	//go:embed data/cluster-templates/aws-ec2-rke2-topology.yaml
 	CAPIAwsEC2RKE2Topology []byte
 
+	//go:embed data/cluster-templates/aws-kubeadm-topology.yaml
+	CAPIAwsKubeadmTopology []byte
+
 	//go:embed data/cluster-templates/gcp-gke.yaml
 	CAPIGCPGKE []byte
 

--- a/test/e2e/data/cluster-templates/aws-kubeadm-topology.yaml
+++ b/test/e2e/data/cluster-templates/aws-kubeadm-topology.yaml
@@ -1,0 +1,34 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cni: calico
+    cloud-provider: aws
+    csi: aws-ebs-csi-driver
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  topology:
+    class: aws-kubeadm-example
+    classNamespace: ${TOPOLOGY_NAMESPACE}
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    variables:
+    - name: region
+      value: ${AWS_REGION}
+    - name: sshKeyName
+      value: ${AWS_SSH_KEY_NAME}
+    - name: controlPlaneMachineType
+      value: ${AWS_CONTROL_PLANE_MACHINE_TYPE}
+    - name: workerMachineType
+      value: ${AWS_NODE_MACHINE_TYPE}
+    version: ${KUBERNETES_VERSION}
+    workers:
+      machineDeployments:
+      - class: default-worker
+        name: md-0
+        replicas: ${WORKER_MACHINE_COUNT}

--- a/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
+++ b/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
@@ -142,9 +142,7 @@ var _ = Describe("[Docker] [RKE2] Create and delete CAPI cluster functionality s
 })
 
 var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster class", Label(e2e.FullTestLabel), func() {
-	var (
-		topologyNamespace string
-	)
+	var topologyNamespace string
 
 	BeforeEach(func() {
 		komega.SetClient(bootstrapClusterProxy.GetClient())
@@ -199,9 +197,7 @@ var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster clas
 })
 
 var _ = Describe("[Azure] [RKE2] - [management.cattle.io/v3] Create and delete CAPI cluster from cluster class", Label(e2e.FullTestLabel, e2e.Rke2TestLabel), func() {
-	var (
-		topologyNamespace string
-	)
+	var topologyNamespace string
 
 	BeforeEach(func() {
 		komega.SetClient(bootstrapClusterProxy.GetClient())
@@ -311,9 +307,13 @@ var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster functionality shoul
 })
 
 var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.FullTestLabel, e2e.KubeadmTestLabel), func() {
+	var topologyNamespace string
+
 	BeforeEach(func() {
 		komega.SetClient(bootstrapClusterProxy.GetClient())
 		komega.SetContext(ctx)
+
+		topologyNamespace = "creategitops-aws-kubeadm"
 	})
 
 	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
@@ -337,12 +337,12 @@ var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionali
 		return specs.CreateMgmtV3UsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
-			ClusterTemplate:                e2e.CAPIAwsEC2Kubeadm,
-			AdditionalTemplates:            [][]byte{e2e.CAPICalico, e2e.CAPIAWSCPICSI},
-			ClusterName:                    "cluster-ec2",
+			ClusterTemplate:                e2e.CAPIAwsKubeadmTopology,
+			ClusterName:                    "cluster-aws-kubeadm",
 			ControlPlaneMachineCount:       ptr.To(1),
 			WorkerMachineCount:             ptr.To(1),
 			GitAddr:                        gitAddress,
+			SkipDeletionTest:               false,
 			LabelNamespace:                 true,
 			RancherServerURL:               hostName,
 			CAPIClusterCreateWaitName:      "wait-capa-create-cluster",
@@ -352,6 +352,33 @@ var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionali
 			OwnedLabelName:                 e2e.OwnedLabelName,
 			AdditionalTemplateVariables: map[string]string{
 				e2e.KubernetesVersionVar: e2e.LoadE2EConfig().GetVariable(e2e.AWSKubernetesVersionVar), // override the default k8s version
+			},
+			TopologyNamespace: topologyNamespace,
+			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
+				{
+					Name:            "aws-cluster-classes-regular",
+					Paths:           []string{"examples/clusterclasses/aws"},
+					ClusterProxy:    bootstrapClusterProxy,
+					TargetNamespace: topologyNamespace,
+				},
+				{
+					Name:            "aws-cni",
+					Paths:           []string{"examples/applications/cni/calico"},
+					ClusterProxy:    bootstrapClusterProxy,
+					TargetNamespace: topologyNamespace,
+				},
+				{
+					Name:            "aws-ccm",
+					Paths:           []string{"examples/applications/ccm/aws"},
+					ClusterProxy:    bootstrapClusterProxy,
+					TargetNamespace: topologyNamespace,
+				},
+				{
+					Name:            "aws-ebs-csi-driver",
+					Paths:           []string{"examples/applications/csi/aws"},
+					ClusterProxy:    bootstrapClusterProxy,
+					TargetNamespace: topologyNamespace,
+				},
 			},
 		}
 	})
@@ -459,9 +486,7 @@ var _ = Describe("[GCP] [GKE] Create and delete CAPI cluster functionality shoul
 })
 
 var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster from cluster class", Label(e2e.VsphereTestLabel, e2e.KubeadmTestLabel), func() {
-	var (
-		topologyNamespace string
-	)
+	var topologyNamespace string
 
 	BeforeEach(func() {
 		komega.SetClient(bootstrapClusterProxy.GetClient())


### PR DESCRIPTION
**What this PR does / why we need it**:

Deprecate the use of `ClusterResourceSet` for installing `cloud-controller-manager` and `ebs-csi-driver` when deploying AWS+Kubeadm clusters.

**Which issue(s) this PR fixes**:
Fixes #1144
Fixes https://github.com/rancher/turtles/issues/1278
Fixes https://github.com/rancher/turtles/issues/1279

**Special notes for your reviewer**:

The existing Calico `HelmApp` could not be re-used because AWS requires a specific configuration (encapsulation, bgp, etc.), so a new file is added for AWS-only. As we use selectors on the class that was used to provision the cluster, this will only apply to the CAPA/CABPK scenario.

AWS Cloud Controller Manager provides a Helm chart that does not support some of the parameters required to set a configuration equivalent to the one we use in the current CRS. For now we opted for creating a Fleet `Bundle` that manages the creation of the resources for AWS CCM. As a follow-up we should probably invest time on helping fixing the existing Helm chart upstream, see https://github.com/kubernetes/cloud-provider-aws/tree/master/charts/aws-cloud-controller-manager.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
