### PR TITLE
Use rancherInstalled value for FleetAddon ConfigMap sync

### DIFF
--- a/charts/rancher-turtles/templates/addon-provider-fleet.yaml
+++ b/charts/rancher-turtles/templates/addon-provider-fleet.yaml
@@ -31,12 +31,14 @@ data:
     spec:
       config:
         featureGates:
+        {{- if index .Values "rancherTurtles" "rancherInstalled" }}
           configMap:
             ref:
               kind: ConfigMap
               apiVersion: v1
               name: rancher-config
               namespace: cattle-system
+        {{- end }}
           experimentalOciStorage: true
           experimentalHelmOps: true
       clusterClass:


### PR DESCRIPTION
**What this PR does / why we need it**:
Only use CAAPF ConfigMap sync if Rancher is installed.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
