### PR TITLE
[vSphere][RKE2] Add docker.io registry authentication support

### DIFF
--- a/.github/workflows/run-vsphere-tests.yaml
+++ b/.github/workflows/run-vsphere-tests.yaml
@@ -20,6 +20,7 @@ env:
   MANAGEMENT_CLUSTER_ENVIRONMENT: "internal-kind"
   GINKGO_LABEL_FILTER: "vsphere"
   TAG: v0.0.1
+  DOCKER_REGISTRY_TOKEN: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
 jobs:
   run_vsphere_e2e:

--- a/examples/clusterclasses/vsphere/rke2/clusterclass-rke2-example.yaml
+++ b/examples/clusterclasses/vsphere/rke2/clusterclass-rke2-example.yaml
@@ -119,6 +119,12 @@ spec:
       openAPIV3Schema:
         description: The SUSE Linux Micro 6.1 product key to register the nodes with.
         type: string
+  - name: dockerAuthSecret
+    required: false
+    schema:
+      openAPIV3Schema:
+        description: The name of the secret containing docker.io credentials.
+        type: string
   patches:
   - name: infraCluster
     definitions:
@@ -311,6 +317,16 @@ spec:
             - transactional-update register -r {{ .productKey }}
             - transactional-update register -p SL-Micro-Extras/6.1/x86_64
             {{- end }}
+      - op: add
+        path: /spec/template/spec/privateRegistriesConfig/configs
+        valueFrom:
+          template: |-
+            {{- if .dockerAuthSecret }}
+            "docker.io":
+              authSecret:
+                name: {{ .dockerAuthSecret }}
+                namespace: {{ .builtin.cluster.namespace }}
+            {{- end }}
       selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
         kind: RKE2ControlPlaneTemplate
@@ -337,6 +353,16 @@ spec:
             # Register SL Micro 6.1 and add the SL Micro Extras repository
             - transactional-update register -r {{ .productKey }}
             - transactional-update register -p SL-Micro-Extras/6.1/x86_64
+            {{- end }}
+      - op: add
+        path: /spec/template/spec/privateRegistriesConfig/configs
+        valueFrom:
+          template: |-
+            {{- if .dockerAuthSecret }}
+            "docker.io":
+              authSecret:
+                name: {{ .dockerAuthSecret }}
+                namespace: {{ .builtin.cluster.namespace }}
             {{- end }}
       selector:
         apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -111,3 +111,6 @@ variables:
   GITEA_CHART_VERSION: "10.6.0"
   GITEA_USER_NAME: "gitea_admin"
   GITEA_USER_PWD: "password"
+
+  # Credentials used to pull images from docker.io
+  DOCKER_REGISTRY_TOKEN: ""

--- a/test/e2e/data/cluster-templates/vsphere-rke2-topology.yaml
+++ b/test/e2e/data/cluster-templates/vsphere-rke2-topology.yaml
@@ -8,6 +8,15 @@ spec:
     selector:
       matchLabels: {}
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '${CLUSTER_NAME}-docker-token'
+  namespace: '${NAMESPACE}'
+type: Opaque
+stringData:
+  identity-token: "${DOCKER_REGISTRY_TOKEN}"
+---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
@@ -58,6 +67,8 @@ spec:
       value: 6443
     - name: kubeVIPInterface
       value: eth0
+    - name: dockerAuthSecret
+      value: '${CLUSTER_NAME}-docker-token'
 ---
 kind: Bundle
 apiVersion: fleet.cattle.io/v1alpha1


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This PR adds support for docker.io registry authentication with the vSphere/RKE2 ClusterClass.

Part of: #1408
Blocked by: https://github.com/rancher/cluster-api-provider-rke2/pull/673
Test run: https://github.com/rancher/turtles/actions/runs/15463788073/job/43531020953

Tested manually:
![vsphere-rke2-registry-auth](https://github.com/user-attachments/assets/ad71fb4e-97a7-42fc-a71f-80f94e52847c)


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
