### PR TITLE
Fix node selector for AWS CPI

### DIFF
--- a/test/e2e/data/cpi-csi/aws.yaml
+++ b/test/e2e/data/cpi-csi/aws.yaml
@@ -33,11 +33,12 @@ data:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: node-role.kubernetes.io/control-plane
-                        operator: Exists
-                      - key: node-role.kubernetes.io/master
-                        operator: Exists
+                - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
           serviceAccountName: cloud-controller-manager
           containers:
             - name: aws-cloud-controller-manager


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Fix node selector for AWS CPI. These changes make it compatible with RKE2 and Kubeadm. Currently, nightly tests fail because CPI can't start on kubeadm clusters.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
