### PR TITLE
Remove insecure-skip-verify usage from test environment

### DIFF
--- a/internal/controllers/import_controller_v3_test.go
+++ b/internal/controllers/import_controller_v3_test.go
@@ -206,7 +206,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(res.Requeue).To(BeTrue())
 		}).Should(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 			g.Expect(rancherClusters.Items[0].Name).To(ContainSubstring("c-"))
@@ -214,7 +214,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(rancherClusters.Items[0].Finalizers).To(ContainElement(managementv3.CapiClusterFinalizer))
 		}).Should(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(capiCluster), capiCluster)).ToNot(HaveOccurred())
 			g.Expect(capiCluster.Finalizers).To(ContainElement(managementv3.CapiClusterFinalizer))
 		}).Should(Succeed())
@@ -236,7 +236,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(res.Requeue).To(BeTrue())
 		}).Should(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
@@ -248,7 +248,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		capiCluster.Status.ControlPlaneReady = true
 		Expect(cl.Status().Update(ctx, capiCluster)).To(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			res, err := r.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: capiCluster.Namespace,
@@ -259,7 +259,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(res.Requeue).To(BeTrue())
 		}).Should(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
@@ -282,7 +282,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 
 		Expect(cl.Create(ctx, agentTlsModeSetting)).To(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 			g.Expect(rancherClusters.Items[0].Finalizers).ToNot(ContainElement(managementv3.CapiClusterFinalizer))
@@ -299,7 +299,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		token.Status.ManifestURL = server.URL
 		Expect(cl.Status().Update(ctx, token)).To(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			_, err := r.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: capiCluster.Namespace,
@@ -342,7 +342,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		Expect(cl.Status().Update(ctx, capiCluster)).To(Succeed())
 		Expect(cl.Create(ctx, rancherCluster)).To(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
@@ -352,7 +352,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		_, err := testEnv.CreateNamespaceWithName(ctx, cluster.Name)
 		Expect(err).ToNot(HaveOccurred())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			res, err := r.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: capiCluster.Namespace,
@@ -371,7 +371,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 
 		Expect(cl.Create(ctx, rancherCluster)).To(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
@@ -406,7 +406,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 
 		Expect(cl.Create(ctx, rancherCluster)).To(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
@@ -422,7 +422,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		token.Status.ManifestURL = server.URL
 		Expect(cl.Status().Update(ctx, token)).To(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			res, err := r.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: capiCluster.Namespace,
@@ -464,7 +464,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		token.Status.ManifestURL = server.URL
 		Expect(cl.Status().Update(ctx, token)).To(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			_, err := r.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: capiCluster.Namespace,
@@ -493,7 +493,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 
 		Expect(cl.Create(ctx, rancherCluster)).To(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
@@ -505,7 +505,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		_, err := testEnv.CreateNamespaceWithName(ctx, cluster.Name)
 		Expect(err).ToNot(HaveOccurred())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			res, err := r.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: capiCluster.Namespace,
@@ -527,7 +527,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 
 		Expect(cl.Create(ctx, rancherCluster)).To(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
@@ -540,7 +540,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cl.Create(ctx, clusterRegistrationToken)).To(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			res, err := r.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: capiCluster.Namespace,
@@ -564,7 +564,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 
 		Expect(cl.Create(ctx, rancherCluster)).To(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(rancherCluster), rancherCluster)).To(Succeed())
 			annoations := rancherCluster.GetAnnotations()
 			if annoations == nil {
@@ -592,7 +592,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(err).ToNot(HaveOccurred())
 		}).Should(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 		}).Should(Succeed())
@@ -622,7 +622,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(res.Requeue).To(BeTrue())
 		}).Should(Succeed())
 
-		Eventually(ctx, func(g Gomega) {
+		Eventually(func(g Gomega) {
 			Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
 			Expect(rancherClusters.Items).To(HaveLen(0))
 		}).Should(Succeed())

--- a/scripts/turtles-quickstart.sh
+++ b/scripts/turtles-quickstart.sh
@@ -276,12 +276,6 @@ kind: Setting
 metadata:
   name: eula-agreed
 value: "2023-08-16T20:39:11.062Z"
----
-apiVersion: management.cattle.io/v3
-kind: Setting
-metadata:
-  name: agent-tls-mode
-value: "system-store"
 EOF
 
     kubectl rollout status deployment rancher -n cattle-system --timeout=180s
@@ -309,7 +303,6 @@ helm repo add turtles https://rancher.github.io/turtles
 helm repo update
 helm install rancher-turtles turtles/rancher-turtles --version ${RANCHER_TURTLES_VERSION} \
     -n rancher-turtles-system \
-    --set rancherTurtles.managerArguments={--insecure-skip-verify} \
     --set turtlesUI.enabled=true \
     --dependency-update \
     --create-namespace --wait \

--- a/test/e2e/data/rancher/rancher-setting-patch.yaml
+++ b/test/e2e/data/rancher/rancher-setting-patch.yaml
@@ -15,9 +15,3 @@ kind: Setting
 metadata:
   name: eula-agreed
 value: "2023-08-16T20:39:11.062Z"
----
-apiVersion: management.cattle.io/v3
-kind: Setting
-metadata:
-  name: agent-tls-mode
-value: "system-store"

--- a/test/testenv/turtles.go
+++ b/test/testenv/turtles.go
@@ -180,7 +180,6 @@ func DeployRancherTurtles(ctx context.Context, input DeployRancherTurtlesInput) 
 
 	By("Installing rancher-turtles chart")
 	values := map[string]string{
-		"rancherTurtles.managerArguments[0]":                 "--insecure-skip-verify=true",
 		"cluster-api-operator.cluster-api.configSecret.name": "variables",
 	}
 
@@ -351,7 +350,6 @@ func UpgradeRancherTurtles(ctx context.Context, input UpgradeRancherTurtlesInput
 		"--wait",
 		"--timeout", "10m",
 		"--kubeconfig", input.BootstrapClusterProxy.GetKubeconfigPath(),
-		"--set", "rancherTurtles.managerArguments[0]=--insecure-skip-verify=true",
 		"--set", fmt.Sprintf("rancherTurtles.image=%s", input.Image),
 		"--set", fmt.Sprintf("rancherTurtles.imageVersion=%s", input.Tag),
 		"--set", fmt.Sprintf("rancherTurtles.tag=%s", input.Tag),

--- a/tilt/project/Tiltfile
+++ b/tilt/project/Tiltfile
@@ -147,7 +147,6 @@ def update_manager(yaml, containerName, debug, env, name, project):
                             continue
                         debugArgs.append(arg)
                     if debug_insecure_skip_verify:
-                        debugArgs.append("--insecure-skip-verify=true")
                         debugArgs.append("--v=5")
                     c["command"] = cmd
                     print(cmd)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes usage of insecure-skip-verify from test (and all other) environment. 

The import now uses the `agent-tls-mode` from Rancher. The PR also reverts this setting to the default 'Strict' value.

Test run: https://github.com/rancher/turtles/actions/runs/14975519278

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1268
Fixes #1370

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
