### PR TITLE
Cleanup vsphere self-hosted runner

### DIFF
--- a/.github/workflows/run-vsphere-tests.yaml
+++ b/.github/workflows/run-vsphere-tests.yaml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 env:
-  VSPHERE_TLS_THUMBPRINT: ${{ secrets.VSPHERE_TLS_THUMBPRINT }} 
-  VSPHERE_SERVER: ${{ secrets.VSPHERE_SERVER }} 
+  VSPHERE_TLS_THUMBPRINT: ${{ secrets.VSPHERE_TLS_THUMBPRINT }}
+  VSPHERE_SERVER: ${{ secrets.VSPHERE_SERVER }}
   VSPHERE_DATACENTER: ${{ secrets.VSPHERE_DATACENTER }}
   VSPHERE_DATASTORE: ${{ secrets.VSPHERE_DATASTORE }}
   VSPHERE_FOLDER: ${{ secrets.VSPHERE_FOLDER }}
@@ -77,3 +77,18 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Docker cleanup
+        if: always()
+        run: |
+          CONTAINERS=$(docker ps --all --quiet)
+          if [ -n "$CONTAINERS" ]; then
+            docker stop $CONTAINERS
+          fi
+          docker system prune --all --volumes --force
+          docker network create \
+            --driver=bridge \
+            --subnet=172.19.0.0/16 \
+            --gateway=172.19.0.1 \
+            --opt "com.docker.network.bridge.enable_ip_masquerade"="true" \
+            --opt "com.docker.network.driver.mtu"="1500" \
+            kind


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Cleans up docker artefacts after performing e2e tests / without this we would be hitting `no space left` soon.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1540

**Special notes for your reviewer**:
* I decided to use `run:` block for the cleanup as the self-hosted runner is only temporary and should be replaced by hosted runner where the cleanup won't be needed.
* Cleans up all docker resources: containers, images, docker build cache, volumes and networks.
* Re-creates kind network needed by kind cluster.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] testrun https://github.com/rancher/turtles/actions/runs/16320506448