### PR TITLE
Remove insecure-skip-verify option from Tiltfile

### DIFF
--- a/tilt/project/Tiltfile
+++ b/tilt/project/Tiltfile
@@ -115,13 +115,14 @@ def update_manager(yaml, containerName, debug, env, name, project):
         The debug section is expected to be in this format:
             {
                 "continue": true,
-                "port": 30000
+                "port": 30000,
+                "verbose": false
             },
     """
     print("update manager")
     debug_port = int(debug.get("port", 0))
     debug_continue = bool(debug.get("continue", "true"))
-    debug_insecure_skip_verify = bool(debug.get("insecure_skip_verify", "false"))
+    debug_verbose = bool(debug.get("verbose", "false"))
     objs = decode_yaml_stream(yaml)
     for o in objs:
         if o["kind"] == "Deployment":
@@ -146,7 +147,7 @@ def update_manager(yaml, containerName, debug, env, name, project):
                         if arg == "--leader-elect" or arg == "--leader-elect=true":
                             continue
                         debugArgs.append(arg)
-                    if debug_insecure_skip_verify:
+                    if debug_verbose:
                         debugArgs.append("--v=5")
                     c["command"] = cmd
                     print(cmd)


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleanup from #1368

Since the insecure-skip-verify option is no longer useful and has been removed, I simply renamed this field to a more appropriate name `verbose`, since it still increases verbosity.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
