### PR TITLE
Do not allow skip resources cleanup for nightly tests

### DIFF
--- a/.github/workflows/e2e-long.yaml
+++ b/.github/workflows/e2e-long.yaml
@@ -4,15 +4,6 @@ on:
   schedule:
     - cron: "0 0 1/2 * *"
   workflow_dispatch:
-    inputs:
-      skip_resource_cleanup:
-        description: Skip Management Cluster and Charts Cleanup
-        default: false
-        type: boolean
-      skip_deletion_test:
-        description: Skip deleting git repo and cluster tests
-        default: false
-        type: boolean
 
 concurrency: ci_e2e_tests
 
@@ -28,8 +19,6 @@ jobs:
       test_name: Import via GitOps [v3]
       artifact_name: artifacts_import_gitops_v3
       MANAGEMENT_CLUSTER_ENVIRONMENT: eks
-      skip_resource_cleanup: ${{ inputs.skip_resource_cleanup != '' && inputs.skip_resource_cleanup || false }}
-      skip_deletion_test: ${{ inputs.skip_deletion_test != '' && inputs.skip_deletion_test || false }}
     secrets: inherit
   e2e_v2prov:
     needs: publish_e2e_image
@@ -41,7 +30,7 @@ jobs:
       MANAGEMENT_CLUSTER_ENVIRONMENT: eks
     secrets: inherit
   e2e_cleanup:
-    if: ${{ inputs.skip_resource_cleanup == '' || !inputs.skip_resource_cleanup }}
+    if: always()
     needs: [e2e_import_gitops_v3, e2e_v2prov]
     uses: ./.github/workflows/e2e-cleanup.yaml
     secrets: inherit


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleaning this up as it is creating more troubles handling this input than anything else.

I also don't find this functional in the first place, since we are not meant to keep resources running. This will have terrible consequences to any next run of the job, if the resources are not manually cleaned (and properly) after, which no one can guarantee and has no indication anywhere.

Therefore the nightly job should always delete resources consistently.
A log trail can be used for troubleshooting in case of errors, otherwise it is already possible to investigate and debug issues while the test are running, since there are abundant timeouts to wait for.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
