### PR TITLE
Fix Azure classes network templating

### DIFF
--- a/examples/clusterclasses/azure/kubeadm/clusterclass-kubeadm-example.yaml
+++ b/examples/clusterclasses/azure/kubeadm/clusterclass-kubeadm-example.yaml
@@ -114,6 +114,19 @@ spec:
               path: "/spec/template/spec/identityRef/name"
               valueFrom:
                 variable: azureClusterIdentityName
+            - op: add
+              path: "/spec/template/spec/networkSpec"
+              valueFrom:
+                template: |
+                  vnet:
+                    name: {{ .builtin.cluster.name }}
+                  subnets:
+                  - name: {{ .builtin.cluster.name }}-kcps
+                    role: control-plane
+                  - name: {{ .builtin.cluster.name }}-nodes
+                    natGateway:
+                      name: {{ .builtin.cluster.name }}-nodes
+                    role: node
     - definitions:
         - jsonPatches:
             - op: add
@@ -198,12 +211,10 @@ spec:
       location: "TO_BE_REPLACED_BY_PATCH"
       networkSpec:
         subnets:
-          - name: control-plane-subnet
-            role: control-plane
-          - name: node-subnet
-            natGateway:
-              name: node-natgateway
-            role: node
+        - name: control-plane-subnet
+          role: control-plane
+        - name: node-subnet
+          role: node
       subscriptionID: "TO_BE_REPLACED_BY_PATCH"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/examples/clusterclasses/azure/rke2/clusterclass-rke2-example.yaml
+++ b/examples/clusterclasses/azure/rke2/clusterclass-rke2-example.yaml
@@ -129,9 +129,18 @@ spec:
               valueFrom:
                 variable: azureClusterIdentityName
             - op: add
-              path: "/spec/template/spec/networkSpec/vnet/name"
+              path: "/spec/template/spec/networkSpec"
               valueFrom:
-                variable: builtin.cluster.name
+                template: |
+                  vnet:
+                    name: {{ .builtin.cluster.name }}
+                  subnets:
+                  - name: {{ .builtin.cluster.name }}-kcps
+                    role: control-plane
+                  - name: {{ .builtin.cluster.name }}-nodes
+                    natGateway:
+                      name: {{ .builtin.cluster.name }}-nodes
+                    role: node
     - name: azureMachineTemplate
       definitions:
         - selector:
@@ -205,8 +214,6 @@ spec:
         - name: control-plane-subnet
           role: control-plane
         - name: node-subnet
-          natGateway:
-            name: node-natgateway
           role: node
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the fixed `natGateway` name. This issue prevented to have two clusters deployed on the same namespace, as the statically named `node-natgateway` would collide after first provisioning.

The PR prefixes the cluster name to all network resources, to avoid collisions in one namespace:

```bash
> kubectl get clusters
NAME            CLUSTERCLASS            PHASE         AGE    VERSION
azure-kubeadm   azure-kubeadm-example   Provisioned   8m4s   v1.31.1
azure-rke2      azure-rke2-example      Provisioned   12m    v1.32.4+rke2r1
```

Test run: https://github.com/rancher/turtles/actions/runs/15583359625 (don't mind the unrelated failure)

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1403

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
