### PR TITLE
Override CAAPF provider image source to downstream one

### DIFF
--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -49,7 +49,7 @@ data:
 
     # Addon providers
     - name:         "fleet"
-      url:          "https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/v0.8.1/addon-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-addon-provider-fleet/releases/v0.8.1/addon-components.yaml"
       type:         "AddonProvider"
 
     # Image overrides
@@ -67,4 +67,6 @@ data:
       infrastructure-gcp:
         repository: "registry.suse.com/rancher"
       infrastructure-vsphere:
+        repository: "registry.suse.com/rancher"
+      addon-fleet:
         repository: "registry.suse.com/rancher"

--- a/internal/controllers/clusterctl/config_test.go
+++ b/internal/controllers/clusterctl/config_test.go
@@ -99,7 +99,7 @@ data:
 							{
 								Name: "fleet",
 								Type: "AddonProvider",
-								URL:  "https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/v0.4.0/addon-components.yaml",
+								URL:  "https://github.com/rancher/cluster-api-addon-provider-fleet/releases/v0.4.0/addon-components.yaml",
 							},
 						},
 						Images: []v1alpha1.Image{
@@ -153,7 +153,7 @@ data:
 		Expect(configRepo.Providers).To(ContainElement(v1alpha1.Provider{
 			Name: "fleet",
 			Type: "AddonProvider",
-			URL:  "https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/v0.4.0/addon-components.yaml",
+			URL:  "https://github.com/rancher/cluster-api-addon-provider-fleet/releases/v0.4.0/addon-components.yaml",
 		}))
 	})
 })

--- a/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
+++ b/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
@@ -119,6 +119,17 @@ var _ = Describe("Chart upgrade functionality should work", Label(e2e.ShortTestL
 			}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
 		}, func() {
 			framework.WaitForCAPIProviderRollout(ctx, framework.WaitForCAPIProviderRolloutInput{
+				Getter: bootstrapClusterProxy.GetClient(),
+				Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+					Name:      "caapf-controller-manager",
+					Namespace: "rancher-turtles-system",
+				}},
+				Image:     "registry.suse.com/rancher/cluster-api-addon-provider-fleet:",
+				Name:      "fleet",
+				Namespace: "rancher-turtles-system",
+			}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+		}, func() {
+			framework.WaitForCAPIProviderRollout(ctx, framework.WaitForCAPIProviderRolloutInput{
 				Getter:    bootstrapClusterProxy.GetClient(),
 				Version:   e2e.CAPIVersion,
 				Name:      "docker",

--- a/updatecli/updatecli.d/manifest.yaml
+++ b/updatecli/updatecli.d/manifest.yaml
@@ -197,8 +197,8 @@ targets:
     kind: file
     spec:
       file: ./internal/controllers/clusterctl/config.yaml
-      matchpattern: 'https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/(.*)/'
-      replacepattern: 'https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/releases/{{ source "capifleetrelease" }}/'
+      matchpattern: 'https://github.com/rancher/cluster-api-addon-provider-fleet/releases/(.*)/'
+      replacepattern: 'https://github.com/rancher/cluster-api-addon-provider-fleet/releases/{{ source "capifleetrelease" }}/'
     scmid: turtles
     sourceid: capifleetrelease # Will be ignored as `replacepattern` is specified
   bumpcapioperator:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Clusterctl overrides didn’t include `CAAPF` source at this point. This change adds override to the list of other providers with image overrides, and adds e2e tests on top.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1340 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
