### PR TITLE
chore: bump cluster-api-provider-rke2 to v0.18.1

### DIFF
--- a/exp/day2/go.mod
+++ b/exp/day2/go.mod
@@ -7,7 +7,7 @@ replace github.com/rancher/turtles => ../..
 require (
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
-	github.com/rancher/cluster-api-provider-rke2 v0.18.0
+	github.com/rancher/cluster-api-provider-rke2 v0.18.1
 	github.com/rancher/turtles v0.0.0-00010101000000-000000000000
 	github.com/spf13/pflag v1.0.6
 	k8s.io/api v0.32.6

--- a/exp/day2/go.sum
+++ b/exp/day2/go.sum
@@ -159,8 +159,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/rancher/cluster-api-provider-rke2 v0.18.0 h1:wB1hrf8X4SCeR6k/3Itu6MxCANUWSlMjBD8NpI0DK9A=
-github.com/rancher/cluster-api-provider-rke2 v0.18.0/go.mod h1:Llm9xlGmXNxj7ETf4WfRCL6oVG+Y2xpNoX5oTYbneHk=
+github.com/rancher/cluster-api-provider-rke2 v0.18.1 h1:eF94zARXhENo8+BMlJG1I2YHeZFKsqPAh5Y+/30SA0k=
+github.com/rancher/cluster-api-provider-rke2 v0.18.1/go.mod h1:Bw8+xS0DyLWApGBq7M0mxy4Zd8ZQ/0hcXsB7hg6ImPw=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/controllers/clusterctl/config.yaml
+++ b/internal/controllers/clusterctl/config.yaml
@@ -36,7 +36,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.9.5/bootstrap-components.yaml"
       type:         "BootstrapProvider"
     - name:         "rke2"
-      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.18.0/bootstrap-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.18.1/bootstrap-components.yaml"
       type:         "BootstrapProvider"
 
     # ControlPlane providers
@@ -44,7 +44,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.9.5/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
     - name:         "rke2"
-      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.18.0/control-plane-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.18.1/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
 
     # Addon providers


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump Cluster API Provider RKE2 to latest patch version `v0.18.1`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
