### PR TITLE
Refactor E2E Fleet GitRepo names and ensure uniqueness

### DIFF
--- a/test/e2e/suites/etcd-snapshot-restore/etcd_snapshot_restore_test.go
+++ b/test/e2e/suites/etcd-snapshot-restore/etcd_snapshot_restore_test.go
@@ -56,8 +56,8 @@ var _ = Describe("[Docker] [RKE2] Perform an ETCD backup and restore of the clus
 			TopologyNamespace:           topologyNamespace,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
-					Name:            "docker-cluster-classes-regular",
-					Paths:           []string{"examples/clusterclasses/docker"},
+					Name:            "docker-cluster-class-rke2",
+					Paths:           []string{"examples/clusterclasses/docker/rke2"},
 					ClusterProxy:    bootstrapClusterProxy,
 					TargetNamespace: topologyNamespace,
 				},

--- a/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
+++ b/test/e2e/suites/import-gitops-v3/import_gitops_v3_test.go
@@ -240,7 +240,7 @@ var _ = Describe("[Azure] [Kubeadm] - [management.cattle.io/v3] Create and delet
 			},
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
-					Name:            "azure-cluster-classes-regular",
+					Name:            "azure-cluster-class-kubeadm",
 					Paths:           []string{"examples/clusterclasses/azure/kubeadm"},
 					ClusterProxy:    bootstrapClusterProxy,
 					TargetNamespace: topologyNamespace,
@@ -308,7 +308,7 @@ var _ = Describe("[Azure] [RKE2] - [management.cattle.io/v3] Create and delete C
 			TopologyNamespace:              topologyNamespace,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
-					Name:            "azure-cluster-classes-regular",
+					Name:            "azure-cluster-class-rke2",
 					Paths:           []string{"examples/clusterclasses/azure/rke2"},
 					ClusterProxy:    bootstrapClusterProxy,
 					TargetNamespace: topologyNamespace,
@@ -492,7 +492,7 @@ var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality 
 			TopologyNamespace:              topologyNamespace,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
-					Name:            "aws-cluster-classes-regular",
+					Name:            "aws-cluster-class-rke2",
 					Paths:           []string{"examples/clusterclasses/aws/rke2"},
 					ClusterProxy:    bootstrapClusterProxy,
 					TargetNamespace: topologyNamespace,

--- a/test/framework/fleet_helper.go
+++ b/test/framework/fleet_helper.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"text/template"
@@ -32,6 +33,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -94,6 +96,10 @@ func FleetCreateGitRepo(ctx context.Context, input FleetCreateGitRepoInput) {
 	Expect(input.Paths).ToNot(HaveLen(0), "Invalid argument. input.Paths can't be empty when calling FleetCreateGitRepo")
 
 	Byf("Creating GitRepo from template %s with path %s", input.Name, input.Paths[0])
+
+	input.Name = fmt.Sprintf("%s-%s", input.Name, util.RandomString(6))
+
+	Byf("Ensuring uniqueness of GitRepo by naming it %s with path %s", input.Name, input.Paths[0])
 
 	t := template.New("fleet-repo-template").Funcs(template.FuncMap{
 		"toYaml": func(v any) (string, error) {


### PR DESCRIPTION

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Rename Fleet GitRepo names in E2E tests to be more specific, including the provider and Kubernetes distribution.

Add a random suffix to generated GitRepo names in the test framework to ensure uniqueness and prevent conflicts.

This should improve stability of both short and long e2e tests, since the race condition is present across both, but mainly affects tests running in parallel (long).

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1428 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
