### PR TITLE
feat: let wrangler manage certs

### DIFF
--- a/api/v1alpha1/conditions_consts.go
+++ b/api/v1alpha1/conditions_consts.go
@@ -33,6 +33,9 @@ const (
 
 	// CheckLatestVersionTime is set as a timestamp info of the last timestamp of the latest version being up-to-date for the CAPIProvider.
 	CheckLatestVersionTime = "CheckLatestVersionTime"
+
+	// CAPIProviderWranglerManagedCertificatesCondition is the condittion used when provider certificates managed by wrangler.
+	CAPIProviderWranglerManagedCertificatesCondition clusterv1.ConditionType = "WranglerManagedCertificates"
 )
 
 const (

--- a/charts/rancher-turtles/questions.yml
+++ b/charts/rancher-turtles/questions.yml
@@ -30,6 +30,12 @@ questions:
         type: boolean
         label: Enable Agent TLS Mode
         group: "Rancher Turtles Features Settings"
+      - variable: rancherTurtles.features.no-cert-manager.enabled
+        default: false
+        description: "[ALPHA] If enabled Turtles will remove cert-manager."
+        type: boolean
+        label: Remove cert-manager
+        group: "Rancher Turtles Features Settings"
       - variable: rancherTurtles.kubectlImage
         default: "registry.k8s.io/kubernetes/kubectl:v1.31.4"
         description: "Specify the image to use when running kubectl in jobs."

--- a/charts/rancher-turtles/templates/deployment.yaml
+++ b/charts/rancher-turtles/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - args:
         - --leader-elect
-        - --feature-gates=agent-tls-mode={{ index .Values "rancherTurtles" "features" "agent-tls-mode" "enabled"}},ui-plugin={{ index .Values "turtlesUI" "enabled"}}
+        - --feature-gates=agent-tls-mode={{ index .Values "rancherTurtles" "features" "agent-tls-mode" "enabled"}},ui-plugin={{ index .Values "turtlesUI" "enabled"}},no-cert-manager={{ index .Values "rancherTurtles" "features" "no-cert-manager" "enabled"}}
         {{- range .Values.rancherTurtles.managerArguments }}
         - {{ . }}
         {{- end }}  

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -45,6 +45,10 @@ rancherTurtles:
     agent-tls-mode:
       # enabled: Turn on or off.
       enabled: true
+    # no-cert-manager: Alpha feature for cert-manager removal.
+    no-cert-manager:
+      # enabled: Turn on or off.
+      enabled: false
     # clusterclass-operations: Alpha feature. Manages cluster class ops. Not ready for testing yet.
     clusterclass-operations:
       # enabled: Turn on or off.

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -28,6 +28,9 @@ const (
 
 	// UIPlugin if enabled Turtles will install and manage UIPlugin resource for CAPI UI.
 	UIPlugin featuregate.Feature = "ui-plugin"
+
+	// NoCertManager if enabled Turtles will remove cert-manager, including Certificate and Issuer.
+	NoCertManager featuregate.Feature = "no-cert-manager"
 )
 
 func init() {
@@ -35,6 +38,7 @@ func init() {
 }
 
 var defaultGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	AgentTLSMode: {Default: true, PreRelease: featuregate.Beta},
-	UIPlugin:     {Default: false, PreRelease: featuregate.Alpha},
+	AgentTLSMode:  {Default: true, PreRelease: featuregate.Beta},
+	UIPlugin:      {Default: false, PreRelease: featuregate.Alpha},
+	NoCertManager: {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds logic to patch objects defined in a provider's manifest leveraging a new CAPI Operator functionality that allows passing a custom alter components function which is executed during the `Fetch` phase.

A new feature gate `no-cert-manager` is added, and this logic is only applied if set to `true` (it is an opt-in action, defaults to `false`). The following operations are performed if enabled.
## Let wrangler manage certificates

This is implemented in function `patchProviderManifestFn`, which retrieves the name of the secret from the `Certificate` resource and annotates the webhook service (e.g. `capi-webhook-service` with:
`need-a-cert.cattle.io/secret-name: <secretName>`

## Remove cert-manager

This is implemented in function `removeCertManagerFn`:
- Removes annotation `cert-manager.io/inject-ca-from` from any resource in the manifest.
- Deletes resources `Certificate` and `Issuer` from the list of objects.

This step runs on provider installation (or update), as modifying the object manifest after is has already been deployed does not have effect on the existing resources. This is because of the reconciliation phases and the manifest being stored in memory.

## Certificate and Issuer removal

After the initial phase of patching manifests, former cert-manager `Certificates` and `Issuers` must be explicitly deleted to prevent conflicts with Wrangler certificate management, this is done by `purgeCertificateResources`, an extra phase that is added to the list of `CAPIProvider` reconciliation phases only when the feature gate is enabled. It deletes resources using a selector on provider namespace and the existence of a CAPI provider label. Resources are listed using `Unstructured` to prevent us from having to add a dependency on `cert-manager` API types.

## Provider restart

After all changes are applied to providers, deployments are annotated to trigger a rollout, which effectively means removing the existing controller pod and creating a new one.

Once this last step is complete, a new `Condition` on `CAPIProvider` is set to true: `WranglerManagedCertificates`. **This condition is also used to only run certificate/issuer removal and provider rollout once**. 

**Which issue(s) this PR fixes**:
Fixes #1513 

**Special notes for your reviewer**:

As a follow-up to this there should be a test case where this feature is enabled.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
