### PR TITLE
Revert "Use rancherInstalled value for FleetAddon ConfigMap sync"

### DIFF
--- a/charts/rancher-turtles/templates/addon-provider-fleet.yaml
+++ b/charts/rancher-turtles/templates/addon-provider-fleet.yaml
@@ -29,14 +29,12 @@ data:
     spec:
       config:
         featureGates:
-        {{- if index .Values "rancherTurtles" "rancherInstalled" }}
           configMap:
             ref:
               kind: ConfigMap
               apiVersion: v1
               name: rancher-config
               namespace: cattle-system
-        {{- end }}
           experimentalOciStorage: true
           experimentalHelmOps: true
       clusterClass:


### PR DESCRIPTION
Reverts rancher/turtles#1322 to solve the [issue](https://github.com/rancher/turtles/pull/1322#discussion_r2070013837)