### PR TITLE
Fix panic on nil error in `defaultToCurrentGitRepo`

### DIFF
--- a/test/framework/git_helper.go
+++ b/test/framework/git_helper.go
@@ -163,11 +163,11 @@ func defaultToCurrentGitRepo(input *FleetCreateGitRepoInput) {
 
 	// Open the current repository
 	repo, err := git.PlainOpen(cmp.Or(os.Getenv("ROOT_DIR"), "."))
-	Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("failed to open git repo: %s", err.Error()))
+	Expect(err).ShouldNot(HaveOccurred(), fmt.Errorf("failed to open git repo: %w", err).Error())
 
 	// Get remote repository URL
 	remotes, err := repo.Remotes()
-	Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("failed to get remotes: %s", err.Error()))
+	Expect(err).ShouldNot(HaveOccurred(), fmt.Errorf("failed to get remotes: %w", err).Error())
 
 	// Find origin remote
 	for _, remote := range remotes {
@@ -185,7 +185,7 @@ func defaultToCurrentGitRepo(input *FleetCreateGitRepoInput) {
 
 			// Get the current branch
 			head, err := repo.Head()
-			Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("failed to get HEAD: %s", err.Error()))
+			Expect(err).ShouldNot(HaveOccurred(), fmt.Errorf("failed to get HEAD: %w", err).Error())
 
 			input.Branch = head.Name().Short()
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Fixes panic in long e2e suite due to adhering to new linter rules.

Test run: https://github.com/rancher/turtles/actions/runs/16070984765

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
