### PR TITLE
Implement CAPIProvider EnableAutomaticUpdate toggle

### DIFF
--- a/api/v1alpha1/capiprovider_types.go
+++ b/api/v1alpha1/capiprovider_types.go
@@ -59,6 +59,10 @@ type CAPIProviderSpec struct {
 	// +kubebuilder:example={CLUSTER_TOPOLOGY:"true",EXP_CLUSTER_RESOURCE_SET:"true",EXP_MACHINE_POOL: "true"}
 	Variables map[string]string `json:"variables,omitempty"`
 
+	// EnableAutomaticUpdate can be used to automatically update the CAPIProvider to a newest version.
+	// +optional
+	EnableAutomaticUpdate bool `json:"enableAutomaticUpdate,omitempty"`
+
 	// ProviderSpec is the spec of the underlying CAPI Provider resource.
 	operatorv1.ProviderSpec `json:",inline"`
 }

--- a/charts/rancher-turtles/templates/addon-provider-fleet.yaml
+++ b/charts/rancher-turtles/templates/addon-provider-fleet.yaml
@@ -7,6 +7,7 @@ metadata:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "2"
 spec:
+  enableAutomaticUpdate: true
   type: addon
   additionalManifests:
     name: fleet-addon-config

--- a/charts/rancher-turtles/templates/core-provider.yaml
+++ b/charts/rancher-turtles/templates/core-provider.yaml
@@ -22,7 +22,10 @@ metadata:
 spec:
   name: cluster-api
   type: core
-  version: {{ index .Values "cluster-api-operator" "cluster-api" "version" }}
+  enableAutomaticUpdate: {{ index .Values "cluster-api-operator" "cluster-api" "core" "enableAutomaticUpdate" }}
+{{- if index .Values "cluster-api-operator" "cluster-api" "core" "version" }}
+  version: {{ index .Values "cluster-api-operator" "cluster-api" "core" "version" }}
+{{- end }}
   additionalManifests:
     name: capi-additional-rbac-roles
     namespace: {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}

--- a/charts/rancher-turtles/templates/rancher-turtles-components.yaml
+++ b/charts/rancher-turtles/templates/rancher-turtles-components.yaml
@@ -2782,6 +2782,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              enableAutomaticUpdate:
+                description: EnableAutomaticUpdate can be used to automatically update
+                  the CAPIProvider to a newest version.
+                type: boolean
               features:
                 description: Features is a collection of features to enable.
                 example:

--- a/charts/rancher-turtles/templates/rke2-bootstrap.yaml
+++ b/charts/rancher-turtles/templates/rke2-bootstrap.yaml
@@ -22,6 +22,7 @@ metadata:
 spec:
   name: rke2
   type: bootstrap
+  enableAutomaticUpdate: {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "enableAutomaticUpdate" }}
 {{- if index .Values  "cluster-api-operator" "cluster-api" "rke2" "version" }}
   version: {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "version" }}
 {{- end }}

--- a/charts/rancher-turtles/templates/rke2-controlplane.yaml
+++ b/charts/rancher-turtles/templates/rke2-controlplane.yaml
@@ -22,6 +22,7 @@ metadata:
 spec:
   name: rke2
   type: controlPlane
+  enableAutomaticUpdate: {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "enableAutomaticUpdate" }}
 {{- if index .Values  "cluster-api-operator" "cluster-api" "rke2" "version" }}
   version: {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "version" }}
 {{- end }}

--- a/charts/rancher-turtles/values.schema.json
+++ b/charts/rancher-turtles/values.schema.json
@@ -257,6 +257,16 @@
                     "url": { "type": "string", "default": "" },
                     "selector": { "type": "string", "default": "" }
                   }
+                },
+                "enableAutomaticUpdates": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Allow the provider to update automatically when a new Turtles version is installed."
+                },
+                "version": {
+                  "type": "string",
+                  "default": "",
+                  "description": "CAPI core provider version."
                 }
               }
             },
@@ -272,6 +282,11 @@
                   "type": "string",
                   "default": "",
                   "description": "RKE2 version."
+                },
+                "enableAutomaticUpdates": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Allow the provider to update automatically when a new Turtles version is installed."
                 },
                 "bootstrap": {
                   "type": "object",

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -84,6 +84,10 @@ cluster-api-operator:
     core:
       # namespace: Core component namespace.
       namespace: capi-system
+      # version: Core ClusterAPI version.
+      version: ""
+      # enableAutomaticUpdate: Allow the provider to update automatically when a new Turtles version is installed.
+      enableAutomaticUpdate: true
       # imageUrl: Custom image URL.
       imageUrl: ""
       # fetchConfig: Config fetching settings.
@@ -98,6 +102,8 @@ cluster-api-operator:
       enabled: true
       # version: RKE2 version.
       version: ""
+      # enableAutomaticUpdate: Allow the provider to update automatically when a new Turtles version is installed.
+      enableAutomaticUpdate: true
       # bootstrap: RKE2 bootstrap provider.
       bootstrap:
         # namespace: Bootstrap namespace.

--- a/config/crd/bases/turtles-capi.cattle.io_capiproviders.yaml
+++ b/config/crd/bases/turtles-capi.cattle.io_capiproviders.yaml
@@ -2782,6 +2782,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              enableAutomaticUpdate:
+                description: EnableAutomaticUpdate can be used to automatically update
+                  the CAPIProvider to a newest version.
+                type: boolean
               features:
                 description: Features is a collection of features to enable.
                 example:

--- a/internal/controllers/operator_reconciler_test.go
+++ b/internal/controllers/operator_reconciler_test.go
@@ -112,6 +112,7 @@ var _ = Describe("Provider sync", func() {
 
 	It("Should sync spec down and leave version to latest", func() {
 		origin := capiProvider.DeepCopy()
+		origin.Spec.EnableAutomaticUpdate = true
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(origin).Build()
 		r := &CAPIProviderReconciler{
 			Client: fakeClient,
@@ -188,6 +189,7 @@ var _ = Describe("Provider sync", func() {
 
 	It("Should set custom provider version to latest according to clusterctlconfig override", func() {
 		origin := customCAPIProvider.DeepCopy()
+		origin.Spec.EnableAutomaticUpdate = true
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(origin, clusterctlconfig).Build()
 		r := &CAPIProviderReconciler{
 			Client: fakeClient,
@@ -277,6 +279,7 @@ var _ = Describe("Provider sync", func() {
 
 	It("Should sync status up and set provisioning state", func() {
 		origin := capiProvider.DeepCopy()
+		origin.Spec.EnableAutomaticUpdate = true
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(origin).Build()
 		r := &CAPIProviderReconciler{
 			Client: fakeClient,

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -28,6 +28,7 @@ intervals:
   default/wait-gitea-service: ["5m", "30s"]
   default/wait-gitea-uninstall: ["10m", "30s"]
   default/wait-turtles-uninstall: ["10m", "30s"]
+  default/wait-capiprovider-update: ["5m", "10s"]
 
 variables:
   # General Configuration

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -134,6 +134,23 @@ var (
 
 	//go:embed data/capi-operator/clusterctlconfig.yaml
 	ClusterctlConfig []byte
+
+	//CAPIProvider test data
+
+	//go:embed data/test-providers/namespace.yaml
+	CAPVProviderNamespace []byte
+
+	//go:embed data/test-providers/capv-provider-no-ver.yaml
+	CAPVProviderNoVersion []byte
+
+	//go:embed data/test-providers/unknown-provider.yaml
+	UnknownProvider []byte
+
+	//go:embed data/test-providers/clusterctlconfig.yaml
+	ClusterctlConfigInitial []byte
+
+	//go:embed data/test-providers/clusterctlconfig-updated.yaml
+	ClusterctlConfigUpdated []byte
 )
 
 const (

--- a/test/e2e/data/test-providers/capv-provider-no-ver.yaml
+++ b/test/e2e/data/test-providers/capv-provider-no-ver.yaml
@@ -1,0 +1,10 @@
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: vsphere
+  namespace: capv-system
+spec:
+  type: infrastructure
+  variables:
+    VSPHERE_USERNAME: ""
+    VSPHERE_PASSWORD: ""

--- a/test/e2e/data/test-providers/clusterctlconfig-updated.yaml
+++ b/test/e2e/data/test-providers/clusterctlconfig-updated.yaml
@@ -1,0 +1,13 @@
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: ClusterctlConfig
+metadata:
+  name: clusterctl-config
+  namespace: rancher-turtles-system
+spec:
+  providers:
+  - name: vsphere
+    url: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/v1.13.0/infrastructure-components.yaml
+    type: InfrastructureProvider
+  images:
+  - name: infrastructure-vsphere
+    repository: registry.k8s.io/cluster-api-vsphere

--- a/test/e2e/data/test-providers/clusterctlconfig.yaml
+++ b/test/e2e/data/test-providers/clusterctlconfig.yaml
@@ -1,0 +1,13 @@
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: ClusterctlConfig
+metadata:
+  name: clusterctl-config
+  namespace: rancher-turtles-system
+spec:
+  providers:
+  - name: vsphere
+    url: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/v1.12.0/infrastructure-components.yaml
+    type: InfrastructureProvider
+  images:
+  - name: infrastructure-vsphere
+    repository: registry.k8s.io/cluster-api-vsphere

--- a/test/e2e/data/test-providers/namespace.yaml
+++ b/test/e2e/data/test-providers/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capv-system

--- a/test/e2e/data/test-providers/unknown-provider.yaml
+++ b/test/e2e/data/test-providers/unknown-provider.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: unknown-provider
+spec: {}
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: vcluster
+  namespace: unknown-provider
+spec:
+  enableAutomaticUpdate: true # Since this provider is uknown, enabling automatic updates should have no effect.
+  version: v0.2.1
+  type: infrastructure

--- a/test/e2e/suites/capiprovider/capiprovider_test.go
+++ b/test/e2e/suites/capiprovider/capiprovider_test.go
@@ -1,0 +1,191 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright © 2023 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capiprovider
+
+import (
+	"context"
+	_ "embed"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+
+	"github.com/rancher/turtles/test/e2e"
+	"github.com/rancher/turtles/test/framework"
+	"github.com/rancher/turtles/test/testenv"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	turtlesv1 "github.com/rancher/turtles/api/v1alpha1"
+)
+
+const (
+	deploymentName      = "capv-controller-manager"
+	deploymentNamespace = "capv-system"
+)
+
+var (
+	deploymentKey = types.NamespacedName{Namespace: deploymentNamespace, Name: deploymentName}
+)
+
+var _ = Describe("CAPIProvider lifecycle", Ordered, Label(e2e.ShortTestLabel), func() {
+	BeforeEach(func() {
+		SetClient(bootstrapClusterProxy.GetClient())
+		SetContext(ctx)
+	})
+
+	It("Should apply initial ClusterctlConfig", func() {
+		Expect(framework.Apply(ctx, bootstrapClusterProxy, e2e.ClusterctlConfigInitial)).Should(Succeed())
+	})
+
+	It("Should install latest available provider version from ClusterctlConfig when version is empty", func() {
+		Expect(framework.Apply(ctx, bootstrapClusterProxy, e2e.CAPVProviderNamespace)).Should(Succeed())
+
+		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			CAPIProvidersYAML: [][]byte{
+				e2e.CAPVProviderNoVersion,
+			},
+			WaitForDeployments: []testenv.NamespaceName{
+				{
+					Name:      deploymentName,
+					Namespace: deploymentNamespace,
+				},
+			},
+		})
+
+		verifyManagerImage(ctx, deploymentKey, "registry.k8s.io/cluster-api-vsphere/cluster-api-vsphere-controller:v1.12.0")
+	})
+
+	It("Should have pinned latest installed version", func() {
+		provider := &turtlesv1.CAPIProvider{}
+		Expect(bootstrapClusterProxy.GetClient().
+			Get(ctx, types.NamespacedName{Namespace: "capv-system", Name: "vsphere"}, provider)).
+			Should(Succeed())
+		Expect(provider.Spec.Version).Should(Equal("v1.12.0"))
+	})
+
+	It("Should notify of available update when bumping ClusterctlConfig", func() {
+		Expect(framework.Apply(ctx, bootstrapClusterProxy, e2e.ClusterctlConfigUpdated)).Should(Succeed())
+		provider := &turtlesv1.CAPIProvider{}
+		checkLastVersionCondition := &clusterv1.Condition{}
+		Eventually(func() bool {
+			Expect(bootstrapClusterProxy.GetClient().
+				Get(ctx, types.NamespacedName{Namespace: "capv-system", Name: "vsphere"}, provider)).
+				Should(Succeed())
+			checkLastVersionCondition = conditions.Get(provider, turtlesv1.CheckLatestVersionTime)
+			if checkLastVersionCondition == nil {
+				return false
+			}
+			if checkLastVersionCondition.Reason != turtlesv1.CheckLatestUpdateAvailableReason {
+				return false
+			}
+			return true
+		}, e2e.LoadE2EConfig().GetIntervals("default", "wait-capiprovider-update")...).Should(BeTrue(), "CAPIProvider must have CheckLatestVersionTime condition with UpdateAvailable reason")
+		Expect(checkLastVersionCondition.Severity).Should(Equal(clusterv1.ConditionSeverityInfo), "UpdateAvailable severity must be Info")
+		Expect(checkLastVersionCondition.Status).Should(Equal(corev1.ConditionFalse), "UpdateAvailable status must be False")
+		Expect(checkLastVersionCondition.Message).Should(Equal("Provider version update available. Current latest is v1.13.0"))
+	})
+
+	It("Should not automatically update provider version", func() {
+		provider := &turtlesv1.CAPIProvider{}
+		Expect(bootstrapClusterProxy.GetClient().
+			Get(ctx, types.NamespacedName{Namespace: "capv-system", Name: "vsphere"}, provider)).
+			Should(Succeed())
+		Expect(provider.Spec.Version).Should(Equal("v1.12.0"))
+		consistentlyVerifyManagerImage(ctx, deploymentKey, "registry.k8s.io/cluster-api-vsphere/cluster-api-vsphere-controller:v1.12.0")
+	})
+
+	It("Should automatically update provider version if EnabledAutomaticUpdate", func() {
+		provider := &turtlesv1.CAPIProvider{}
+		Expect(bootstrapClusterProxy.GetClient().
+			Get(ctx, types.NamespacedName{Namespace: "capv-system", Name: "vsphere"}, provider)).
+			Should(Succeed())
+		provider.Spec.EnableAutomaticUpdate = true
+		Expect(bootstrapClusterProxy.GetClient().Update(ctx, provider)).Should(Succeed())
+
+		Eventually(func() bool {
+			Expect(bootstrapClusterProxy.GetClient().
+				Get(ctx, types.NamespacedName{Namespace: "capv-system", Name: "vsphere"}, provider)).
+				Should(Succeed())
+			checkLastVersionCondition := conditions.Get(provider, turtlesv1.CheckLatestVersionTime)
+			if checkLastVersionCondition == nil {
+				return false
+			}
+			if checkLastVersionCondition.Status != corev1.ConditionTrue {
+				return false
+			}
+			return true
+		}, e2e.LoadE2EConfig().GetIntervals("default", "wait-capiprovider-update")...).
+			Should(BeTrue(), "CAPIProvider must have CheckLatestVersionTime condition True")
+
+		Expect(provider.Spec.Version).Should(Equal("v1.13.0"))
+		verifyManagerImage(ctx, deploymentKey, "registry.k8s.io/cluster-api-vsphere/cluster-api-vsphere-controller:v1.13.0")
+	})
+
+	It("Should not automatically update Uknown provider", func() {
+		Expect(framework.Apply(ctx, bootstrapClusterProxy, e2e.UnknownProvider)).Should(Succeed())
+		provider := &turtlesv1.CAPIProvider{}
+		checkLastVersionCondition := &clusterv1.Condition{}
+		Eventually(func() bool {
+			Expect(bootstrapClusterProxy.GetClient().
+				Get(ctx, types.NamespacedName{Namespace: "unknown-provider", Name: "vcluster"}, provider)).
+				Should(Succeed())
+			checkLastVersionCondition = conditions.Get(provider, turtlesv1.CheckLatestVersionTime)
+			if checkLastVersionCondition == nil {
+				return false
+			}
+			return true
+		}, e2e.LoadE2EConfig().GetIntervals("default", "wait-capiprovider-update")...).
+			Should(BeTrue(), "CAPIProvider must have CheckLatestVersionTime condition")
+		Expect(checkLastVersionCondition.Status).Should(Equal(corev1.ConditionUnknown), "UpdateAvailable status must be Unknown")
+		Expect(checkLastVersionCondition.Message).Should(Equal("Provider is unknown"))
+		Expect(checkLastVersionCondition.Reason).Should(Equal(turtlesv1.CheckLatestProviderUnknownReason))
+
+		Expect(provider.Spec.Version).Should(Equal("v0.2.1"))
+		consistentlyVerifyManagerImage(ctx, deploymentKey, "docker.io/loftsh/cluster-api-provider-vcluster:0.2.1")
+	})
+})
+
+func verifyManagerImage(ctx context.Context, deploymentKey types.NamespacedName, desiredImage string) {
+	GinkgoHelper()
+	deployment := &appsv1.Deployment{}
+	Expect(bootstrapClusterProxy.GetClient().Get(ctx, deploymentKey, deployment)).Should(Succeed())
+	foundImage := ""
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == "manager" {
+			foundImage = container.Image
+		}
+	}
+	Expect(foundImage).ShouldNot(BeEmpty(), "Could not find any manager container image")
+
+	Expect(foundImage).Should(Equal(desiredImage))
+}
+
+func consistentlyVerifyManagerImage(ctx context.Context, deploymentKey types.NamespacedName, desiredImage string) {
+	Consistently(func() {
+		verifyManagerImage(ctx, deploymentKey, desiredImage)
+	}).WithTimeout(2 * time.Minute).WithPolling(10 * time.Second)
+}

--- a/test/e2e/suites/capiprovider/suite_test.go
+++ b/test/e2e/suites/capiprovider/suite_test.go
@@ -1,0 +1,125 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright © 2023 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capiprovider
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/json"
+	capiframework "sigs.k8s.io/cluster-api/test/framework"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/rancher/turtles/test/e2e"
+	"github.com/rancher/turtles/test/testenv"
+)
+
+// Test suite global vars.
+var (
+	// hostName is the host name for the Rancher Manager server.
+	hostName string
+
+	ctx = context.Background()
+
+	setupClusterResult    *testenv.SetupTestClusterResult
+	bootstrapClusterProxy capiframework.ClusterProxy
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	ctrl.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	RunSpecs(t, "rancher-turtles-e2e-capiprovider")
+}
+
+var _ = SynchronizedBeforeSuite(
+	func() []byte {
+		e2eConfig := e2e.LoadE2EConfig()
+		e2eConfig.ManagementClusterName = e2eConfig.ManagementClusterName + "-capiprovider"
+		setupClusterResult = testenv.SetupTestCluster(ctx, testenv.SetupTestClusterInput{
+			E2EConfig: e2eConfig,
+			Scheme:    e2e.InitScheme(),
+		})
+
+		testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
+			BootstrapClusterProxy:     setupClusterResult.BootstrapClusterProxy,
+			CustomIngress:             e2e.NginxIngress,
+			CustomIngressLoadBalancer: e2e.NginxIngressLoadBalancer,
+			DefaultIngressClassPatch:  e2e.IngressClassPatch,
+		})
+
+		rancherHookResult := testenv.DeployRancher(ctx, testenv.DeployRancherInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+			RancherPatches:        [][]byte{e2e.RancherSettingPatch},
+		})
+
+		testenv.DeployRancherTurtles(ctx, testenv.DeployRancherTurtlesInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+			AdditionalValues:      map[string]string{},
+		})
+
+		data, err := json.Marshal(e2e.Setup{
+			ClusterName:     setupClusterResult.ClusterName,
+			KubeconfigPath:  setupClusterResult.KubeconfigPath,
+			RancherHostname: rancherHookResult.Hostname,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		return data
+	},
+	func(sharedData []byte) {
+		setup := e2e.Setup{}
+		Expect(json.Unmarshal(sharedData, &setup)).To(Succeed())
+
+		hostName = setup.RancherHostname
+
+		bootstrapClusterProxy = capiframework.NewClusterProxy(setup.ClusterName, setup.KubeconfigPath, e2e.InitScheme(), capiframework.WithMachineLogCollector(capiframework.DockerLogCollector{}))
+		Expect(bootstrapClusterProxy).ToNot(BeNil(), "cluster proxy should not be nil")
+	},
+)
+
+var _ = SynchronizedAfterSuite(
+	func() {
+	},
+	func() {
+		By("Dumping artifacts from the bootstrap cluster")
+		testenv.DumpBootstrapCluster(ctx)
+
+		config := e2e.LoadE2EConfig()
+		// skipping error check since it is already done at the beginning of the test in e2e.ValidateE2EConfig()
+		skipCleanup, _ := strconv.ParseBool(config.GetVariableOrEmpty(e2e.SkipResourceCleanupVar))
+		if skipCleanup {
+			// add a log line about skipping charts uninstallation and cluster cleanup
+			return
+		}
+
+		testenv.UninstallRancherTurtles(ctx, testenv.UninstallRancherTurtlesInput{
+			BootstrapClusterProxy: bootstrapClusterProxy,
+		})
+
+		testenv.CleanupTestCluster(ctx, testenv.CleanupTestClusterInput{
+			SetupTestClusterResult: *setupClusterResult,
+		})
+	},
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does mainly two things: 
- Allows the upstream provider reconciler to patch the CAPIProviderSpec. It's more straightforward to simply rely on the upstream business logic for all the generic provider fields.
- Introduces a new feature `EnableAutomaticUpdate` on CAPIProviders. This feature is needed to clearly distinguish whether the user wants the providers to be automatically updated, or not. Previously this was done by leaving the CAPIProvider.Spec.Version blank. The behavior is going to change in the following way:

1. Users installing the default providers from the chart will not be affected (core, rke2, fleet) and will continue to experience automatic updates on Turtles updates (on ClusterctlConfig updates). 
2. Users who pinned the `Version` on their installed providers will not be affected. The new toggle is off by default, they have to opt-in explicitly.
3. Users who didn't pin the `Version` (previous automatic update toggle), will see their providers updating to latest (which should already be the case) and the `Version` then pinned. In order to restore automatic updates functionality, they have to explicitly opt-in with the new `EnableAutomaticUpdate` toggle. 

Documentation: https://github.com/rancher/turtles-docs/pull/351

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The current implementation of CAPIProvider reconciler does not patch the CAPIProviderSpec. This has the consequence of never updating the `operator.cluster.x-k8s.io/applied-spec-hash` annotation, which will lead to the cache constantly being invalid. This PR originated from this issue and it fixes it.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
