### PR TITLE
Add insecureSkipTLSVerify to Calico HelmApp

### DIFF
--- a/examples/applications/cni/calico/helm-chart.yaml
+++ b/examples/applications/cni/calico/helm-chart.yaml
@@ -25,6 +25,7 @@ spec:
       name: default
       operations:
       - {"op":"remove", "path":"/spec/kubernetesProvider"}
+  insecureSkipTLSVerify: true
   targets:
   - clusterSelector:
       matchLabels:


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a workaround to prevent Fleet failing installing all charts when the Rancher `agent-tls-mode` is set to Strict (default)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
