### PR TITLE
Print e2e Rancher kubeconfig secret key

### DIFF
--- a/test/framework/rancher_helpers.go
+++ b/test/framework/rancher_helpers.go
@@ -83,7 +83,7 @@ func RancherGetClusterKubeconfig(ctx context.Context, input RancherGetClusterKub
 		input.Namespace = DefaultNamespace
 	}
 
-	By("Getting Rancher kubeconfig secret")
+	Byf("Getting Rancher kubeconfig secret: %s/%s", input.Namespace, input.SecretName)
 	secret := &corev1.Secret{}
 
 	Eventually(
@@ -138,7 +138,7 @@ func RancherGetOriginalKubeconfig(ctx context.Context, input RancherGetClusterKu
 		input.Namespace = DefaultNamespace
 	}
 
-	By("Getting Rancher kubeconfig secret")
+	Byf("Getting Original Rancher kubeconfig secret: %s/%s", input.Namespace, input.SecretName)
 	secret := &corev1.Secret{}
 
 	err := input.Getter.Get(ctx, types.NamespacedName{Namespace: input.Namespace, Name: input.SecretName}, secret)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR prints the (Rancher) kubeconfig secret key to better determine test failures.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
