### PR TITLE
e2e: Bump AWS_KUBERNETES_VERSION

### DIFF
--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -57,7 +57,7 @@ variables:
   # AWS Kubeadm tests need specific k8s version.
   # This is due to the limited availability of published AMIs.
   # For a complete list, run: clusterawsadm ami list
-  AWS_KUBERNETES_VERSION: "v1.31.0"
+  AWS_KUBERNETES_VERSION: "v1.31.5"
   AWS_REGION: "eu-west-2"
   KUBERNETES_MANAGEMENT_AWS_REGION: "eu-west-2"
   AWS_CONTROL_PLANE_MACHINE_TYPE: "t3.large"


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Bump AWS_KUBERNETES_VERSION for AWS Kubeadm tests with respect to available [ami-012e88f0aa221423a](https://github.com/rancher/turtles/blob/main/test/e2e/config/operator.yaml#L67) `(capa-ami-ubuntu-24.04-v1.31.5 -1738233293)` in `eu-west-2`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
