### PR TITLE
Remove locations where the community image is not present

### DIFF
--- a/examples/clusterclasses/azure/clusterclass-rke2-example.yaml
+++ b/examples/clusterclasses/azure/clusterclass-rke2-example.yaml
@@ -47,8 +47,6 @@ spec:
           type: string
           enum:
             - australiaeast
-            - eastus
-            - eastus2
             - francecentral
             - germanywestcentral
             - northcentralus


### PR DESCRIPTION
**What this PR does / why we need it**:
Thanks to @valaparthvi we found that `eastus` and `eastus2` do not have the default Community image we use.
Not sure if it was removed recently or I made a mistake building the original list. 
Either way better remove these to prevent errors.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
