### PR TITLE
Remove deprecated bootstrap-config-gvk capz argument

### DIFF
--- a/internal/sync/azure_provider_sync.go
+++ b/internal/sync/azure_provider_sync.go
@@ -39,32 +39,6 @@ func NewAzureProviderSync(cl client.Client, capiProvider *turtlesv1.CAPIProvider
 		spec.Deployment = &operatorv1.DeploymentSpec{}
 	}
 
-	var container *operatorv1.ContainerSpec
-
-	for i := range spec.Deployment.Containers {
-		if spec.Deployment.Containers[i].Name == "manager" {
-			container = &spec.Deployment.Containers[i]
-			break
-		}
-	}
-
-	if container != nil {
-		if len(container.Args) == 0 {
-			container.Args = map[string]string{
-				"--bootstrap-config-gvk": "RKE2Config.v1beta1.bootstrap.cluster.x-k8s.io",
-			}
-		} else if _, found := container.Args["--bootstrap-config-gvk"]; !found {
-			container.Args["--bootstrap-config-gvk"] = "RKE2Config.v1beta1.bootstrap.cluster.x-k8s.io"
-		}
-	} else {
-		spec.Deployment.Containers = append(spec.Deployment.Containers, operatorv1.ContainerSpec{
-			Name: "manager",
-			Args: map[string]string{
-				"--bootstrap-config-gvk": "RKE2Config.v1beta1.bootstrap.cluster.x-k8s.io",
-			},
-		})
-	}
-
 	capiProvider.SetSpec(spec)
 
 	if capiProvider.Spec.Variables == nil {

--- a/internal/sync/provider_sync_test.go
+++ b/internal/sync/provider_sync_test.go
@@ -265,15 +265,6 @@ var _ = Describe("Provider sync", func() {
 			Expect(err).To(Succeed())
 		}).Should(Succeed())
 
-		capiProviderAzure.Spec.Deployment = &operatorv1.DeploymentSpec{
-			Containers: []operatorv1.ContainerSpec{{
-				Name: "manager",
-				Args: map[string]string{
-					"--bootstrap-config-gvk": "RKE2Config.v1beta1.bootstrap.cluster.x-k8s.io",
-				},
-			}},
-		}
-
 		Eventually(Object(infrastructureAzure)).Should(
 			HaveField("Spec.ProviderSpec", Equal(capiProviderAzure.Spec.ProviderSpec)))
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Just a random cleanup I noticed. 
This argument is deprecated since 0.19.0: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5416

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
