### PR TITLE
chore: bump caapf to v0.8.0

### DIFF
--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -49,7 +49,7 @@ data:
 
     # Addon providers
     - name:         "fleet"
-      url:          "https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/v0.7.4/addon-components.yaml"
+      url:          "https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/v0.8.0/addon-components.yaml"
       type:         "AddonProvider"
 
     # Image overrides


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump CAAPF to `v0.8.0`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
