### PR TITLE
Perform create only after sync operation

### DIFF
--- a/internal/sync/core_test.go
+++ b/internal/sync/core_test.go
@@ -105,6 +105,7 @@ var _ = Describe("Core provider", func() {
 
 		s := sync.NewDefaultSynchronizer(testEnv, capiProvider, secret)
 		Expect(s.Get(ctx)).To(Succeed())
+		s.Apply(ctx, &err)
 
 		Eventually(func() error {
 			return testEnv.Client.Get(ctx, client.ObjectKeyFromObject(secret), secret)


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

The issue is related to the order of provider creation. Initially, a `create` call is made on the synced manifest, resulting in an empty spec for the resource in the CAPI Operator case. This leads the provider to install the latest version if it detects the event before the subsequent `patch`, and if user specified version of the provider differs, it attempts a downgrade later (which is not allowed).

To resolve this, the `create` operation should be moved to the `apply` scenario. Alternatively, an SSA patch can be used and the `create` operation removed, but this approach reintroduces flakes in the `Updated to latest %s version` test.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1257 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
