### PR TITLE
vSphere Kubeadm Class improvements

### DIFF
--- a/examples/clusterclasses/vsphere/kubeadm/clusterclass-kubeadm-example.yaml
+++ b/examples/clusterclasses/vsphere/kubeadm/clusterclass-kubeadm-example.yaml
@@ -1,94 +1,121 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: VSphereClusterTemplate
-metadata:
-  name: 'vsphere-kubeadm-example'
-spec:
-  template:
-    spec: {}
----
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
-  name: 'vsphere-kubeadm-example'
+  name: vsphere-kubeadm-example
 spec:
   controlPlane:
-    machineInfrastructure:
-      ref:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: VSphereMachineTemplate
-        name: vsphere-kubeadm-example-template
     ref:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
       name: vsphere-kubeadm-example-controlplane
+    machineInfrastructure:
+      ref:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        name: vsphere-kubeadm-example-controlplane
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: VSphereClusterTemplate
-      name: 'vsphere-kubeadm-example'
+      name: vsphere-kubeadm-example
+  workers:
+    machineDeployments:
+    - class: vsphere-kubeadm-example-worker
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: vsphere-kubeadm-example-worker
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: VSphereMachineTemplate
+            name: vsphere-kubeadm-example-worker
+  variables:
+  - name: sshKey
+    required: false
+    schema:
+      openAPIV3Schema:
+        description: Public key to SSH onto the cluster nodes.
+        type: string
+  - name: controlPlaneIpAddr
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: Floating VIP for the control plane.
+        type: string
+  - name: controlPlanePort
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: Port for the control plane endpoint.
+        type: integer
+  - name: kubeVIPInterface
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: The interface name used by kube-vip in ARP mode.
+        type: string
+        default: eth0
+  - name: vSphereTLSThumbprint
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: "sha256 thumbprint of the vcenter certificate: openssl x509 -sha256 -fingerprint -in ca.crt -noout"
+        type: string
+  - name: vSphereClusterIdentityName
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: The VSphereClusterIdentity resource name referencing the credentials to create the Cluster.
+        type: string
+        default: cluster-identity
+  - name: vSphereServer
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: The vCenter server IP or FQDN.
+        type: string
+  - name: vSphereDataCenter
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: The vSphere datacenter to deploy the Cluster on.
+        type: string
+  - name: vSphereResourcePool
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: The vSphere resource pool for your VMs.
+        type: string
+  - name: vSphereDataStore
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: The vSphere datastore to deploy the Cluster on.
+        type: string
+  - name: vSphereNetwork
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: The VM network to deploy the Cluster on.
+        type: string
+  - name: vSphereFolder
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: The VM folder for your VMs. Set to "" to use the root vSphere folder.
+        type: string
+  - name: vSphereTemplate
+    required: true
+    schema:
+      openAPIV3Schema:
+        description: The VM template to use for your Cluster.
+        type: string
   patches:
-  - definitions:
-    - jsonPatches:
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/files
-        value: []
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/postKubeadmCommands
-        value: []
-      selector:
-        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-        kind: KubeadmControlPlaneTemplate
-        matchResources:
-          controlPlane: true
-    - jsonPatches:
-      - op: add
-        path: /spec/template/spec/files
-        value: []
-      - op: add
-        path: /spec/template/spec/postKubeadmCommands
-        value: []
-      selector:
-        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-        kind: KubeadmConfigTemplate
-        matchResources:
-          machineDeploymentClass:
-            names:
-            - vsphere-kubeadm-example-worker
-    name: createEmptyArrays
-  - definitions:
-    - jsonPatches:
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/users
-        valueFrom:
-          template: |
-            - name: capv
-              sshAuthorizedKeys:
-              - '{{ .sshKey }}'
-              sudo: ALL=(ALL) NOPASSWD:ALL
-      selector:
-        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-        kind: KubeadmControlPlaneTemplate
-        matchResources:
-          controlPlane: true
-    - jsonPatches:
-      - op: add
-        path: /spec/template/spec/users
-        valueFrom:
-          template: |
-            - name: capv
-              sshAuthorizedKeys:
-              - '{{ .sshKey }}'
-              sudo: ALL=(ALL) NOPASSWD:ALL
-      selector:
-        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-        kind: KubeadmConfigTemplate
-        matchResources:
-          machineDeploymentClass:
-            names:
-            - vsphere-kubeadm-example-worker
-    enabledIf: '{{ if .sshKey }}true{{end}}'
-    name: enableSSHIntoNodes
-  - definitions:
+  - name: infraCluster
+    definitions:
     - jsonPatches:
       - op: add
         path: /spec/template/spec/controlPlaneEndpoint
@@ -97,35 +124,166 @@ spec:
             host: '{{ .controlPlaneIpAddr }}'
             port: {{ .controlPlanePort }}
       - op: add
-        path: /spec/template/spec/identityRef
+        path: /spec/template/spec/identityRef/name
         valueFrom:
-          template: |
-            kind: Secret
-            name: '{{ .credsSecretName }}'
+          variable: vSphereClusterIdentityName
       - op: add
         path: /spec/template/spec/server
         valueFrom:
-          variable: infraServer.url
+          variable: vSphereServer
       - op: add
         path: /spec/template/spec/thumbprint
         valueFrom:
-          variable: infraServer.thumbprint
+          variable: vSphereTLSThumbprint
       selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: VSphereClusterTemplate
         matchResources:
           infrastructureCluster: true
-    name: infraClusterSubstitutions
-  - definitions:
+  - name: vsphereMachineTemplate
+    definitions:
     - jsonPatches:
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        path: /spec/template/spec
         valueFrom:
-          template: |-
-            owner: "root:root"
-            path: "/etc/kubernetes/manifests/kube-vip.yaml"
-            content: {{ printf "%q" (regexReplaceAll "(name: address\n +value:).*" .kubeVipPodManifest (printf "$1 %s" .controlPlaneIpAddr)) }}
-            permissions: "0644"
+          template: |
+            cloneMode: linkedClone
+            datacenter: '{{ .vSphereDataCenter }}'
+            datastore: '{{ .vSphereDataStore }}'
+            diskGiB: 25
+            folder: '{{ .vSphereFolder }}'
+            memoryMiB: 8192
+            network:
+              devices:
+              - dhcp4: true
+                networkName: '{{ .vSphereNetwork }}'
+            numCPUs: 2
+            os: Linux
+            powerOffMode: trySoft
+            resourcePool: '{{ .vSphereResourcePool }}'
+            server: '{{ .vSphereServer }}'
+            storagePolicyName: ''
+            template: '{{ .vSphereTemplate }}'
+      selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          controlPlane: true
+    - jsonPatches:  
+      - op: add
+        path: /spec/template/spec
+        valueFrom:
+          template: |
+            cloneMode: linkedClone
+            datacenter: '{{ .vSphereDataCenter }}'
+            datastore: '{{ .vSphereDataStore }}'
+            diskGiB: 25
+            folder: '{{ .vSphereFolder }}'
+            memoryMiB: 8192
+            network:
+              devices:
+              - dhcp4: true
+                networkName: '{{ .vSphereNetwork }}'
+            numCPUs: 2
+            os: Linux
+            powerOffMode: trySoft
+            resourcePool: '{{ .vSphereResourcePool }}'
+            server: '{{ .vSphereServer }}'
+            storagePolicyName: ''
+            template: '{{ .vSphereTemplate }}'
+      selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          machineDeploymentClass:
+            names: 
+            - vsphere-kubeadm-example-worker
+  - name: kubeadmControlPlaneTemplate
+    definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files
+        valueFrom:
+          template: |
+            - path: "/etc/kubernetes/manifests/kube-vip.yaml"
+              owner: "root:root"
+              permissions: "0640"
+              content: |
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  creationTimestamp: null
+                  name: kube-vip
+                  namespace: kube-system
+                spec:
+                  containers:
+                  - args:
+                    - manager
+                    env:
+                    - name: vip_arp
+                      value: "true"
+                    - name: port
+                      value: "{{ .controlPlanePort }}"
+                    - name: vip_nodename
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: spec.nodeName
+                    - name: vip_interface
+                      value: "{{ .kubeVIPInterface }}"
+                    - name: vip_subnet
+                      value: "32"
+                    - name: dns_mode
+                      value: first
+                    - name: cp_enable
+                      value: "true"
+                    - name: cp_namespace
+                      value: kube-system
+                    - name: svc_enable
+                      value: "true"
+                    - name: svc_leasename
+                      value: plndr-svcs-lock
+                    - name: vip_leaderelection
+                      value: "true"
+                    - name: vip_leasename
+                      value: plndr-cp-lock
+                    - name: vip_leaseduration
+                      value: "5"
+                    - name: vip_renewdeadline
+                      value: "3"
+                    - name: vip_retryperiod
+                      value: "1"
+                    - name: address
+                      value: "{{ .controlPlaneIpAddr }}"
+                    - name: prometheus_server
+                      value: :2112
+                    image: ghcr.io/kube-vip/kube-vip:v0.9.1
+                    imagePullPolicy: IfNotPresent
+                    name: kube-vip
+                    resources: {}
+                    securityContext:
+                      capabilities:
+                        add:
+                        - NET_ADMIN
+                        - NET_RAW
+                        drop:
+                        - ALL
+                    volumeMounts:
+                    - mountPath: /etc/kubernetes/admin.conf
+                      name: kubeconfig
+                    - mountPath: /etc/hosts
+                      name: etchosts
+                  hostAliases:
+                  - hostnames:
+                    - kubernetes
+                    ip: 127.0.0.1
+                  hostNetwork: true
+                  volumes:
+                  - hostPath:
+                      path: /etc/kubernetes/admin.conf
+                    name: kubeconfig
+                  - hostPath:
+                      path: /etc/kube-vip.hosts
+                    name: etchosts
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
@@ -185,212 +343,48 @@ spec:
             owner: root:root
             path: /etc/pre-kubeadm-commands/50-kube-vip-prepare.sh
             permissions: "0700"
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/users
+        valueFrom:
+          template: |
+            - name: capv
+              sshAuthorizedKeys:
+              - '{{ .sshKey }}'
+              sudo: ALL=(ALL) NOPASSWD:ALL
       selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
         kind: KubeadmControlPlaneTemplate
         matchResources:
           controlPlane: true
-    name: kubeVipPodManifest
-  - definitions:
+  - name: kubeadmConfigTemplate
+    definitions:
     - jsonPatches:
       - op: add
-        path: /spec/template/spec
+        path: /spec/template/spec/users
         valueFrom:
           template: |
-            cloneMode: linkedClone
-            datacenter: '{{ .vsphereDataCenter }}'
-            datastore: '{{ .vsphereDataStore }}'
-            diskGiB: 25
-            folder: '{{ .vsphereFolder }}'
-            memoryMiB: 8192
-            network:
-              devices:
-              - dhcp4: true
-                networkName: '{{ .vsphereNetwork }}'
-            numCPUs: 2
-            os: Linux
-            powerOffMode: trySoft
-            resourcePool: '{{ .vsphereResourcePool }}'
-            server: '{{ .vsphereServer }}'
-            storagePolicyName: '{{ .vsphereStorageServer }}'
-            template: '{{ .vsphereTemplate }}'
+            - name: capv
+              sshAuthorizedKeys:
+              - '{{ .sshKey }}'
+              sudo: ALL=(ALL) NOPASSWD:ALL
       selector:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: VSphereMachineTemplate
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
         matchResources:
-          controlPlane: true
           machineDeploymentClass:
             names:
             - vsphere-kubeadm-example-worker
-    name: vsphereMachineTemplateSpec
-  variables:
-  - metadata: {}
-    name: sshKey
-    required: false
-    schema:
-      openAPIV3Schema:
-        description: Public key to SSH onto the cluster nodes.
-        type: string
-  - metadata: {}
-    name: controlPlaneIpAddr
-    required: true
-    schema:
-      openAPIV3Schema:
-        description: Floating VIP for the control plane.
-        type: string
-  - metadata: {}
-    name: controlPlanePort
-    required: true
-    schema:
-      openAPIV3Schema:
-        description: Port for the control plane endpoint.
-        type: integer
-  - metadata: {}
-    name: kubeVipPodManifest
-    required: true
-    schema:
-      openAPIV3Schema:
-        description: kube-vip manifest for the control plane.
-        type: string
-  - metadata: {}
-    name: infraServer
-    required: true
-    schema:
-      openAPIV3Schema:
-        properties:
-          thumbprint:
-            type: string
-          url:
-            type: string
-        type: object
-  - metadata: {}
-    name: credsSecretName
-    required: true
-    schema:
-      openAPIV3Schema:
-        description: Secret containing the credentials for the infra cluster.
-        type: string
-  - metadata: {}
-    name: vsphereDataCenter
-    required: true
-    schema:
-      openAPIV3Schema:
-        description: vSphere data center
-        type: string
-  - metadata: {}
-    name: vsphereDataStore
-    required: true
-    schema:
-      openAPIV3Schema:
-        description: vSphere data store
-        type: string
-  - metadata: {}
-    name: vsphereFolder
-    required: true
-    schema:
-      openAPIV3Schema:
-        description: vSphere folder name
-        type: string
-  - metadata: {}
-    name: vsphereNetwork
-    required: true
-    schema:
-      openAPIV3Schema:
-        description: vSphere network name
-        type: string
-  - metadata: {}
-    name: vsphereResourcePool
-    required: true
-    schema:
-      openAPIV3Schema:
-        description: vSphere resource pool
-        type: string
-  - metadata: {}
-    name: vsphereServer
-    required: true
-    schema:
-      openAPIV3Schema:
-        description: vSphere server
-        type: string
-  - metadata: {}
-    name: vsphereStorageServer
-    required: true
-    schema:
-      openAPIV3Schema:
-        description: vSphere storage server
-        type: string
-  - metadata: {}
-    name: vsphereTemplate
-    required: true
-    schema:
-      openAPIV3Schema:
-        description: vSphere machine template
-        type: string
-  workers:
-    machineDeployments:
-    - class: vsphere-kubeadm-example-worker
-      template:
-        bootstrap:
-          ref:
-            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-            kind: KubeadmConfigTemplate
-            name: vsphere-kubeadm-example-worker-bootstrap-template
-        infrastructure:
-          ref:
-            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-            kind: VSphereMachineTemplate
-            name: vsphere-kubeadm-example-worker-machinetemplate
-        metadata: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: VSphereMachineTemplate
+kind: VSphereClusterTemplate
 metadata:
-  name: vsphere-kubeadm-example-template
+  name: vsphere-kubeadm-example
 spec:
   template:
     spec:
-      cloneMode: linkedClone
-      datacenter: 'set-by-patch'
-      datastore: 'set-by-patch'
-      diskGiB: 25
-      folder: 'set-by-patch'
-      memoryMiB: 8192
-      network:
-        devices:
-        - dhcp4: true
-          networkName: 'set-by-patch'
-      numCPUs: 2
-      os: Linux
-      powerOffMode: trySoft
-      resourcePool: 'set-by-patch'
-      server: 'set-by-patch'
-      storagePolicyName: 'set-by-patch'
-      template: 'set-by-patch'
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: VSphereMachineTemplate
-metadata:
-  name: vsphere-kubeadm-example-worker-machinetemplate
-spec:
-  template:
-    spec:
-      cloneMode: linkedClone
-      datacenter: 'set-by-patch'
-      datastore: 'set-by-patch'
-      diskGiB: 25
-      folder: 'set-by-patch'
-      memoryMiB: 8192
-      network:
-        devices:
-        - dhcp4: true
-          networkName: 'set-by-patch'
-      numCPUs: 2
-      os: Linux
-      powerOffMode: trySoft
-      resourcePool: 'set-by-patch'
-      server: 'set-by-patch'
-      storagePolicyName: 'set-by-patch'
-      template: 'set-by-patch'
+      identityRef:
+        kind: VSphereClusterIdentity
+        name: cluster-identity
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlaneTemplate
@@ -418,23 +412,15 @@ spec:
             name: '{{ local_hostname }}'
         preKubeadmCommands:
         - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
-        - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6"
-          >/etc/hosts
-        - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
-          localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+        - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6" >/etc/hosts
+        - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
         - mkdir -p /etc/pre-kubeadm-commands
-        - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
-          do echo "Running script $script"; "$script"; done
-        users:
-        - name: capv
-          sshAuthorizedKeys:
-          - ''
-          sudo: ALL=(ALL) NOPASSWD:ALL
+        - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort); do echo "Running script $script"; "$script"; done
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: vsphere-kubeadm-example-worker-bootstrap-template
+  name: vsphere-kubeadm-example-worker
 spec:
   template:
     spec:
@@ -446,10 +432,33 @@ spec:
           name: '{{ local_hostname }}'
       preKubeadmCommands:
       - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
-      - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6"
-        >/etc/hosts
-      - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost
-        localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
+      - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6" >/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }} {{ local_hostname }} localhost localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
       - mkdir -p /etc/pre-kubeadm-commands
-      - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
-        do echo "Running script $script"; "$script"; done
+      - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort); do echo "Running script $script"; "$script"; done
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: vsphere-kubeadm-example-controlplane
+spec:
+  template:
+    # Hardcoded values will not be respected.
+    # Configure everything via patch.
+    spec:
+      template: 'set-by-patch'
+      network:
+       devices: []
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: vsphere-kubeadm-example-worker
+spec:
+  template:
+    # Hardcoded values will not be respected.
+    # Configure everything via patch.
+    spec:
+      template: 'set-by-patch'
+      network:
+       devices: []

--- a/examples/clusterclasses/vsphere/rke2/clusterclass-rke2-example.yaml
+++ b/examples/clusterclasses/vsphere/rke2/clusterclass-rke2-example.yaml
@@ -204,44 +204,11 @@ spec:
       - op: add
         path: /spec/template/spec/files
         valueFrom:
-          template: |-
-            - path: "/var/lib/rancher/rke2/server/manifests/kubevip.yaml"
+          template: |
+            - path: "/var/lib/rancher/rke2/server/manifests/kube-vip.yaml"
               owner: "root:root"
               permissions: "0640"
-              content: |-
-                apiVersion: v1
-                kind: ServiceAccount
-                metadata:
-                  name: kube-vip
-                  namespace: kube-system
-                ---
-                apiVersion: rbac.authorization.k8s.io/v1
-                kind: ClusterRole
-                metadata:
-                  annotations:
-                    rbac.authorization.kubernetes.io/autoupdate: "true"
-                  name: system:kube-vip-role
-                rules:
-                  - apiGroups: [""]
-                    resources: ["services", "services/status", "nodes"]
-                    verbs: ["list","get","watch", "update"]
-                  - apiGroups: ["coordination.k8s.io"]
-                    resources: ["leases"]
-                    verbs: ["list", "get", "watch", "update", "create"]
-                ---
-                kind: ClusterRoleBinding
-                apiVersion: rbac.authorization.k8s.io/v1
-                metadata:
-                  name: system:kube-vip-binding
-                roleRef:
-                  apiGroup: rbac.authorization.k8s.io
-                  kind: ClusterRole
-                  name: system:kube-vip-role
-                subjects:
-                - kind: ServiceAccount
-                  name: kube-vip
-                  namespace: kube-system
-                ---
+              content: |
                 apiVersion: v1
                 kind: Pod
                 metadata:
@@ -270,7 +237,7 @@ spec:
                           fieldPath: spec.nodeName
                     - name: vip_interface
                       value: "{{ .kubeVIPInterface }}"
-                    - name: vip_cidr
+                    - name: vip_subnet
                       value: "32"
                     - name: dns_mode
                       value: first
@@ -296,7 +263,7 @@ spec:
                       value: "{{ .controlPlaneIpAddr }}"
                     - name: prometheus_server
                       value: :2112
-                    image: ghcr.io/kube-vip/kube-vip:v0.8.10
+                    image: ghcr.io/kube-vip/kube-vip:v0.9.1
                     imagePullPolicy: IfNotPresent
                     name: kube-vip
                     resources: {}
@@ -315,11 +282,9 @@ spec:
                     - kubernetes
                     ip: 127.0.0.1
                   hostNetwork: true
-                  serviceAccountName: kube-vip
                   volumes:
                   - hostPath:
                       path: /etc/rancher/rke2/rke2.yaml
-                      type: File
                     name: kubeconfig
       - op: add
         path: /spec/template/spec/agentConfig/additionalUserData

--- a/test/e2e/data/cluster-templates/vsphere-kubeadm-topology.yaml
+++ b/test/e2e/data/cluster-templates/vsphere-kubeadm-topology.yaml
@@ -1,235 +1,120 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereClusterIdentity
+metadata:
+  name: cluster-identity
+spec:
+  secretName: cluster-identity
+  allowedNamespaces:
+    selector:
+      matchLabels: {}
+---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  labels:
-    cni: calico
-    cloud-provider: vsphere
-    csi: vsphere
   name: '${CLUSTER_NAME}'
   namespace: '${NAMESPACE}'
+  labels:
+    cni: calico
+    csi: vsphere
+    cloud-provider: vsphere
 spec:
   clusterNetwork:
     pods:
       cidrBlocks:
       - 192.168.0.0/16
   topology:
-    class: 'vsphere-kubeadm-example'
+    class: vsphere-kubeadm-example
     classNamespace: ${TOPOLOGY_NAMESPACE}
+    version: ${KUBERNETES_VERSION}
     controlPlane:
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
-    variables:
-    - name: sshKey
-      value: '${VSPHERE_SSH_AUTHORIZED_KEY}'
-    - name: kubeVipPodManifest
-      value: |
-        apiVersion: v1
-        kind: Pod
-        metadata:
-          creationTimestamp: null
-          name: kube-vip
-          namespace: kube-system
-        spec:
-          containers:
-          - args:
-            - manager
-            env:
-            - name: vip_arp
-              value: "true"
-            - name: port
-              value: "6443"
-            - name: vip_nodename
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: vip_interface
-              value: eth0
-            - name: vip_cidr
-              value: "32"
-            - name: dns_mode
-              value: first
-            - name: cp_enable
-              value: "true"
-            - name: cp_namespace
-              value: kube-system
-            - name: svc_enable
-              value: "true"
-            - name: svc_leasename
-              value: plndr-svcs-lock
-            - name: vip_leaderelection
-              value: "true"
-            - name: vip_leasename
-              value: plndr-cp-lock
-            - name: vip_leaseduration
-              value: "5"
-            - name: vip_renewdeadline
-              value: "3"
-            - name: vip_retryperiod
-              value: "1"
-            - name: address
-              value: ${CONTROL_PLANE_ENDPOINT_IP}
-            - name: prometheus_server
-              value: :2112
-            image: ghcr.io/kube-vip/kube-vip:v0.8.10
-            imagePullPolicy: IfNotPresent
-            name: kube-vip
-            resources: {}
-            securityContext:
-              capabilities:
-                add:
-                - NET_ADMIN
-                - NET_RAW
-                drop:
-                - ALL
-            volumeMounts:
-            - mountPath: /etc/kubernetes/admin.conf
-              name: kubeconfig
-            - mountPath: /etc/hosts
-              name: etchosts
-          hostNetwork: true
-          volumes:
-          - hostPath:
-              path: /etc/kubernetes/super-admin.conf
-              type: File
-            name: kubeconfig
-          - hostPath:
-              path: /etc/kube-vip.hosts
-              type: File
-            name: etchosts
-    - name: controlPlaneIpAddr
-      value: ${CONTROL_PLANE_ENDPOINT_IP}
-    - name: controlPlanePort
-      value: 6443
-    - name: infraServer
-      value:
-        thumbprint: '${VSPHERE_TLS_THUMBPRINT}'
-        url: '${VSPHERE_SERVER}'
-    - name: credsSecretName
-      value: '${CLUSTER_NAME}'
-    - name: vsphereDataCenter
-      value: '${VSPHERE_DATACENTER}'
-    - name: vsphereDataStore
-      value: '${VSPHERE_DATASTORE}'
-    - name: vsphereFolder
-      value: '${VSPHERE_FOLDER}'
-    - name: vsphereNetwork
-      value: '${VSPHERE_NETWORK}'
-    - name: vsphereResourcePool
-      value: '${VSPHERE_RESOURCE_POOL}'
-    - name: vsphereServer
-      value: '${VSPHERE_SERVER}'
-    - name: vsphereStorageServer
-      value: '${VSPHERE_STORAGE_SERVER}'
-    - name: vsphereTemplate
-      value: '${VSPHERE_TEMPLATE}'
-    version: '${KUBERNETES_VERSION}'
     workers:
       machineDeployments:
       - class: vsphere-kubeadm-example-worker
-        metadata: {}
         name: md-0
         replicas: ${WORKER_MACHINE_COUNT}
+    variables:
+    - name: vSphereClusterIdentityName
+      value: cluster-identity
+    - name: vSphereTLSThumbprint
+      value: '${VSPHERE_TLS_THUMBPRINT}'
+    - name: vSphereDataCenter
+      value: '${VSPHERE_DATACENTER}'
+    - name: vSphereDataStore
+      value: '${VSPHERE_DATASTORE}'
+    - name: vSphereFolder
+      value: '${VSPHERE_FOLDER}'
+    - name: vSphereNetwork
+      value: '${VSPHERE_NETWORK}'
+    - name: vSphereResourcePool
+      value: '${VSPHERE_RESOURCE_POOL}'
+    - name: vSphereServer
+      value: '${VSPHERE_SERVER}'
+    - name: vSphereTemplate
+      value: '${VSPHERE_TEMPLATE}'
+    - name: controlPlaneIpAddr
+      value: '${CONTROL_PLANE_ENDPOINT_IP}'
+    - name: controlPlanePort
+      value: 6443
+    - name: kubeVIPInterface
+      value: eth0
 ---
-apiVersion: v1
-kind: Secret
+kind: Bundle
+apiVersion: fleet.cattle.io/v1alpha1
 metadata:
-  name: '${CLUSTER_NAME}'
-  namespace: '${NAMESPACE}'
-stringData:
-  password: "${VSPHERE_PASSWORD}"
-  username: "${VSPHERE_USERNAME}"
----
-apiVersion: addons.cluster.x-k8s.io/v1beta1
-kind: ClusterResourceSet
-metadata:
-  name: ${CLUSTER_NAME}-crs-0
+  name: vsphere-csi-config
   namespace: '${NAMESPACE}'
 spec:
-  clusterSelector:
-    matchLabels:
-      cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
   resources:
-  - kind: Secret
-    name: vsphere-config-secret
-  - kind: Secret
-    name: cloud-provider-vsphere-credentials
-  - kind: ConfigMap
-    name: cpi-configmap
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: vsphere-config-secret
-  namespace: '${NAMESPACE}'
-stringData:
-  data: |-
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: vsphere-config-secret
-      namespace: vmware-system-csi
-    stringData:
-      csi-vsphere.conf: |+
-        [Global]
-        thumbprint = "${VSPHERE_TLS_THUMBPRINT}"
+  - content: |-
+      apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        name: vsphere-config-secret
+        namespace: vmware-system-csi
+      stringData:
+        csi-vsphere.conf: |+
+          [Global]
+          thumbprint = "${VSPHERE_TLS_THUMBPRINT}"
 
-        [VirtualCenter "${VSPHERE_SERVER}"]
-        user = "${VSPHERE_USERNAME}"
-        password = "${VSPHERE_PASSWORD}"
-        datacenters = "${VSPHERE_DATACENTER}"
+          [VirtualCenter "${VSPHERE_SERVER}"]
+          user = "${VSPHERE_USERNAME}"
+          password = "${VSPHERE_PASSWORD}"
+          datacenters = "${VSPHERE_DATACENTER}"
 
-        [Network]
-        public-network = "${VSPHERE_NETWORK}"
+          [Network]
+          public-network = "${VSPHERE_NETWORK}"
 
-    type: Opaque
-type: addons.cluster.x-k8s.io/resource-set
+          [Labels]
+          region = ""
+          zone = ""
+  targets:
+  - clusterSelector:
+      matchLabels:
+        csi: vsphere
+        cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
 ---
-apiVersion: v1
-kind: Secret
+kind: Bundle
+apiVersion: fleet.cattle.io/v1alpha1
 metadata:
-  name: cloud-provider-vsphere-credentials
+  name: vsphere-cloud-credentials
   namespace: '${NAMESPACE}'
-stringData:
-  data: |-
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      labels:
-        component: cloud-controller-manager
-        vsphere-cpi-infra: secret
-      name: cloud-provider-vsphere-credentials
-      namespace: kube-system
-    stringData:
-      ${VSPHERE_SERVER}.password: "${VSPHERE_PASSWORD}"
-      ${VSPHERE_SERVER}.username: "${VSPHERE_USERNAME}"
-    type: Opaque
-type: addons.cluster.x-k8s.io/resource-set
+spec:
+  resources:
+  - content: |-
+      apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        name: vsphere-cloud-secret
+        namespace: kube-system
+      stringData:
+        ${VSPHERE_SERVER}.password: "${VSPHERE_PASSWORD}"
+        ${VSPHERE_SERVER}.username: "${VSPHERE_USERNAME}"
+  targets:
+  - clusterSelector:
+      matchLabels:
+        cloud-provider: vsphere
+        cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
 ---
-apiVersion: v1
-data:
-  data: |-
-    ---
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: cloud-config
-      labels:
-        app: "cpi"
-        vsphere-cpi-infra: cloud-config
-        component: cloud-controller-manager
-      namespace: kube-system
-    data:
-      vsphere.conf: |
-        global:
-          port: 443
-          thumbprint: "${VSPHERE_TLS_THUMBPRINT}"
-          secretName: cloud-provider-vsphere-credentials
-          secretNamespace: kube-system
-        vcenter:
-          "${VSPHERE_SERVER}":
-            server: "${VSPHERE_SERVER}"
-            datacenters:
-              - "${VSPHERE_DATACENTER}"
-kind: ConfigMap
-metadata:
-  name: cpi-configmap
-  namespace: '${NAMESPACE}'

--- a/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
+++ b/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
@@ -484,7 +484,7 @@ var _ = Describe("[GCP] [GKE] Create and delete CAPI cluster functionality shoul
 	})
 })
 
-var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster from cluster class", Ordered, Label("skip"), func() {
+var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster from cluster class", Ordered, Label(e2e.VsphereTestLabel, e2e.KubeadmTestLabel), func() {
 	var topologyNamespace string
 
 	BeforeEach(func() {
@@ -506,18 +506,19 @@ var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster from cluste
 				e2e.CapvProvider,
 				e2e.CapiProviders,
 			},
-			WaitForDeployments: []testenv.NamespaceName{
+			WaitForDeployments: append([]testenv.NamespaceName{
 				{
 					Name:      "capv-controller-manager",
 					Namespace: "capv-system",
 				},
-			},
+			}, testenv.DefaultDeployments...),
 		})
 
 		return specs.CreateMgmtV3UsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIvSphereKubeadmTopology,
+			TopologyNamespace:              topologyNamespace,
 			ClusterName:                    "cluster-vsphere-kubeadm",
 			ControlPlaneMachineCount:       ptr.To(1),
 			WorkerMachineCount:             ptr.To(1),
@@ -528,10 +529,6 @@ var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster from cluste
 			CapiClusterOwnerLabel:          e2e.CapiClusterOwnerLabel,
 			CapiClusterOwnerNamespaceLabel: e2e.CapiClusterOwnerNamespaceLabel,
 			OwnedLabelName:                 e2e.OwnedLabelName,
-			TopologyNamespace:              topologyNamespace,
-			AdditionalTemplateVariables: map[string]string{
-				"VIP_NETWORK_INTERFACE": "",
-			},
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "vsphere-cluster-classes-kubeadm",


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactor the Kubeadm vSphere class to align with the RKE2 one.

This also includes usage of VSphereClusterIdentity.
e2e test has also been added to the suite (previously skipped).

Test run: https://github.com/rancher/turtles/actions/runs/14776183446/job/41484866481
Docs: https://github.com/rancher/turtles-docs/pull/297

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher/turtles/issues/1200

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
