### PR TITLE
Change networking rules for rke2 on ec2

### DIFF
--- a/examples/applications/cni/aws/calico/helm-chart.yaml
+++ b/examples/applications/cni/aws/calico/helm-chart.yaml
@@ -36,3 +36,4 @@ spec:
         operator: In
         values:
           - aws-kubeadm-example
+          - aws-rke2-example

--- a/examples/clusterclasses/aws/rke2/clusterclass-ec2-rke2-example.yaml
+++ b/examples/clusterclasses/aws/rke2/clusterclass-ec2-rke2-example.yaml
@@ -178,7 +178,34 @@ spec:
           toPort: 2380
         loadBalancerType: nlb
       network:
+        cni:
+          cniIngressRules:
+            - description: BGP
+              fromPort: 179
+              protocol: tcp
+              toPort: 179
+            - description: IP-in-IP
+              fromPort: -1
+              protocol: "4"
+              toPort: 65535
+            - description: Calico Typha
+              fromPort: 5473
+              protocol: tcp
+              toPort: 5473
+            - description: Calico Typha health check
+              fromPort: 9098
+              protocol: tcp
+              toPort: 9098
+            - description: Calico health check
+              fromPort: 9099
+              protocol: tcp
+              toPort: 9099
         additionalControlPlaneIngressRules:
+        - description: RKE2 Control Plane
+          fromPort: 9345
+          natGatewaysIPsSource: true
+          protocol: tcp
+          toPort: 9345
         - description: RKE2 Control Plane additional group
           fromPort: 9345
           protocol: tcp
@@ -198,33 +225,6 @@ spec:
           natGatewaysIPsSource: true
           protocol: tcp
           toPort: 2380
-        - description: Calico Typha
-          fromPort: 5473
-          protocol: tcp
-          toPort: 5473
-          sourceSecurityGroupRoles:
-          - node
-          - controlplane
-          - apiserver-lb
-          - lb
-        - description: Calico Typha health check
-          fromPort: 9098
-          protocol: tcp
-          toPort: 9098
-          sourceSecurityGroupRoles:
-          - node
-          - controlplane
-          - apiserver-lb
-          - lb
-        - description: Calico health check
-          fromPort: 9099
-          protocol: tcp
-          toPort: 9099
-          sourceSecurityGroupRoles:
-          - node
-          - controlplane
-          - apiserver-lb
-          - lb
         vpc:
           availabilityZoneUsageLimit: 1
 ---

--- a/test/e2e/data/cluster-templates/aws-ec2-rke2-topology.yaml
+++ b/test/e2e/data/cluster-templates/aws-ec2-rke2-topology.yaml
@@ -4,6 +4,7 @@ kind: Cluster
 metadata:
   labels:
     cloud-provider: aws
+    cni: calico
     csi: aws-ebs-csi-driver
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
@@ -28,6 +29,8 @@ spec:
       value: ${AWS_RKE2_NODE_MACHINE_TYPE}
     - name: amiID
       value: ${AWS_AMI_ID}
+    - name: cni
+      value: none
     version: ${RKE2_VERSION}
     workers:
       machineDeployments:

--- a/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
+++ b/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
@@ -438,6 +438,12 @@ var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality 
 					ClusterProxy:    bootstrapClusterProxy,
 					TargetNamespace: topologyNamespace,
 				},
+				{
+					Name:            "aws-cni",
+					Paths:           []string{"examples/applications/cni/aws/calico"},
+					ClusterProxy:    bootstrapClusterProxy,
+					TargetNamespace: topologyNamespace,
+				},
 			},
 		}
 	})


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
I've seen Calico node agent failing to connect to Typha sometimes, it happened previously for Kubeadm when networking rules were not set properly. This PR attempts to fix the flake. While at it I also switched RKE2 cluster to consume the same Calico chart as Kubeadm.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher/turtles/issues/1405

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
