### PR TITLE
feat: Add post-upgrade hook that deletes all CAPI Operator provider resources

### DIFF
--- a/charts/rancher-turtles/templates/post-upgrade-job.yaml
+++ b/charts/rancher-turtles/templates/post-upgrade-job.yaml
@@ -1,0 +1,109 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: post-upgrade-job
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "1"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: post-upgrade-job-delete-capi-operator-resources
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "1"
+rules:
+- apiGroups:
+  - operator.cluster.x-k8s.io
+  resources:
+  - addonproviders
+  - bootstrapproviders
+  - controlplaneproviders
+  - coreproviders
+  - infrastructureproviders
+  - ipamproviders
+  - runtimeextensionproviders
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: post-upgrade-job-capi-operator-resources-cleanup
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "1"
+subjects:
+  - kind: ServiceAccount
+    name: post-upgrade-job
+    namespace: '{{ .Values.rancherTurtles.namespace }}'
+roleRef:
+  kind: ClusterRole
+  name: post-upgrade-job-delete-capi-operator-resources
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-api-operator-resources-cleanup-script
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "1"
+data:
+  cleanup.sh: |
+    #!/usr/bin/env bash
+
+    set -euo pipefail
+
+    kubectl get addonproviders.operator.cluster.x-k8s.io --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch addonproviders.operator.cluster.x-k8s.io "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
+    kubectl delete addonproviders.operator.cluster.x-k8s.io --all --all-namespaces 
+    kubectl get bootstrapproviders.operator.cluster.x-k8s.io --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch bootstrapproviders.operator.cluster.x-k8s.io "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
+    kubectl delete bootstrapproviders.operator.cluster.x-k8s.io --all --all-namespaces
+    kubectl get controlplaneproviders.operator.cluster.x-k8s.io --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch controlplaneproviders.operator.cluster.x-k8s.io "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
+    kubectl delete controlplaneproviders.operator.cluster.x-k8s.io --all --all-namespaces
+    kubectl get coreproviders.operator.cluster.x-k8s.io --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch coreproviders.operator.cluster.x-k8s.io "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
+    kubectl delete coreproviders.operator.cluster.x-k8s.io --all --all-namespaces
+    kubectl get infrastructureproviders.operator.cluster.x-k8s.io --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch infrastructureproviders.operator.cluster.x-k8s.io "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
+    kubectl delete infrastructureproviders.operator.cluster.x-k8s.io --all --all-namespaces
+    kubectl get ipamproviders.operator.cluster.x-k8s.io --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch ipamproviders.operator.cluster.x-k8s.io "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
+    kubectl delete ipamproviders.operator.cluster.x-k8s.io --all --all-namespaces
+    kubectl get runtimeextensionproviders.operator.cluster.x-k8s.io --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch runtimeextensionproviders.operator.cluster.x-k8s.io "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
+    kubectl delete runtimeextensionproviders.operator.cluster.x-k8s.io --all --all-namespaces
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cluster-api-operator-resources-cleanup
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "2"
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: post-upgrade-job
+      containers:
+        - name: cluster-api-operator-resources-cleanup
+          image: {{ index .Values "rancherTurtles" "shellImage" }}
+          command: ["/bin/bash"]
+          args:
+          - "-c"
+          - "/scripts/cleanup.sh"
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+      volumes:
+        - name: script
+          configMap:
+            name: cluster-api-operator-resources-cleanup-script
+            defaultMode: 0777
+      restartPolicy: Never
+---

--- a/charts/rancher-turtles/templates/post-upgrade-job.yaml
+++ b/charts/rancher-turtles/templates/post-upgrade-job.yaml
@@ -62,20 +62,25 @@ data:
 
     set -euo pipefail
 
-    kubectl get addonproviders.operator.cluster.x-k8s.io --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch addonproviders.operator.cluster.x-k8s.io "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
-    kubectl delete addonproviders.operator.cluster.x-k8s.io --all --all-namespaces 
-    kubectl get bootstrapproviders.operator.cluster.x-k8s.io --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch bootstrapproviders.operator.cluster.x-k8s.io "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
-    kubectl delete bootstrapproviders.operator.cluster.x-k8s.io --all --all-namespaces
-    kubectl get controlplaneproviders.operator.cluster.x-k8s.io --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch controlplaneproviders.operator.cluster.x-k8s.io "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
-    kubectl delete controlplaneproviders.operator.cluster.x-k8s.io --all --all-namespaces
-    kubectl get coreproviders.operator.cluster.x-k8s.io --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch coreproviders.operator.cluster.x-k8s.io "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
-    kubectl delete coreproviders.operator.cluster.x-k8s.io --all --all-namespaces
-    kubectl get infrastructureproviders.operator.cluster.x-k8s.io --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch infrastructureproviders.operator.cluster.x-k8s.io "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
-    kubectl delete infrastructureproviders.operator.cluster.x-k8s.io --all --all-namespaces
-    kubectl get ipamproviders.operator.cluster.x-k8s.io --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch ipamproviders.operator.cluster.x-k8s.io "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
-    kubectl delete ipamproviders.operator.cluster.x-k8s.io --all --all-namespaces
-    kubectl get runtimeextensionproviders.operator.cluster.x-k8s.io --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch runtimeextensionproviders.operator.cluster.x-k8s.io "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
-    kubectl delete runtimeextensionproviders.operator.cluster.x-k8s.io --all --all-namespaces
+    remove_finalizers_and_delete() {
+      local resource_type="$1"
+      kubectl get $resource_type --all-namespaces --no-headers --ignore-not-found | awk '{print $1 " " $2}' | xargs -r -n2 bash -c 'kubectl patch '"${resource_type}"' "$1" -n "$0" --type merge -p "{\"metadata\":{\"finalizers\":null}}"'
+      kubectl delete $resource_type --all --all-namespaces
+    }
+
+    resource_types=(
+      "addonproviders.operator.cluster.x-k8s.io"
+      "bootstrapproviders.operator.cluster.x-k8s.io"
+      "controlplaneproviders.operator.cluster.x-k8s.io"
+      "coreproviders.operator.cluster.x-k8s.io"
+      "infrastructureproviders.operator.cluster.x-k8s.io"
+      "ipamproviders.operator.cluster.x-k8s.io"
+      "runtimeextensionproviders.operator.cluster.x-k8s.io"
+    )
+
+    for resource_type in "${resource_types[@]}"; do
+      remove_finalizers_and_delete "$resource_type"
+    done
 ---
 apiVersion: batch/v1
 kind: Job

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -23,6 +23,8 @@ rancherTurtles:
   rancherInstalled: true
   # kubectlImage: Image for kubectl tasks.
   kubectlImage: registry.k8s.io/kubernetes/kubectl:v1.30.0
+  # shellImage: Image for shell tasks.
+  shellImage: rancher/kuberlr-kubectl:v5.0.0
   # features: Optional and experimental features.
   features:
     # day2operations: Alpha feature.


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR adds a post-upgrade hook that removes all CAPI Operator provider resources from the cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1548 

**Special notes for your reviewer**:

To test this, run `RELEASE_TAG=v0.22.0 make release` then upgrade an existing Turtles installation by running 
```
helm upgrade rancher-turtles -n rancher-turtles-system --reset-then-reuse-values ./out/package/rancher-turtles-0.22.0.tgz --debug
```
to install the new chart version.

The `kubectl` image could not be used as it is distroless. 

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
