### PR TITLE
Ensure Cluster is Ready in e2e tests

### DIFF
--- a/examples/clusterclasses/azure/clusterclass-rke2-example.yaml
+++ b/examples/clusterclasses/azure/clusterclass-rke2-example.yaml
@@ -200,6 +200,7 @@ metadata:
 spec:
   template:
     spec:
+      registrationMethod: internal-first
       rolloutStrategy:
         type: "RollingUpdate"
         rollingUpdate:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an additional check to verify the CAPI Clusters have the `Ready` condition.
This is to ensure they are fully provisioned.

It can be otherwise that the test will succeed only if the first control plane node is initialized, but all the others fail to join.

Did a first run without editing the Azure RKE2 Class, and it does fail as expected:
https://github.com/rancher/turtles/actions/runs/14360104898/job/40259416000

```
  [FAILED] Timed out after 2100.001s.
  CAPI Cluster should be Ready
  Expected success, but got an error:
      <*errors.errorString | 0xc0008d0aa0>: 
      Cluster is not Ready
      {
          s: "Cluster is not Ready",
      }
```

Running a second one (expected to succeed) after I added back the `registrationMethod: internal-first` to the Class: https://github.com/rancher/turtles/actions/runs/14362168776

The observed behavior when `registrationMethod` is not defined, is that all nodes fail to join the Cluster, with the rke2-agent failing with:

```
failed to get CA certs: Get \"https://my-control-plane-endpoint:9345/cacerts\": context deadline exceeded
```

A proper fix depends on https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5525

Using  `registrationMethod: internal-first`  solves the provisioning problem, but will later fail on machine rollouts, so it's a temporary solution.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
