### PR TITLE
Exclude GKE cluster from CAAPF

### DIFF
--- a/test/e2e/data/cluster-templates/gcp-gke.yaml
+++ b/test/e2e/data/cluster-templates/gcp-gke.yaml
@@ -4,6 +4,8 @@ kind: Cluster
 metadata:
   name: "${CLUSTER_NAME}"
   namespace: "${NAMESPACE}"
+  labels:
+    cluster-api.cattle.io/disable-fleet-auto-import: "true"
 spec:
   clusterNetwork:
     pods:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Exclude GKE cluster from CAAPF import, as it is not using any bundles ATM. This should mitigate the issue, leaving time to work on it.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1436 

**Special notes for your reviewer**:
Waiting on https://github.com/rancher/turtles/actions/runs/15439510613 to pass

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
