### PR TITLE
Add Azure kubeadm clusterclass example

### DIFF
--- a/examples/applications/ccm/azure/helm-chart.yaml
+++ b/examples/applications/ccm/azure/helm-chart.yaml
@@ -15,7 +15,11 @@ spec:
         caCertDir: /etc/ssl
         hostNetworking: true
         nodeSelector:
+          ${- if contains "KubeadmControlPlane" ( .ClusterValues | quote ) }
+          node-role.kubernetes.io/control-plane: ""
+          ${- else }
           node-role.kubernetes.io/control-plane: "true"
+          ${- end }
   insecureSkipTLSVerify: true
   targets:
   - clusterSelector:
@@ -24,4 +28,4 @@ spec:
       matchExpressions:
       - key: clusterclass-name.fleet.addons.cluster.x-k8s.io
         operator: In
-        values: [azure-rke2-example]
+        values: [azure-rke2-example, azure-kubeadm-example]

--- a/examples/applications/cni/calico/helm-chart.yaml
+++ b/examples/applications/cni/calico/helm-chart.yaml
@@ -36,6 +36,7 @@ spec:
         operator: In
         values:
           - azure-rke2-example
+          - azure-kubeadm-example
           - docker-kubeadm-example
           - docker-rke2-example
           - etcd-snapshot-restore

--- a/examples/clusterclasses/azure/kubeadm/clusterclass-kubeadm-example.yaml
+++ b/examples/clusterclasses/azure/kubeadm/clusterclass-kubeadm-example.yaml
@@ -1,0 +1,331 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: azure-kubeadm-example
+spec:
+  controlPlane:
+    machineInfrastructure:
+      ref:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureMachineTemplate
+        name: azure-machine-control-plane
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlaneTemplate
+      name: kubeadm-control-plane
+  infrastructure:
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: AzureClusterTemplate
+      name: azure-kubeadm-cluster
+  workers:
+    machineDeployments:
+      - class: kubeadm-default-worker
+        template:
+          bootstrap:
+            ref:
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              kind: KubeadmConfigTemplate
+              name: kubeadm-default-worker-bootstrap
+          infrastructure:
+            ref:
+              apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+              kind: AzureMachineTemplate
+              name: kubeadm-default-worker
+  variables:
+    - name: subscriptionID
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: "The Azure Subscription ID where the Cluster will be created."
+          type: string
+    - name: location
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: "The Azure location where the Cluster will be created."
+          type: string
+          enum:
+            - australiaeast
+            - francecentral
+            - germanywestcentral
+            - northcentralus
+            - northeurope
+            - switzerlandnorth
+            - uksouth
+            - westeurope
+            - westus2
+    - name: resourceGroup
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: "The Azure Resource Group where the Cluster will be created."
+          type: string
+    - name: azureClusterIdentityName
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: "The AzureClusterIdentity resource name referencing the credentials to create the Cluster."
+          type: string
+          default: "cluster-identity"
+    - name: imageGallery
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: "The image Public gallery name."
+          type: string
+          default: "ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019"
+    - name: imageName
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: "The image name"
+          type: string
+          default: "capi-ubun2-2404"
+    - name: vmSize
+      required: true
+      schema:
+        openAPIV3Schema:
+          description: "The VM size used by machines."
+          type: string
+          default: "Standard_D2s_v3"
+  patches:
+    - name: azureClusterTemplate
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: AzureClusterTemplate
+            matchResources:
+              infrastructureCluster: true
+          jsonPatches:
+            - op: add
+              path: "/spec/template/spec/subscriptionID"
+              valueFrom:
+                variable: subscriptionID
+            - op: add
+              path: "/spec/template/spec/location"
+              valueFrom:
+                variable: location
+            - op: add
+              path: "/spec/template/spec/resourceGroup"
+              valueFrom:
+                variable: resourceGroup
+            - op: add
+              path: "/spec/template/spec/identityRef/name"
+              valueFrom:
+                variable: azureClusterIdentityName
+    - definitions:
+        - jsonPatches:
+            - op: add
+              path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs/cluster-name
+              valueFrom:
+                variable: builtin.cluster.name
+            - op: replace
+              path: /spec/template/spec/kubeadmConfigSpec/files
+              valueFrom:
+                template: |
+                  - contentFrom:
+                      secret:
+                        key: control-plane-azure.json
+                        name: "{{ .builtin.controlPlane.machineTemplate.infrastructureRef.name }}-azure-json"
+                    owner: root:root
+                    path: /etc/kubernetes/azure.json
+                    permissions: "0644"
+          selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            kind: KubeadmControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: AzureMachineTemplate
+            matchResources:
+              controlPlane: true
+              machineDeploymentClass:
+                names:
+                  - kubeadm-default-worker
+          jsonPatches:
+            - op: add
+              path: "/spec/template/spec/image/computeGallery/gallery"
+              valueFrom:
+                variable: imageGallery
+            - op: add
+              path: "/spec/template/spec/image/computeGallery/name"
+              valueFrom:
+                variable: imageName
+            - op: replace
+              path: /spec/template/spec/image/computeGallery/version
+              valueFrom:
+                template: '{{ trimPrefix "v" (trimSuffix "+rke2r1" .builtin.cluster.topology.version) }}'
+            - op: add
+              path: "/spec/template/spec/vmSize"
+              valueFrom:
+                variable: vmSize
+      name: controlPlaneAzureJsonSecretName
+    - definitions:
+        - jsonPatches:
+            - op: replace
+              path: /spec/template/spec/files
+              valueFrom:
+                template: |
+                  - contentFrom:
+                      secret:
+                        key: worker-node-azure.json
+                        name: "{{ .builtin.machineDeployment.infrastructureRef.name }}-azure-json"
+                    owner: root:root
+                    path: /etc/kubernetes/azure.json
+                    permissions: "0644"
+          selector:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            matchResources:
+              machineDeploymentClass:
+                names:
+                  - kubeadm-default-worker
+      name: workerAzureJsonSecretName
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureClusterTemplate
+metadata:
+  name: azure-kubeadm-cluster
+spec:
+  template:
+    spec:
+      identityRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureClusterIdentity
+        name: cluster-identity
+      location: "TO_BE_REPLACED_BY_PATCH"
+      networkSpec:
+        subnets:
+          - name: control-plane-subnet
+            role: control-plane
+          - name: node-subnet
+            natGateway:
+              name: node-natgateway
+            role: node
+      subscriptionID: "TO_BE_REPLACED_BY_PATCH"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: azure-machine-control-plane
+spec:
+  template:
+    spec:
+      dataDisks:
+        - diskSizeGB: 256
+          lun: 0
+          nameSuffix: etcddisk
+      osDisk:
+        diskSizeGB: 128
+        osType: Linux
+      vmSize: "TO_BE_REPLACED_BY_PATCH"
+      image:
+        computeGallery:
+          gallery: "TO_BE_REPLACED_BY_PATCH"
+          name: "TO_BE_REPLACED_BY_PATCH"
+          version: "TO_BE_REPLACED_BY_PATCH"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: kubeadm-default-worker
+spec:
+  template:
+    spec:
+      image:
+        computeGallery:
+          gallery: "TO_BE_REPLACED_BY_PATCH"
+          name: "TO_BE_REPLACED_BY_PATCH"
+          version: "TO_BE_REPLACED_BY_PATCH"
+      osDisk:
+        diskSizeGB: 128
+        osType: Linux
+      vmSize: "TO_BE_REPLACED_BY_PATCH"
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: kubeadm-control-plane
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          apiServer:
+            extraArgs: {}
+            timeoutForControlPlane: 20m
+          controllerManager:
+            extraArgs:
+              allocate-node-cidrs: "false"
+              cloud-provider: external
+              cluster-name: "TO_BE_REPLACED_BY_PATCH"
+          etcd:
+            local:
+              dataDir: /var/lib/etcddisk/etcd
+              extraArgs:
+                quota-backend-bytes: "8589934592"
+        diskSetup:
+          filesystems:
+            - device: /dev/disk/azure/scsi1/lun0
+              extraOpts:
+                - -E
+                - lazy_itable_init=1,lazy_journal_init=1
+              filesystem: ext4
+              label: etcd_disk
+            - device: ephemeral0.1
+              filesystem: ext4
+              label: ephemeral0
+              replaceFS: ntfs
+          partitions:
+            - device: /dev/disk/azure/scsi1/lun0
+              layout: true
+              overwrite: false
+              tableType: gpt
+        files:
+          - contentFrom:
+              secret:
+                key: control-plane-azure.json
+                name: replace_me
+            owner: root:root
+            path: /etc/kubernetes/azure.json
+            permissions: "0644"
+        initConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              cloud-provider: external
+            name: '{{ ds.meta_data["local_hostname"] }}'
+        joinConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              cloud-provider: external
+            name: '{{ ds.meta_data["local_hostname"] }}'
+        mounts:
+          - - LABEL=etcd_disk
+            - /var/lib/etcddisk
+        postKubeadmCommands: []
+        preKubeadmCommands: []
+        verbosity: 10
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: kubeadm-default-worker-bootstrap
+spec:
+  template:
+    spec:
+      files:
+        - contentFrom:
+            secret:
+              key: worker-node-azure.json
+              name: replace_me
+          owner: root:root
+          path: /etc/kubernetes/azure.json
+          permissions: "0644"
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
+          name: '{{ ds.meta_data["local_hostname"] }}'
+      preKubeadmCommands: []

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -46,6 +46,10 @@ variables:
   RKE2_CNI: "none"
 
   # Azure Configuration
+  #
+  # Azure Kubeadm tests need specific k8s version.
+  # This is due to the limited availability of published AMIs.
+  # For example: https://portal.azure.com/#@suseazuredev.onmicrosoft.com/resource/providers/Microsoft.Compute/locations/FranceCentral/CommunityGalleries/ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019/Images/capi-ubun2-2204/overview
   AZURE_KUBERNETES_VERSION: "v1.31.1"
 
   # AWS Configuration

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -45,6 +45,9 @@ variables:
   RKE2_VERSION: "v1.31.7+rke2r1"
   RKE2_CNI: "none"
 
+  # Azure Configuration
+  AZURE_KUBERNETES_VERSION: "v1.31.1"
+
   # AWS Configuration
   #
   # AWS Kubeadm tests need specific k8s version.

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -108,6 +108,9 @@ var (
 	//go:embed data/cluster-templates/azure-rke2-topology.yaml
 	CAPIAzureRKE2Topology []byte
 
+	//go:embed data/cluster-templates/azure-kubeadm-topology.yaml
+	CAPIAzureKubeadmTopology []byte
+
 	//go:embed data/cluster-templates/vsphere-kubeadm-topology.yaml
 	CAPIvSphereKubeadmTopology []byte
 
@@ -147,23 +150,24 @@ const (
 
 	ClusterctlRepositoryFolderVar = "CLUSTERCTL_REPOSITORY_FOLDER"
 
-	KubernetesVersionVar    = "KUBERNETES_VERSION"
-	AWSKubernetesVersionVar = "AWS_KUBERNETES_VERSION"
-	RancherFeaturesVar      = "RANCHER_FEATURES"
-	RancherHostnameVar      = "RANCHER_HOSTNAME"
-	RancherVersionVar       = "RANCHER_VERSION"
-	RancherAlphaVersionVar  = "RANCHER_ALPHA_VERSION"
-	RancherPathVar          = "RANCHER_PATH"
-	RancherAlphaPathVar     = "RANCHER_ALPHA_PATH"
-	RancherUrlVar           = "RANCHER_URL"
-	RancherAlphaUrlVar      = "RANCHER_ALPHA_URL"
-	RancherRepoNameVar      = "RANCHER_REPO_NAME"
-	RancherAlphaRepoNameVar = "RANCHER_ALPHA_REPO_NAME"
-	RancherPasswordVar      = "RANCHER_PASSWORD"
-	CertManagerUrlVar       = "CERT_MANAGER_URL"
-	CertManagerRepoNameVar  = "CERT_MANAGER_REPO_NAME"
-	CertManagerPathVar      = "CERT_MANAGER_PATH"
-	CapiInfrastructureVar   = "CAPI_INFRASTRUCTURE"
+	KubernetesVersionVar      = "KUBERNETES_VERSION"
+	AWSKubernetesVersionVar   = "AWS_KUBERNETES_VERSION"
+	AzureKubernetesVersionVar = "AZURE_KUBERNETES_VERSION"
+	RancherFeaturesVar        = "RANCHER_FEATURES"
+	RancherHostnameVar        = "RANCHER_HOSTNAME"
+	RancherVersionVar         = "RANCHER_VERSION"
+	RancherAlphaVersionVar    = "RANCHER_ALPHA_VERSION"
+	RancherPathVar            = "RANCHER_PATH"
+	RancherAlphaPathVar       = "RANCHER_ALPHA_PATH"
+	RancherUrlVar             = "RANCHER_URL"
+	RancherAlphaUrlVar        = "RANCHER_ALPHA_URL"
+	RancherRepoNameVar        = "RANCHER_REPO_NAME"
+	RancherAlphaRepoNameVar   = "RANCHER_ALPHA_REPO_NAME"
+	RancherPasswordVar        = "RANCHER_PASSWORD"
+	CertManagerUrlVar         = "CERT_MANAGER_URL"
+	CertManagerRepoNameVar    = "CERT_MANAGER_REPO_NAME"
+	CertManagerPathVar        = "CERT_MANAGER_PATH"
+	CapiInfrastructureVar     = "CAPI_INFRASTRUCTURE"
 
 	NgrokRepoNameVar  = "NGROK_REPO_NAME"
 	NgrokUrlVar       = "NGROK_URL"

--- a/test/e2e/data/cluster-templates/azure-kubeadm-topology.yaml
+++ b/test/e2e/data/cluster-templates/azure-kubeadm-topology.yaml
@@ -1,0 +1,53 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureClusterIdentity
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  name: cluster-identity
+  namespace: ${NAMESPACE}
+spec:
+  allowedNamespaces: {}
+  clientID: ${AZURE_CLIENT_ID}
+  clientSecret:
+    name: cluster-identity-secret
+    namespace: capz-system
+  tenantID: ${AZURE_TENANT_ID}
+  type: ServicePrincipal
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster-api.cattle.io/rancher-auto-import: "true"
+    cni: calico
+    cloud-provider: azure
+  name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+  topology:
+    class: azure-kubeadm-example
+    classNamespace: ${TOPOLOGY_NAMESPACE}
+    controlPlane:
+      replicas: 1
+    variables:
+      - name: subscriptionID
+        value: ${AZURE_SUBSCRIPTION_ID}
+      - name: location
+        value: germanywestcentral
+      - name: resourceGroup
+        value: highlander-e2e-azure-kubeadm
+      - name: azureClusterIdentityName
+        value: cluster-identity
+    version: ${AZURE_KUBERNETES_VERSION}
+    workers:
+      machineDeployments:
+        - class: kubeadm-default-worker
+          name: md-0
+          replicas: 1
+


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->
kind/enhancement

**What this PR does / why we need it**:
This PR adds Azure Kubeadm Clusterclass example and related test.
- Modify the CCM and CNI to refer the new class.
- Add Azure Kubeadm ClusterClass example that can be referred in documentation (documentation change pending)
- Add e2e test.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1330


**Special notes for your reviewer**:
I will work on documentation for this soon.

Issues discovered while working on the PR:
- [Can not provision a second Azure Cluster while one already exists](https://github.com/rancher/turtles/issues/1403)
- [Can not provision Kubeadm cluster with multiple control plane nodes](https://github.com/rancher/turtles/issues/1402)
- [Infinite Fleet Cluster patching loop](https://github.com/rancher/cluster-api-addon-provider-fleet/issues/313)

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
- [x] github action test run - https://github.com/rancher/turtles/actions/runs/15390032249/job/43297426585 
