### PR TITLE
Bump RKE2 version in e2e

### DIFF
--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -42,7 +42,7 @@ variables:
   # Kubernetes Configuration
   KUBERNETES_VERSION: "v1.31.4"
   KUBERNETES_MANAGEMENT_VERSION: "v1.31.4"
-  RKE2_VERSION: "v1.31.4+rke2r1"
+  RKE2_VERSION: "v1.31.7+rke2r1"
   RKE2_CNI: "none"
 
   # AWS Configuration

--- a/test/e2e/data/cluster-templates/aws-ec2-rke2-topology.yaml
+++ b/test/e2e/data/cluster-templates/aws-ec2-rke2-topology.yaml
@@ -28,7 +28,7 @@ spec:
       value: ${AWS_RKE2_NODE_MACHINE_TYPE}
     - name: amiID
       value: ${AWS_AMI_ID}
-    version: ${KUBERNETES_VERSION}+rke2r1
+    version: ${RKE2_VERSION}
     workers:
       machineDeployments:
       - class: default-worker

--- a/test/e2e/data/cluster-templates/azure-rke2-topology.yaml
+++ b/test/e2e/data/cluster-templates/azure-rke2-topology.yaml
@@ -46,7 +46,7 @@ spec:
       value: cluster-identity
     - name: registrationMethod
       value: internal-first
-    version: ${KUBERNETES_VERSION}+rke2r1
+    version: ${RKE2_VERSION}
     workers:
       machineDeployments:
       - class: rke2-default-worker


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Bump RKE2 version in e2e, this is needed to use a newer version of CoreDNS and reduce the number of flakes for cases where rancher server URL can't be resolved.

✅  https://github.com/rancher/turtles/actions/runs/14725052460

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
