### PR TITLE
Restore bootstrap cluster kubeconfig path

### DIFF
--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -155,7 +155,6 @@ const (
 	KubernetesManagementVersionVar = "KUBERNETES_MANAGEMENT_VERSION"
 
 	BootstrapClusterNameVar       = "BOOTSTRAP_CLUSTER_NAME"
-	BootstrapClusterKubeconfigVar = "BOOTSTRAP_CLUSTER_KUBECONFIG_PATH"
 
 	ClusterctlRepositoryFolderVar = "CLUSTERCTL_REPOSITORY_FOLDER"
 

--- a/test/e2e/specs/etcd_snapshot_restore.go
+++ b/test/e2e/specs/etcd_snapshot_restore.go
@@ -294,7 +294,8 @@ func ETCDSnapshotRestore(ctx context.Context, inputGetter func() ETCDSnapshotRes
 		By(fmt.Sprintf("Collecting artifacts for %s/%s", input.ClusterName, specName))
 
 		err := testenv.CollectArtifacts(ctx, testenv.CollectArtifactsInput{
-			Path: input.ClusterName + "-bootstrap-" + specName,
+			Path:                    input.ClusterName + "-bootstrap-" + specName,
+			BootstrapKubeconfigPath: input.BootstrapClusterProxy.GetKubeconfigPath(),
 		})
 		if err != nil {
 			log.FromContext(ctx).Error(err, "failed to collect artifacts for the bootstrap cluster")

--- a/test/e2e/specs/import_gitops_mgmtv3.go
+++ b/test/e2e/specs/import_gitops_mgmtv3.go
@@ -366,7 +366,8 @@ func CreateMgmtV3UsingGitOpsSpec(ctx context.Context, inputGetter func() CreateM
 		By(fmt.Sprintf("Collecting artifacts for %s/%s", input.ClusterName, specName))
 
 		err := testenv.CollectArtifacts(ctx, testenv.CollectArtifactsInput{
-			Path: input.ClusterName + "-bootstrap-" + specName,
+			Path:                    input.ClusterName + "-bootstrap-" + specName,
+			BootstrapKubeconfigPath: input.BootstrapClusterProxy.GetKubeconfigPath(),
 		})
 		if err != nil {
 			log.FromContext(ctx).Error(err, "failed to collect artifacts for the bootstrap cluster")

--- a/test/e2e/suites/v2prov/v2prov_test.go
+++ b/test/e2e/suites/v2prov/v2prov_test.go
@@ -172,7 +172,8 @@ var _ = Describe("[v2prov] [Azure] Creating a cluster with v2prov should still w
 		By(fmt.Sprintf("Collecting artifacts for %s/%s", clusterName, specName))
 
 		err := testenv.CollectArtifacts(ctx, testenv.CollectArtifactsInput{
-			Path: clusterName + "-bootstrap-" + specName,
+			Path:                    clusterName + "-bootstrap-" + specName,
+			BootstrapKubeconfigPath: bootstrapClusterProxy.GetKubeconfigPath(),
 		})
 		if err != nil {
 			log.FromContext(ctx).Error(err, "failed to collect artifacts for the bootstrap cluster")

--- a/test/testenv/cleanup.go
+++ b/test/testenv/cleanup.go
@@ -65,7 +65,7 @@ func CleanupTestCluster(ctx context.Context, input CleanupTestClusterInput) {
 
 type CollectArtifactsInput struct {
 	// BootstrapKubeconfigPath is a path to the bootstrap cluster kubeconfig
-	BootstrapKubeconfigPath string `env:"BOOTSTRAP_CLUSTER_KUBECONFIG_PATH"`
+	BootstrapKubeconfigPath string
 
 	// KubeconfigPath is a path to the cluster kubeconfig
 	KubeconfigPath string

--- a/test/testenv/setupcluster.go
+++ b/test/testenv/setupcluster.go
@@ -142,8 +142,6 @@ func (r *SetupTestClusterResult) setupCluster(ctx context.Context, config *clust
 
 		kubeconfigPath = clusterProvider.GetKubeconfigPath()
 		Expect(kubeconfigPath).To(BeAnExistingFile(), "Failed to get the kubeconfig file for the bootstrap cluster")
-
-		Expect(os.Setenv(e2e.BootstrapClusterKubeconfigVar, kubeconfigPath)).To(Succeed(), "Failed to setup bootstrap cluster kubeconfig path env")
 	}
 
 	proxy := framework.NewClusterProxy(clusterName, kubeconfigPath, scheme, framework.WithMachineLogCollector(framework.DockerLogCollector{}))


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Restore bootstrap kubeconfig path to `CollectArtifacts`, as existing setup effectively populated only one thread env with the `kubeconfig` path, resulting in a single random artifact collected per test suite for each bootstrap cluster.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Long run: https://github.com/rancher/turtles/actions/runs/16145581339

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
