### PR TITLE
Bump CAPRKE2 to v0.16.0

### DIFF
--- a/exp/day2/go.mod
+++ b/exp/day2/go.mod
@@ -7,7 +7,7 @@ replace github.com/rancher/turtles => ../..
 require (
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
-	github.com/rancher/cluster-api-provider-rke2 v0.15.1
+	github.com/rancher/cluster-api-provider-rke2 v0.16.0
 	github.com/rancher/turtles v0.0.0-00010101000000-000000000000
 	github.com/spf13/pflag v1.0.6
 	k8s.io/api v0.31.6

--- a/exp/day2/go.sum
+++ b/exp/day2/go.sum
@@ -158,8 +158,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/rancher/cluster-api-provider-rke2 v0.15.1 h1:TbSV0JPvX47AhMJY9j9u12LunAcfOkYcjJ3YI9X27a4=
-github.com/rancher/cluster-api-provider-rke2 v0.15.1/go.mod h1:Vn0kxG/FmSiP3lvPoSKpt43Yd3yvVyi9jZe03e+Agps=
+github.com/rancher/cluster-api-provider-rke2 v0.16.0 h1:tInXIpl57sS+SObwq9QPWUv8mpsnwvQrHzmiSCxurZ0=
+github.com/rancher/cluster-api-provider-rke2 v0.16.0/go.mod h1:Vn0kxG/FmSiP3lvPoSKpt43Yd3yvVyi9jZe03e+Agps=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -36,7 +36,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.9.5/bootstrap-components.yaml"
       type:         "BootstrapProvider"
     - name:         "rke2"
-      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.15.1/bootstrap-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.16.0/bootstrap-components.yaml"
       type:         "BootstrapProvider"
 
     # ControlPlane providers
@@ -44,7 +44,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.9.5/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
     - name:         "rke2"
-      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.15.1/control-plane-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.16.0/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
 
     # Addon providers


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/rancher/cluster-api-provider-rke2/releases/tag/v0.16.0

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
