### PR TITLE
Print eksctl command errors

### DIFF
--- a/test/testenv/eksctl_provider.go
+++ b/test/testenv/eksctl_provider.go
@@ -89,8 +89,8 @@ func (k *EKSClusterProvider) Create(ctx context.Context) {
 			"m5.xlarge",
 		},
 	}, createClusterRes)
-	Expect(createClusterRes.Error).NotTo(HaveOccurred(), "Failed to create cluster using eksctl: %s", createClusterRes.Stderr)
-	Expect(createClusterRes.ExitCode).To(Equal(0), "Creating cluster returned non-zero exit code")
+	Expect(createClusterRes.Error).NotTo(HaveOccurred(), "Failed to create cluster using eksctl. Stderr: %s", createClusterRes.Stderr)
+	Expect(createClusterRes.ExitCode).To(Equal(0), "Creating cluster returned non-zero exit code. Stderr: %s", createClusterRes.Stderr)
 
 	k.kubeconfigPath = tempFile.Name()
 }
@@ -117,8 +117,8 @@ func (k *EKSClusterProvider) Dispose(ctx context.Context) {
 			"--wait",
 		},
 	}, deleteClusterRes)
-	Expect(deleteClusterRes.Error).NotTo(HaveOccurred(), "Failed to delete cluster using eksctl")
-	Expect(deleteClusterRes.ExitCode).To(Equal(0), "Deleting cluster returned non-zero exit code")
+	Expect(deleteClusterRes.Error).NotTo(HaveOccurred(), "Failed to delete cluster using eksctl. Stderr: %s", deleteClusterRes.Stderr)
+	Expect(deleteClusterRes.ExitCode).To(Equal(0), "Deleting cluster returned non-zero exit code. Stderr: %s", deleteClusterRes.Stderr)
 
 	if err := os.Remove(k.kubeconfigPath); err != nil {
 		framework.Byf("Error deleting the kubeconfig file %q file. You may need to remove this by hand.", k.kubeconfigPath)


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Sometimes E2E suite fails on deleting the management cluster https://github.com/rancher/turtles/actions/runs/15838088666/job/44645806530. This PR adds code to print error messages so we can see the reason for failing commands.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
