### PR TITLE
Enable long run in pre-submits via the merge-queue

### DIFF
--- a/.github/workflows/e2e-long.yaml
+++ b/.github/workflows/e2e-long.yaml
@@ -1,11 +1,16 @@
-name: Run nightly e2e tests
+name: Run long e2e tests
 
 on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+  merge_group:
 
-concurrency: ci_e2e_tests
+concurrency:
+  group: ci-${{ github.ref }}
+
+env:
+  GINKGO_LABEL_FILTER: ${{ github.event.pull_request.labels && (contains(join(github.event.pull_request.labels.*.name, ','), 'test/full') && 'full' || '') || 'full' }}
 
 jobs:
   publish_e2e_image:

--- a/test/e2e/specs/etcd_snapshot_restore.go
+++ b/test/e2e/specs/etcd_snapshot_restore.go
@@ -39,6 +39,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -146,6 +147,9 @@ func ETCDSnapshotRestore(ctx context.Context, inputGetter func() ETCDSnapshotRes
 		Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
 		input = inputGetter()
 		Expect(turtlesframework.Parse(&input)).To(Succeed(), "Failed to parse environment variables")
+
+		input.ClusterName = fmt.Sprintf("%s-%s", input.ClusterName, util.RandomString(6))
+		turtlesframework.Byf("Testing with cluster %s", input.ClusterName)
 
 		Expect(input.E2EConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
 		Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)

--- a/test/e2e/specs/import_gitops_mgmtv3.go
+++ b/test/e2e/specs/import_gitops_mgmtv3.go
@@ -39,6 +39,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
@@ -177,6 +178,9 @@ func CreateMgmtV3UsingGitOpsSpec(ctx context.Context, inputGetter func() CreateM
 		Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
 		input = inputGetter()
 		Expect(turtlesframework.Parse(&input)).To(Succeed(), "Failed to parse environment variables")
+
+		input.ClusterName = fmt.Sprintf("%s-%s", input.ClusterName, util.RandomString(6))
+		turtlesframework.Byf("Testing with cluster %s", input.ClusterName)
 
 		Expect(input.E2EConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
 		Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This change would automate the nightly run for every PR, instead of requiring the reviewer to attach one automatically. This check can be made mandatory to prevent merges with failing long e2e tests later, if needed.

Such change would eliminate situations when several independent PRs are merged simultaneously, and all have attached successful nightly runs, but in combination they cause nightlies to fail.

Merge queues perform checks in a sequential order, with all PRs currently in the queue rebased on top of each other. Therefore, it follows the established concurrency pattern, but in order to eliminate conflicts between regular nightly runs and merge queue ones, the `concurrency: ci_e2e_tests` is lifted, and each cluster uses a unique name now.

In addition to that, it uses a specific [temporary branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-third-party-ci-providers) created in the `rancher/turtles` repo. Therefore, a merge queue run has access to repository secrets as any other nightly run.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
