### PR TITLE
Fix kube-vip static pod location and add a label

### DIFF
--- a/examples/clusterclasses/vsphere/rke2/clusterclass-rke2-example.yaml
+++ b/examples/clusterclasses/vsphere/rke2/clusterclass-rke2-example.yaml
@@ -217,16 +217,17 @@ spec:
         path: /spec/template/spec/files
         valueFrom:
           template: |
-            - path: "/var/lib/rancher/rke2/server/manifests/kube-vip.yaml"
+            - path: "/var/lib/rancher/rke2/agent/pod-manifests/kube-vip.yaml"
               owner: "root:root"
               permissions: "0640"
               content: |
                 apiVersion: v1
                 kind: Pod
                 metadata:
-                  creationTimestamp: null
                   name: kube-vip
                   namespace: kube-system
+                  labels:
+                    app: kube-vip
                 spec:
                   tolerations:
                   - effect: NoSchedule


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix for `kube-vip` in clusterClass CAPV RKE2 example.

With original `kube-vip` static pod manifest location there was one pod running on the first control plane only so in case the first CP went down for whatever reason the cluster become unreachable (because kubevip:6443 was assigned only to the first node) and leader election did not work as there were no other kube-vip pods running on other CPs.

**BEFORE**
```
kubectl get pod kube-vip -n kube-system
NAME       READY   STATUS    RESTARTS   AGE
kube-vip   1/1     Running   0          2d8h
```

I fixed that by placing the kube-vip manifest into right location and now all the CPs have their own kube-vip pod running and leader elections is working as expected. After turning off the first CP (the one with VIP assigned) I can reach the kubeapi almost immediately since the VIP address is getting re-assigned to another CP node (this is visible in vsphere UI).

I have also added a label to kube-vip pod `app: kube-vip` for better pod filtering.

**AFTER**
```
kubectl get pods -lapp=kube-vip -n kube-system
NAMESPACE     NAME                                                READY   STATUS    RESTARTS   AGE
kube-system   kube-vip-turtles-qa-capv-rke2-example-qfwk6-2thq5   1/1     Running   0          2m8s
kube-system   kube-vip-turtles-qa-capv-rke2-example-qfwk6-jmxdr   1/1     Running   0          9m38s
kube-system   kube-vip-turtles-qa-capv-rke2-example-qfwk6-xqv6q   1/1     Running   0          5m45s
```

**Which issue(s) this PR fixes**:
Fixes part of https://github.com/rancher/rancher-turtles-e2e/issues/168

**Special notes for your reviewer**:
* The original location `/var/lib/rancher/rke2/server/manifests` is not meant to be used for static pods manifests location, but for package AddOns, see https://docs.rke2.io/install/packaged_components
* The right location in RKE2 is `/var/lib/rancher/rke2/agent/pod-manifests/`, as this path is used by rke2 kubelet arg. `--pod-manifest-path=/var/lib/rancher/rke2/agent/pod-manifests` , also see https://www.suse.com/support/kb/doc/?id=000020834

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
