### PR TITLE
Remove vSphere tests from e2e run

### DIFF
--- a/.github/workflows/e2e-long.yaml
+++ b/.github/workflows/e2e-long.yaml
@@ -34,9 +34,6 @@ jobs:
       artifact_name: v2prov
       MANAGEMENT_CLUSTER_ENVIRONMENT: eks
     secrets: inherit
-  e2e_vsphere:
-    uses: ./.github/workflows/run-vsphere-tests.yaml
-    secrets: inherit
   e2e_cleanup:
     if: always()
     needs: [e2e_import_gitops_v3, e2e_v2prov]

--- a/.github/workflows/run-vsphere-tests.yaml
+++ b/.github/workflows/run-vsphere-tests.yaml
@@ -1,6 +1,8 @@
 name: Run vsphere e2e tests on self-hosted runner
 
 on:
+  schedule:
+    - cron: "0 0 * * *"
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The vSphere e2e turned out to be a great time sink. 

The environment we use is not suitable for reliable testing.
Until that is fixed, it's best to separate the vSphere tests to avoid alarm fatigue on the rest of the e2e suite.

Test run: https://github.com/rancher/turtles/actions/runs/15633843762

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
