### PR TITLE
Disable bastion in AWS EC2 RKE2 test

### DIFF
--- a/examples/clusterclasses/aws/rke2/clusterclass-ec2-rke2-example.yaml
+++ b/examples/clusterclasses/aws/rke2/clusterclass-ec2-rke2-example.yaml
@@ -147,7 +147,7 @@ spec:
   template:
     spec:
       bastion:
-        enabled: true
+        enabled: false
       controlPlaneLoadBalancer:
         additionalListeners:
         - port: 9345

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -64,7 +64,7 @@ variables:
   AWS_NODE_MACHINE_TYPE: "t3.large"
   AWS_RKE2_CONTROL_PLANE_MACHINE_TYPE: "t3.xlarge"
   AWS_RKE2_NODE_MACHINE_TYPE: "t3.xlarge"
-  AWS_AMI_ID: "ami-0054630107ba40e56" # Public upstream AMI
+  AWS_AMI_ID: "ami-012e88f0aa221423a" # Public upstream AMI
 
   # CLI Tool Paths
   CLUSTERCTL_BINARY_PATH: ""


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

update the AWS AMI ID used in E2E tests and disable the bastion host in the AWS RKE2 example cluster class.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1445 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
