### PR TITLE
Use predictable resourceGroup for AKS nodes

### DIFF
--- a/examples/clusterclasses/azure/clusterclass-aks-example.yaml
+++ b/examples/clusterclasses/azure/clusterclass-aks-example.yaml
@@ -118,6 +118,11 @@ spec:
               valueFrom:
                 variable: resourceGroup
             - op: add
+              path: "/spec/template/spec/nodeResourceGroupName"
+              valueFrom:
+                template: |
+                  {{ .resourceGroup }}-nodes
+            - op: add
               path: "/spec/template/spec/identityRef/name"
               valueFrom:
                 variable: azureClusterIdentityName


### PR DESCRIPTION
**What this PR does / why we need it**:
Just a smaller quality of life changes. 
By default Azure creates a randomized resource group for AKS nodes, for example: `MC_my-resource-group-w77s7_westeurope`. 

By reusing the already defined `resourceGroup` variable, we can better scope this group name. 
Additionally, this change should now also cover the `resourceGroup` in the [cleanup job](https://github.com/rancher/turtles/blob/main/.github/workflows/e2e-cleanup.yaml#L42), which is not the case currently due to the `MC_` prefix.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
