### PR TITLE
test: increase cpu for aws/rke2 test

### DIFF
--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -51,6 +51,8 @@ variables:
   KUBERNETES_MANAGEMENT_AWS_REGION: "eu-west-2"
   AWS_CONTROL_PLANE_MACHINE_TYPE: "t3.large"
   AWS_NODE_MACHINE_TYPE: "t3.large"
+  AWS_RKE2_CONTROL_PLANE_MACHINE_TYPE: "t3.xlarge"
+  AWS_RKE2_NODE_MACHINE_TYPE: "t3.xlarge"
   AWS_AMI_ID: "ami-0054630107ba40e56" # Public upstream AMI
 
   # CLI Tool Paths

--- a/test/e2e/data/cluster-templates/aws-ec2-rke2-topology.yaml
+++ b/test/e2e/data/cluster-templates/aws-ec2-rke2-topology.yaml
@@ -23,9 +23,9 @@ spec:
     - name: sshKeyName
       value: ${AWS_SSH_KEY_NAME}
     - name: controlPlaneMachineType
-      value: ${AWS_CONTROL_PLANE_MACHINE_TYPE}
+      value: ${AWS_RKE2_CONTROL_PLANE_MACHINE_TYPE}
     - name: workerMachineType
-      value: ${AWS_NODE_MACHINE_TYPE}
+      value: ${AWS_RKE2_NODE_MACHINE_TYPE}
     - name: amiID
       value: ${AWS_AMI_ID}
     version: ${KUBERNETES_VERSION}+rke2r1


### PR DESCRIPTION
**What this PR does / why we need it**:

Looks like AWS/RKE2 tests are intermittently failing and the workload seems to have a very high CPU usage. In some of executions where an error occurs, the cluster is provisioned successfully, the Rancher agent is deployed and validated and the cluster is fully functional. Then, before finishing all checks, it just stops responding. This would also explain why this error happens randomly and some tests just pass.

To remediate this, we can go up in the size of the EC2 instances used. To avoid increasing costs for AWS/Kubeadm, where we don't encounter this issue, a new variable is added to set the machine type for AWS/RKE2 only.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Let's run a full nightly E2E to validate that this is in fact solving the issue.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
