### PR TITLE
:seedling: Promote agent-tls-mode feature to beta

### DIFF
--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -39,10 +39,10 @@ rancherTurtles:
       etcdBackupRestore:
         # enabled: Turn on (true) or off (false).
         enabled: false
-    # agent-tls-mode: Alpha feature for agent TLS.
+    # agent-tls-mode: Beta feature for agent TLS.
     agent-tls-mode:
       # enabled: Turn on or off.
-      enabled: false
+      enabled: true
     # clusterclass-operations: Alpha feature. Manages cluster class ops. Not ready for testing yet.
     clusterclass-operations:
       # enabled: Turn on or off.

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -35,6 +35,6 @@ func init() {
 }
 
 var defaultGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	AgentTLSMode: {Default: false, PreRelease: featuregate.Beta},
+	AgentTLSMode: {Default: true, PreRelease: featuregate.Beta},
 	UIPlugin:     {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/internal/controllers/import_controller_v3_test.go
+++ b/internal/controllers/import_controller_v3_test.go
@@ -52,6 +52,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		capiCluster              *clusterv1.Cluster
 		rancherClusters          *managementv3.ClusterList
 		rancherCluster           *managementv3.Cluster
+		agentTlsModeSetting      *managementv3.Setting
 		clusterRegistrationToken *managementv3.ClusterRegistrationToken
 		v1rancherCluster         *provisioningv1.Cluster
 		capiKubeconfigSecret     *corev1.Secret
@@ -105,6 +106,14 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		}
 
 		rancherClusters = &managementv3.ClusterList{}
+
+		agentTlsModeSetting = &managementv3.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "agent-tls-mode",
+			},
+			Default: "strict",
+			Value:   "system-store",
+		}
 
 		selectors = []client.ListOption{
 			client.MatchingLabels{
@@ -270,6 +279,8 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		Expect(cl.Create(ctx, capiKubeconfigSecret)).To(Succeed())
 
 		Expect(cl.Create(ctx, rancherCluster)).To(Succeed())
+
+		Expect(cl.Create(ctx, agentTlsModeSetting)).To(Succeed())
 
 		Eventually(ctx, func(g Gomega) {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Promoted agent-tls-mode to beta so it is now enabled by default. Note that the tests do not validate the behaviour when the mode is set to `strict` as that would also require a custom CA to be used which complicates test setup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1318 

**Special notes for your reviewer**:

Related docs PR: https://github.com/rancher/turtles-docs/pull/294

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
