### PR TITLE
Wait for mounted clusterctl config to be synced

### DIFF
--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -64,8 +64,6 @@ data:
         repository: "registry.suse.com/rancher"
       infrastructure-azure:
         repository: "registry.suse.com/rancher"
-      infrastructure-docker:
-        repository: "gcr.io/k8s-staging-cluster-api"
       infrastructure-gcp:
         repository: "registry.suse.com/rancher"
       infrastructure-vsphere:

--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -101,6 +101,8 @@ install_local_rancher_turtles_chart() {
         --dependency-update \
         --create-namespace --wait \
         --timeout 180s
+
+    kubectl apply -f test/e2e/data/capi-operator/clusterctlconfig.yaml
 }
 
 echo "Installing local Rancher Turtles chart for development..."

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -131,6 +131,9 @@ var (
 
 	//go:embed data/gitea/values.yaml
 	GiteaValues []byte
+
+	//go:embed data/capi-operator/clusterctlconfig.yaml
+	ClusterctlConfig []byte
 )
 
 const (
@@ -154,7 +157,7 @@ const (
 
 	KubernetesManagementVersionVar = "KUBERNETES_MANAGEMENT_VERSION"
 
-	BootstrapClusterNameVar       = "BOOTSTRAP_CLUSTER_NAME"
+	BootstrapClusterNameVar = "BOOTSTRAP_CLUSTER_NAME"
 
 	ClusterctlRepositoryFolderVar = "CLUSTERCTL_REPOSITORY_FOLDER"
 

--- a/test/e2e/data/capi-operator/clusterctlconfig.yaml
+++ b/test/e2e/data/capi-operator/clusterctlconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: ClusterctlConfig
+metadata:
+  name: clusterctl-config
+  namespace: rancher-turtles-system
+spec:
+  images:
+  - name: docker
+    repository: "gcr.io/k8s-staging-cluster-api"

--- a/test/testenv/turtles.go
+++ b/test/testenv/turtles.go
@@ -226,6 +226,9 @@ func DeployRancherTurtles(ctx context.Context, input DeployRancherTurtlesInput) 
 		Expect(fmt.Errorf("Unable to perform chart upgrade: %w\nOutput: %s, Command: %s", err, out, strings.Join(fullCommand, " "))).ToNot(HaveOccurred())
 	}
 
+	By("Applying test ClusterctlConfig")
+	Expect(turtlesframework.Apply(ctx, input.BootstrapClusterProxy, e2e.ClusterctlConfig)).To(Succeed())
+
 	if input.CAPIProvidersYAML != nil {
 		By("Adding CAPI infrastructure providers")
 		Expect(turtlesframework.Apply(ctx, input.BootstrapClusterProxy, input.CAPIProvidersYAML)).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an initial phase to Provider reconciliation, so that it waits for the mounted config (`/config/clusterctl.yaml`) to be synced. Note that it may take [a few minutes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically) for the sync to happen, all the CAPIProviders will be stuck in "Provisioning" for the time being. This is not great, but certainly better than trying to deploy providers **without** overrides (and then patch them).

The sync itself is left untouched, so it will still load the in-memory embedded config and apply changes from the user-defined ClusterctlConfig resource, if any.

I added some rudimentary image override validation in e2e, since we are currently blind on this issue, and moved the `gcr.io/k8s-staging-cluster-api` override for capd in e2e tests only.

Waiting for a test run and further validation. 

Test run: https://github.com/rancher/turtles/actions/runs/16322697320

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1542

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
