### PR TITLE
Add AMI ID optional variable in AWS Kubeadm Class

### DIFF
--- a/examples/clusterclasses/aws/kubeadm/clusterclass-kubeadm-example.yaml
+++ b/examples/clusterclasses/aws/kubeadm/clusterclass-kubeadm-example.yaml
@@ -57,6 +57,11 @@ spec:
         openAPIV3Schema:
           type: string
           default: t3.large
+    - name: amiID
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: string
   patches:
     - name: region
       definitions:
@@ -121,6 +126,31 @@ spec:
               path: /spec/template/spec/instanceType
               valueFrom:
                 variable: workerMachineType
+    - name: amiID
+      enabledIf: '{{ if .amiID }}true{{end}}'
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+            kind: AWSMachineTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/ami/id
+              valueFrom:
+                variable: amiID      
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+            kind: AWSMachineTemplate
+            matchResources:
+              machineDeploymentClass:
+                names:
+                  - default-worker
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/ami/id
+              valueFrom:
+                variable: amiID
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterTemplate
@@ -186,6 +216,7 @@ spec:
       iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
       rootVolume:
         size: 50
+      ami: {}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
@@ -199,6 +230,7 @@ spec:
       iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
       rootVolume:
         size: 50
+      ami: {}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Adds AMI ID optional patch in AWS Kubeadm ClusterClass, providing ability to set custom AMI for [unsupported regions](https://cluster-api-aws.sigs.k8s.io/topics/images/built-amis#supported-aws-regions) (eg. ap-south-2) and corresponding Kubernetes version. 
Existing cluster template unchanged as it uses already [published](https://github.com/rancher/turtles/blob/main/test/e2e/config/operator.yaml#L57) AMI for the region.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
