### PR TITLE
Add ability to run examples CLI with `go run` from tag

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -51,10 +51,12 @@ git clone git@github.com:rancher/turtles.git
 # Create tags locally
 git tag -s -a ${RELEASE_TAG} -m ${RELEASE_TAG}
 git tag -s  -a test/${RELEASE_TAG} -m "Testing framework ${RELEASE_TAG}"
+git tag -s  -a examples/${RELEASE_TAG} -m "ClusterClass examples ${RELEASE_TAG}"
 
 # Push tags
 git push upstream ${RELEASE_TAG}
 git push upstream test/${RELEASE_TAG}
+git push upstream examples/${RELEASE_TAG}
 ```
 
 This will trigger a [release GitHub action](https://github.com/rancher/turtles/actions/workflows/release-workflow.yaml) that creates a release with Rancher Turtles components.

--- a/examples/README.md
+++ b/examples/README.md
@@ -57,3 +57,37 @@ To apply the extracted examples, you can use the following command:
 ```bash
 go run main.go <search_key> | kubectl apply -f -
 ```
+
+## Running from tag or latest
+
+You can run the examples CLI tool using `go run`. This method allows you to execute the tool directly from the module path without needing to clone the repository locally first.
+
+Using a specific tag (`@<tag>`) is recommended for reproducible results, while `@latest` will always fetch the most recent version.
+
+To run the latest version:
+
+```bash
+go run github.com/rancher/turtles/examples@latest
+```
+
+To run from a specific tag:
+
+```bash
+go run github.com/rancher/turtles/examples@<tag>
+```
+
+Make sure to replace `<tag>` with the desired tag name.
+
+### Example: applying a specific cluster class from a specific tag
+
+Apply examples from the `azure-aks` cluster class in the default namespace:
+
+```bash
+go run github.com/rancher/turtles/examples@<tag> azure-aks | kubectl apply -f -
+```
+
+Apply all `azure` example cluster classes in a custom namespace:
+
+```bash
+go run github.com/rancher/turtles/examples@<tag> -r azure | kubectl apply -f -n <namespace> -
+```


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR introduces the capability to run the examples CLI tool directly using `go run` from the module path, without requiring a local clone of the repository. This is particularly useful for quickly applying `ClusterClass` examples with applications.

- Add a note to [documentation](docs/release.md) to include tagging the `examples` directory during releases. This ensures that specific version of the examples CLI is available with the new release.
- Add a README section which explains how to use the `go run` command with `@latest` (available already) or with specific tag (available after release including these changes) to apply examples from CLI.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1455 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
