### PR TITLE
Remove CAPIO from updatecli

### DIFF
--- a/updatecli/updatecli.d/manifest.yaml
+++ b/updatecli/updatecli.d/manifest.yaml
@@ -86,16 +86,6 @@ sources:
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
       typeFilter:
         latest: true
-  capioperatorrelease:
-    kind: githubrelease
-    name: Get the latest CAPI operator release
-    spec:
-      owner: "rancher-sandbox"
-      repository: "cluster-api-operator"
-      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
-      typeFilter:
-        latest: true
   capiuirelease:
     kind: githubrelease
     name: Get the latest CAPI UI extension release
@@ -201,14 +191,6 @@ targets:
       replacepattern: 'https://github.com/rancher/cluster-api-addon-provider-fleet/releases/{{ source "capifleetrelease" }}/'
     scmid: turtles
     sourceid: capifleetrelease # Will be ignored as `replacepattern` is specified
-  bumpcapioperator:
-    name: bump CAPI Operator version
-    kind: yaml
-    spec:
-      file: "charts/rancher-turtles/Chart.yaml"
-      key: "$.dependencies[0].version"
-    scmid: turtles
-    sourceid: capioperatorrelease # Will be ignored as `replacepattern` is specified
   bumpcapiui:
     name: bump CAPI UI version
     kind: yaml


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Turtles no longer uses CAPI operator helm chart, so regular CAPIO updates are carried by the dependabot dependency bumps in `go.mod` file. This change cleans up outstanding parts.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
