### PR TITLE
chore: bump cluster-api-provider-gcp to v1.10.0

### DIFF
--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -22,7 +22,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api-provider-azure/releases/v1.19.1/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "gcp"
-      url:          "https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/v1.9.0/infrastructure-components.yaml"
+      url:          "https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/v1.10.0/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "vsphere"
       url:          "https://github.com/rancher-sandbox/cluster-api-provider-vsphere/releases/v1.12.0/infrastructure-components.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump CAPG from v1.9.0 to v1.10.0

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
