### PR TITLE
Set higher memory limits for the CAPI Operator

### DIFF
--- a/charts/rancher-turtles/values.schema.json
+++ b/charts/rancher-turtles/values.schema.json
@@ -259,6 +259,42 @@
             }
           }
         },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "manager": {
+              "type": "object",
+              "properties": {
+                "limits": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "type": "string",
+                      "description": "CPU limit."
+                    },
+                    "memory": {
+                      "type": "string",
+                      "description": "Memory limit."
+                    }
+                  }
+                },
+                "requests": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "type": "string",
+                      "description": "CPU request."
+                    },
+                    "memory": {
+                      "type": "string",
+                      "description": "Memory request."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "cleanup": {
           "type": "boolean",
           "default": true,

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -74,6 +74,14 @@ cluster-api-operator:
       configMap:
         # name: ConfigMap for clusterctl.
         name: clusterctl-config
+  resources:
+    manager:
+      limits:
+        cpu: 100m
+        memory: 300Mi
+      requests:
+        cpu: 100m
+        memory: 100Mi
   # image: Operator manager image.
   image:
     manager:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Increase memory limits to allow the CAPI operator deployment to complete the reconcile on CAPZ provider components without getting OOMKilled after surpassing 150Mi limit set currently.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1204 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
