### PR TITLE
Use control-plane-endpoint RKE2 registrationMethod with Azure

### DIFF
--- a/examples/clusterclasses/azure/rke2/clusterclass-rke2-example.yaml
+++ b/examples/clusterclasses/azure/rke2/clusterclass-rke2-example.yaml
@@ -89,20 +89,6 @@ spec:
           description: "The VM size used by machines."
           type: string
           default: "Standard_D2s_v3"
-    - name: registrationMethod
-      required: true
-      schema:
-        openAPIV3Schema:
-          description: "Registration method to use. Defaults to control-plane endpoint (empty string). Immutable once is set."
-          type: string
-          default: ""
-          enum:
-            - internal-first
-            - internal-only-ips
-            - external-only-ips
-            - address
-            - control-plane-endpoint
-            - ""
   patches:
     - name: azureClusterTemplate
       definitions:
@@ -137,10 +123,25 @@ spec:
                   subnets:
                   - name: {{ .builtin.cluster.name }}-kcps
                     role: control-plane
+                    securityGroup:
+                      securityRules:
+                      - action: Allow
+                        description: Allow port 9345 for RKE2
+                        destination: '*'
+                        destinationPorts: "9345"
+                        direction: Inbound
+                        name: allow_port_9345
+                        priority: 2203
+                        protocol: Tcp
+                        source: '*'
+                        sourcePorts: '*'
                   - name: {{ .builtin.cluster.name }}-nodes
                     natGateway:
                       name: {{ .builtin.cluster.name }}-nodes
                     role: node
+                  additionalAPIServerLBPorts:
+                  - name: rke2
+                    port: 9345
     - name: azureMachineTemplate
       definitions:
         - selector:
@@ -160,10 +161,6 @@ spec:
                     owner: root:root
                     path: /etc/kubernetes/azure.json
                     permissions: "0644"
-            - op: add
-              path: /spec/template/spec/registrationMethod
-              valueFrom:
-                variable: registrationMethod
         - selector:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: AzureMachineTemplate

--- a/test/e2e/data/cluster-templates/azure-rke2-topology.yaml
+++ b/test/e2e/data/cluster-templates/azure-rke2-topology.yaml
@@ -44,8 +44,6 @@ spec:
       value: highlander-e2e-azure-rke2
     - name: azureClusterIdentityName
       value: cluster-identity
-    - name: registrationMethod
-      value: internal-first
     version: ${RKE2_VERSION}
     workers:
       machineDeployments:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR leverages new CAPZ [security groups functionality](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5525) to properly configure the control plane loadbalancer for RKE2. 

The `internal-first` registration method is no longer needed, and we can default to `control-plane-endpoint` instead.

Test run: https://github.com/rancher/turtles/actions/runs/16164349249
Doc: https://github.com/rancher/turtles-docs/pull/339

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
