### PR TITLE
chore: bump golangci lint action to 8

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -25,9 +25,9 @@ jobs:
         with:
           go-version: '=1.23.9'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0.2
+          version: v2.1.6
           working-directory: ${{matrix.working-directory}}
           args: --timeout=5m0s
           skip-cache: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Equivalent to what we already did in CAPRKE2 https://github.com/rancher/cluster-api-provider-rke2/pull/666. This PR updates Go linter and fixes format errors raised by the new version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
