### PR TITLE
Increase ginkgo nodes for parallel vSphere e2e

### DIFF
--- a/.github/workflows/run-vsphere-tests.yaml
+++ b/.github/workflows/run-vsphere-tests.yaml
@@ -25,6 +25,7 @@ env:
   TAG: v0.0.1
   DOCKER_REGISTRY_TOKEN: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
   DOCKER_REGISTRY_CONFIG: ${{ secrets.DOCKER_REGISTRY_CONFIG }}
+  GINKGO_NODES: 2
 
 jobs:
   run_vsphere_e2e:

--- a/test/e2e/specs/etcd_snapshot_restore.go
+++ b/test/e2e/specs/etcd_snapshot_restore.go
@@ -263,7 +263,7 @@ func ETCDSnapshotRestore(ctx context.Context, inputGetter func() ETCDSnapshotRes
 
 		By("Storing the original CAPI cluster kubeconfig")
 		turtlesframework.RancherGetOriginalKubeconfig(ctx, turtlesframework.RancherGetClusterKubeconfigInput{
-			Getter:          input.BootstrapClusterProxy.GetClient(),
+			ClusterProxy:    input.BootstrapClusterProxy,
 			SecretName:      fmt.Sprintf("%s-kubeconfig", capiCluster.Name),
 			ClusterName:     capiCluster.Name,
 			Namespace:       capiCluster.Namespace,

--- a/test/e2e/specs/import_gitops_mgmtv3.go
+++ b/test/e2e/specs/import_gitops_mgmtv3.go
@@ -152,7 +152,7 @@ func CreateMgmtV3UsingGitOpsSpec(ctx context.Context, inputGetter func() CreateM
 
 		By("Waiting for the CAPI cluster to be connectable using Rancher kubeconfig")
 		turtlesframework.RancherGetClusterKubeconfig(ctx, turtlesframework.RancherGetClusterKubeconfigInput{
-			Getter:           input.BootstrapClusterProxy.GetClient(),
+			ClusterProxy:     input.BootstrapClusterProxy,
 			SecretName:       fmt.Sprintf("%s-kubeconfig", rancherCluster.Name),
 			Namespace:        rancherCluster.Spec.FleetWorkspaceName,
 			RancherServerURL: input.RancherServerURL,
@@ -293,7 +293,7 @@ func CreateMgmtV3UsingGitOpsSpec(ctx context.Context, inputGetter func() CreateM
 
 		By("Storing the original CAPI cluster kubeconfig")
 		turtlesframework.RancherGetOriginalKubeconfig(ctx, turtlesframework.RancherGetClusterKubeconfigInput{
-			Getter:          input.BootstrapClusterProxy.GetClient(),
+			ClusterProxy:    input.BootstrapClusterProxy,
 			SecretName:      fmt.Sprintf("%s-kubeconfig", capiCluster.Name),
 			ClusterName:     capiCluster.Name,
 			Namespace:       capiCluster.Namespace,

--- a/test/e2e/suites/v2prov/v2prov_test.go
+++ b/test/e2e/suites/v2prov/v2prov_test.go
@@ -145,7 +145,7 @@ var _ = Describe("[v2prov] [Azure] Creating a cluster with v2prov should still w
 
 		By("Waiting for the CAPI cluster to be connectable using Rancher kubeconfig")
 		turtlesframework.RancherGetClusterKubeconfig(ctx, turtlesframework.RancherGetClusterKubeconfigInput{
-			Getter:           bootstrapClusterProxy.GetClient(),
+			ClusterProxy:     bootstrapClusterProxy,
 			SecretName:       fmt.Sprintf("%s-kubeconfig", rancherCluster.Name),
 			Namespace:        rancherCluster.Namespace,
 			RancherServerURL: hostName,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the needed ginkgo node for parallel test execution. It's a little bit faster now.

I also consume the ClusterProxy directly, instead of just the Client, to avoid cache and print some maybe useful information on the kubectl setup. This to guarantee we are not somehow using a different kubeconfig path when the test presents flakiness.

Relates to #1392 

Test run: https://github.com/rancher/turtles/actions/runs/15752888760

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
