### PR TITLE
Use SystemStore agent-tls-setting with ngrok

### DIFF
--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -74,6 +74,14 @@ kubectl rollout status deployment rancher -n cattle-system --timeout=180s
 kubectl apply -f test/e2e/data/rancher/rancher-service-patch.yaml
 envsubst <test/e2e/data/rancher/rancher-setting-patch.yaml | kubectl apply -f -
 
+cat << EOF | kubectl apply -f -
+apiVersion: management.cattle.io/v3
+kind: Setting
+metadata:
+  name: agent-tls-mode
+value: "system-store"
+EOF
+
 # Install the locally build chart of Rancher Turtles
 install_local_rancher_turtles_chart() {
     # Remove the previous chart directory

--- a/scripts/turtles-quickstart.sh
+++ b/scripts/turtles-quickstart.sh
@@ -278,6 +278,18 @@ metadata:
 value: "2023-08-16T20:39:11.062Z"
 EOF
 
+    if [ "$WITH_NGROK" -eq 1 ]; then
+    show_step "Using Rancher agent-tls-mode SystemStore setting"
+
+    cat << EOF | kubectl apply -f -
+apiVersion: management.cattle.io/v3
+kind: Setting
+metadata:
+  name: agent-tls-mode
+value: "system-store"
+EOF
+    fi 
+
     kubectl rollout status deployment rancher -n cattle-system --timeout=180s
 
     show_step "Waiting for Rancher to be READY ..."


### PR DESCRIPTION
**What this PR does / why we need it**:
Cluster import fails when ngrok is used and Rancher is served on a different Ingress.
The easiest solution is to set Rancher agent-tls-setting to SystemStore, assuming the certificate will be trusted.

Alternatively the agent-tls-setting can be kept to Strict, but the tls-rancher-ingress cert needs to be used instead.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
