### PR TITLE
Bump CAPZ to version v1.20.1

### DIFF
--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -19,7 +19,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api-provider-aws/releases/v2.8.1/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "azure"
-      url:          "https://github.com/rancher-sandbox/cluster-api-provider-azure/releases/v1.19.1/infrastructure-components.yaml"
+      url:          "https://github.com/rancher-sandbox/cluster-api-provider-azure/releases/v1.20.1/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "gcp"
       url:          "https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/v1.10.0/infrastructure-components.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps CAPZ to version v1.20.1, which uses CAPI v1.10.3.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
e2e long run: https://github.com/rancher/turtles/actions/runs/16047443833

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
