### PR TITLE
Add support for docker.io registry authentication support

### DIFF
--- a/examples/clusterclasses/docker/kubeadm/clusterclass-docker-kubeadm.yaml
+++ b/examples/clusterclasses/docker/kubeadm/clusterclass-docker-kubeadm.yaml
@@ -167,6 +167,12 @@ spec:
       enabledIf: '{{ .podSecurityStandard.enabled }}'
       name: podSecurityStandard
   variables:
+    - name: imagePullSecret
+      required: false
+      schema:
+        openAPIV3Schema:
+          description: The name of a dockerconfigjson secret on the Cluster that can be used to pull images.
+          type: string
     - name: imageRepository
       required: true
       schema:

--- a/examples/clusterclasses/docker/rke2/clusterclass-docker-rke2.yaml
+++ b/examples/clusterclasses/docker/rke2/clusterclass-docker-rke2.yaml
@@ -43,6 +43,12 @@ spec:
       schema:
         openAPIV3Schema:
           type: string
+    - name: dockerAuthSecret
+      required: false
+      schema:
+        openAPIV3Schema:
+          description: The name of the secret containing docker.io credentials.
+          type: string
   patches:
     - name: rke2CNI
       definitions:
@@ -71,6 +77,43 @@ spec:
               path: /spec/template/spec/customImage
               valueFrom: 
                 variable: dockerImage
+    - name: dockerAuthSecret
+      definitions:
+        - selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            kind: RKE2ControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/privateRegistriesConfig/configs
+              valueFrom:
+                template: |-
+                   {{- if .dockerAuthSecret }}
+                    "registry-1.docker.io":
+                      authSecret:
+                        name: {{ .dockerAuthSecret }}
+                        namespace: {{ .builtin.cluster.namespace }}
+                    {{- end }}
+        - selector:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: RKE2ConfigTemplate
+            matchResources:
+              machineDeploymentClass:
+                names:
+                - default-worker
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/privateRegistriesConfig/configs
+              valueFrom:
+                template: |-
+                  {{- if .dockerAuthSecret }}
+                  "registry-1.docker.io":
+                    authSecret:
+                      name: {{ .dockerAuthSecret }}
+                      namespace: {{ .builtin.cluster.namespace }}
+                  {{- end }}
+
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate


### PR DESCRIPTION
**What this PR does / why we need it**:  
Adds optional dockerAuthSecret support to the Docker RKE2 ClusterClass to enable authenticated pulls from Docker Hub, preventing 429 rate-limit errors and allowing private repo access.

**Which issue(s) this PR fixes**:  
Fixes #1608  

**Checklist**:
- [x] squashed commits into logical changes  
- [ ] includes documentation for the new `dockerAuthSecret` variable and Secret format  
- [ ] adds unit tests (N/A for this YAML example)  
- [ ] adds or updates e2e tests  