### PR TITLE
Create separate providers chart

### DIFF
--- a/charts/rancher-turtles-providers/.gitignore
+++ b/charts/rancher-turtles-providers/.gitignore
@@ -1,0 +1,2 @@
+Chartlock.lock
+charts/

--- a/charts/rancher-turtles-providers/.helmignore
+++ b/charts/rancher-turtles-providers/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/rancher-turtles-providers/Chart.yaml
+++ b/charts/rancher-turtles-providers/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: rancher-turtles-providers
+description: This chart installs the Rancher Turtles certified providers.
+home: https://turtles.docs.rancher.com/turtles/stable/en/overview/certified.html
+icon: https://raw.githubusercontent.com/rancher/turtles/main/logos/capi.svg
+version: 0.0.0
+appVersion: "0.0.0"
+keywords:
+- rancher
+- cluster-api
+- capi
+- provisioning
+- provider
+annotations:
+  catalog.cattle.io/certified: rancher
+  catalog.cattle.io/display-name: Rancher Turtles Certified Providers
+  catalog.cattle.io/kube-version: '>= 1.23.0-0'
+  catalog.cattle.io/namespace: rancher-turtles-system
+  catalog.cattle.io/os: linux
+  catalog.cattle.io/permits-os: linux
+  catalog.cattle.io/rancher-version: '>= 2.11.0-1'
+  catalog.cattle.io/release-name: rancher-turtles
+  catalog.cattle.io/scope: management
+  catalog.cattle.io/type: cluster-tool

--- a/charts/rancher-turtles-providers/README.md
+++ b/charts/rancher-turtles-providers/README.md
@@ -1,0 +1,5 @@
+# Rancher Turtles Providers Chart
+
+This chart installs Rancher Turtles Certified CAPI providers using Helm.
+
+Checkout the [documentation](https://turtles.docs.rancher.com/turtles/stable/en/overview/certified.html) for further information.

--- a/charts/rancher-turtles-providers/templates/addon-fleet.yaml
+++ b/charts/rancher-turtles-providers/templates/addon-fleet.yaml
@@ -1,0 +1,113 @@
+{{- if index .Values "providers" "addonFleet" "enabled" }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ index .Values "providers" "addonFleet" "namespace" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fleet-addon-config
+  namespace: {{ index .Values "providers" "addonFleet" "namespace" }}
+data:
+  manifests: |-
+    apiVersion: addons.cluster.x-k8s.io/v1alpha1
+    kind: FleetAddonConfig
+    metadata:
+      name: fleet-addon-config
+    spec:
+      config:
+        featureGates:
+          configMap:
+            ref:
+              kind: ConfigMap
+              apiVersion: v1
+              name: rancher-config
+              namespace: cattle-system
+          experimentalOciStorage: true
+          experimentalHelmOps: true
+      clusterClass:
+        patchResource: true
+        setOwnerReferences: true
+      cluster:
+        agentNamespace: cattle-fleet-system
+        applyClassGroup: true
+        patchResource: true
+        setOwnerReferences: true
+        hostNetwork: true
+        selector:
+          matchLabels:
+            cluster-api.cattle.io/rancher-auto-import: "true"
+          matchExpressions:
+            - key: cluster-api.cattle.io/disable-fleet-auto-import
+              operator: DoesNotExist
+        namespaceSelector:
+          matchLabels:
+            cluster-api.cattle.io/rancher-auto-import: "true"
+          matchExpressions:
+            - key: cluster-api.cattle.io/disable-fleet-auto-import
+              operator: DoesNotExist
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: cappf-controller-psa
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: fleet-controller-psa
+    subjects:
+    - kind: ServiceAccount
+      name: caapf-controller-manager
+      namespace: {{ .Values.providers.addonFleet.namespace }}
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: fleet
+  namespace: {{ index .Values "providers" "addonFleet" "namespace" }}
+spec:
+  name: fleet
+  type: addon
+{{- if index .Values  "providers" "addonFleet" "version" }}
+  version: {{ index .Values "providers" "addonFleet" "version" }}
+{{- end }}
+{{- if index .Values  "providers" "addonFleet" "enableAutomaticUpdate" }}
+  enableAutomaticUpdate: {{ index .Values "providers" "addonFleet" "enableAutomaticUpdate" }}
+{{- end }}
+{{- if index .Values  "providers" "addonFleet" "features" }}
+  features:
+      machinePool: {{ index .Values "providers" "addonFleet" "features" "machinePool" }}
+      clusterResourceSet: {{ index .Values "providers" "addonFleet" "features" "clusterResourceSet" }}
+      clusterTopology: {{ index .Values "providers" "addonFleet" "features" "clusterTopology" }}
+{{- end }}
+{{- if index .Values  "providers" "addonFleet" "variables" }}
+  variables:
+  {{- range $key, $val := .Values.providers.addonFleet.variables }}
+    {{ $key }}: "{{ $val }}"
+  {{- end }}
+{{- end }}
+{{- if or (index .Values "providers" "addonFleet" "credentials") }}
+  credentials:
+    name: {{ index .Values "providers" "addonFleet" "credentials" "name" }}
+    namespace: {{ index .Values "providers" "addonFleet" "credentials" "namespace" }}
+{{- end }}
+{{- if or (index .Values "providers" "addonFleet" "configSecret") }}
+  configSecret:
+    name: {{ index .Values "providers" "addonFleet" "configSecret" "name" }}
+    namespace: {{ index .Values "providers" "addonFleet" "configSecret" "namespace" }}
+{{- end }}
+{{- if index .Values "providers" "addonFleet" "fetchConfig" }}
+  fetchConfig:
+    {{- if index .Values "providers" "addonFleet" "fetchConfig" "url" }}
+    url: {{ index .Values "providers" "addonFleet" "fetchConfig" "url" }}
+    {{- end }}
+    {{- if index .Values "providers" "addonFleet" "fetchConfig" "url" }}
+    oci: {{ index .Values "providers" "addonFleet" "fetchConfig" "url" }}
+    {{- end }}
+{{- end }}
+  additionalManifests:
+    name: fleet-addon-config
+    namespace: {{ index .Values "providers" "addonFleet" "namespace" }}
+{{- end }}

--- a/charts/rancher-turtles-providers/templates/boostrap-kubeadm.yaml
+++ b/charts/rancher-turtles-providers/templates/boostrap-kubeadm.yaml
@@ -1,0 +1,53 @@
+{{- if index .Values "providers" "bootstrapKubeadm" "enabled" }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ index .Values "providers" "bootstrapKubeadm" "namespace" }}
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: kubeadm-bootstrap
+  namespace: {{ index .Values "providers" "bootstrapKubeadm" "namespace" }}
+spec:
+  name: kubeadm
+  type: bootstrap
+{{- if index .Values  "providers" "bootstrapKubeadm" "version" }}
+  version: {{ index .Values "providers" "bootstrapKubeadm" "version" }}
+{{- end }}
+{{- if index .Values  "providers" "bootstrapKubeadm" "enableAutomaticUpdate" }}
+  enableAutomaticUpdate: {{ index .Values "providers" "bootstrapKubeadm" "enableAutomaticUpdate" }}
+{{- end }}
+{{- if index .Values  "providers" "bootstrapKubeadm" "features" }}
+  features:
+      machinePool: {{ index .Values "providers" "bootstrapKubeadm" "features" "machinePool" }}
+      clusterResourceSet: {{ index .Values "providers" "bootstrapKubeadm" "features" "clusterResourceSet" }}
+      clusterTopology: {{ index .Values "providers" "bootstrapKubeadm" "features" "clusterTopology" }}
+{{- end }}
+{{- if index .Values  "providers" "bootstrapKubeadm" "variables" }}
+  variables:
+  {{- range $key, $val := .Values.providers.bootstrapKubeadm.variables }}
+    {{ $key }}: "{{ $val }}"
+  {{- end }}
+{{- end }}
+{{- if or (index .Values "providers" "bootstrapKubeadm" "credentials") }}
+  credentials:
+    name: {{ index .Values "providers" "bootstrapKubeadm" "credentials" "name" }}
+    namespace: {{ index .Values "providers" "bootstrapKubeadm" "credentials" "namespace" }}
+{{- end }}
+{{- if or (index .Values "providers" "bootstrapKubeadm" "configSecret") }}
+  configSecret:
+    name: {{ index .Values "providers" "bootstrapKubeadm" "configSecret" "name" }}
+    namespace: {{ index .Values "providers" "bootstrapKubeadm" "configSecret" "namespace" }}
+{{- end }}
+{{- if index .Values "providers" "bootstrapKubeadm" "fetchConfig" }}
+  fetchConfig:
+    {{- if index .Values "providers" "bootstrapKubeadm" "fetchConfig" "url" }}
+    url: {{ index .Values "providers" "bootstrapKubeadm" "fetchConfig" "url" }}
+    {{- end }}
+    {{- if index .Values "providers" "bootstrapKubeadm" "fetchConfig" "url" }}
+    oci: {{ index .Values "providers" "bootstrapKubeadm" "fetchConfig" "url" }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rancher-turtles-providers/templates/bootstrap-rke2.yaml
+++ b/charts/rancher-turtles-providers/templates/bootstrap-rke2.yaml
@@ -1,0 +1,53 @@
+{{- if index .Values "providers" "bootstrapRKE2" "enabled" }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ index .Values "providers" "bootstrapRKE2" "namespace" }}
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: rke2-bootstrap
+  namespace: {{ index .Values "providers" "bootstrapRKE2" "namespace" }}
+spec:
+  name: rke2
+  type: bootstrap
+{{- if index .Values  "providers" "bootstrapRKE2" "version" }}
+  version: {{ index .Values "providers" "bootstrapRKE2" "version" }}
+{{- end }}
+{{- if index .Values  "providers" "bootstrapRKE2" "enableAutomaticUpdate" }}
+  enableAutomaticUpdate: {{ index .Values "providers" "bootstrapRKE2" "enableAutomaticUpdate" }}
+{{- end }}
+{{- if index .Values  "providers" "bootstrapRKE2" "features" }}
+  features:
+      machinePool: {{ index .Values "providers" "bootstrapRKE2" "features" "machinePool" }}
+      clusterResourceSet: {{ index .Values "providers" "bootstrapRKE2" "features" "clusterResourceSet" }}
+      clusterTopology: {{ index .Values "providers" "bootstrapRKE2" "features" "clusterTopology" }}
+{{- end }}
+{{- if index .Values  "providers" "bootstrapRKE2" "variables" }}
+  variables:
+  {{- range $key, $val := .Values.providers.bootstrapRKE2.variables }}
+    {{ $key }}: "{{ $val }}"
+  {{- end }}
+{{- end }}
+{{- if or (index .Values "providers" "bootstrapRKE2" "credentials") }}
+  credentials:
+    name: {{ index .Values "providers" "bootstrapRKE2" "credentials" "name" }}
+    namespace: {{ index .Values "providers" "bootstrapRKE2" "credentials" "namespace" }}
+{{- end }}
+{{- if or (index .Values "providers" "bootstrapRKE2" "configSecret") }}
+  configSecret:
+    name: {{ index .Values "providers" "bootstrapRKE2" "configSecret" "name" }}
+    namespace: {{ index .Values "providers" "bootstrapRKE2" "configSecret" "namespace" }}
+{{- end }}
+{{- if index .Values "providers" "bootstrapRKE2" "fetchConfig" }}
+  fetchConfig:
+    {{- if index .Values "providers" "bootstrapRKE2" "fetchConfig" "url" }}
+    url: {{ index .Values "providers" "bootstrapRKE2" "fetchConfig" "url" }}
+    {{- end }}
+    {{- if index .Values "providers" "bootstrapRKE2" "fetchConfig" "url" }}
+    oci: {{ index .Values "providers" "bootstrapRKE2" "fetchConfig" "url" }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rancher-turtles-providers/templates/controlplane-kubeadm.yaml
+++ b/charts/rancher-turtles-providers/templates/controlplane-kubeadm.yaml
@@ -1,0 +1,53 @@
+{{- if index .Values "providers" "controlplaneKubeadm" "enabled" }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ index .Values "providers" "controlplaneKubeadm" "namespace" }}
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: kubeadm-control-plane
+  namespace: {{ index .Values "providers" "controlplaneKubeadm" "namespace" }}
+spec:
+  name: kubeadm
+  type: controlPlane
+{{- if index .Values  "providers" "controlplaneKubeadm" "version" }}
+  version: {{ index .Values "providers" "controlplaneKubeadm" "version" }}
+{{- end }}
+{{- if index .Values  "providers" "controlplaneKubeadm" "enableAutomaticUpdate" }}
+  enableAutomaticUpdate: {{ index .Values "providers" "controlplaneKubeadm" "enableAutomaticUpdate" }}
+{{- end }}
+{{- if index .Values  "providers" "controlplaneKubeadm" "features" }}
+  features:
+      machinePool: {{ index .Values "providers" "controlplaneKubeadm" "features" "machinePool" }}
+      clusterResourceSet: {{ index .Values "providers" "controlplaneKubeadm" "features" "clusterResourceSet" }}
+      clusterTopology: {{ index .Values "providers" "controlplaneKubeadm" "features" "clusterTopology" }}
+{{- end }}
+{{- if index .Values  "providers" "controlplaneKubeadm" "variables" }}
+  variables:
+  {{- range $key, $val := .Values.providers.controlplaneKubeadm.variables }}
+    {{ $key }}: "{{ $val }}"
+  {{- end }}
+{{- end }}
+{{- if or (index .Values "providers" "controlplaneKubeadm" "credentials") }}
+  credentials:
+    name: {{ index .Values "providers" "controlplaneKubeadm" "credentials" "name" }}
+    namespace: {{ index .Values "providers" "controlplaneKubeadm" "credentials" "namespace" }}
+{{- end }}
+{{- if or (index .Values "providers" "controlplaneKubeadm" "configSecret") }}
+  configSecret:
+    name: {{ index .Values "providers" "controlplaneKubeadm" "configSecret" "name" }}
+    namespace: {{ index .Values "providers" "controlplaneKubeadm" "configSecret" "namespace" }}
+{{- end }}
+{{- if index .Values "providers" "controlplaneKubeadm" "fetchConfig" }}
+  fetchConfig:
+    {{- if index .Values "providers" "controlplaneKubeadm" "fetchConfig" "url" }}
+    url: {{ index .Values "providers" "controlplaneKubeadm" "fetchConfig" "url" }}
+    {{- end }}
+    {{- if index .Values "providers" "controlplaneKubeadm" "fetchConfig" "url" }}
+    oci: {{ index .Values "providers" "controlplaneKubeadm" "fetchConfig" "url" }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rancher-turtles-providers/templates/controlplane-rke2.yaml
+++ b/charts/rancher-turtles-providers/templates/controlplane-rke2.yaml
@@ -1,0 +1,53 @@
+{{- if index .Values "providers" "controlplaneRKE2" "enabled" }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ index .Values "providers" "controlplaneRKE2" "namespace" }}
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: rke2-control-plane
+  namespace: {{ index .Values "providers" "controlplaneRKE2" "namespace" }}
+spec:
+  name: rke2
+  type: controlPlane
+{{- if index .Values  "providers" "controlplaneRKE2" "version" }}
+  version: {{ index .Values "providers" "controlplaneRKE2" "version" }}
+{{- end }}
+{{- if index .Values  "providers" "controlplaneRKE2" "enableAutomaticUpdate" }}
+  enableAutomaticUpdate: {{ index .Values "providers" "controlplaneRKE2" "enableAutomaticUpdate" }}
+{{- end }}
+{{- if index .Values  "providers" "controlplaneRKE2" "features" }}
+  features:
+      machinePool: {{ index .Values "providers" "controlplaneRKE2" "features" "machinePool" }}
+      clusterResourceSet: {{ index .Values "providers" "controlplaneRKE2" "features" "clusterResourceSet" }}
+      clusterTopology: {{ index .Values "providers" "controlplaneRKE2" "features" "clusterTopology" }}
+{{- end }}
+{{- if index .Values  "providers" "controlplaneRKE2" "variables" }}
+  variables:
+  {{- range $key, $val := .Values.providers.controlplaneRKE2.variables }}
+    {{ $key }}: "{{ $val }}"
+  {{- end }}
+{{- end }}
+{{- if or (index .Values "providers" "controlplaneRKE2" "credentials") }}
+  credentials:
+    name: {{ index .Values "providers" "controlplaneRKE2" "credentials" "name" }}
+    namespace: {{ index .Values "providers" "controlplaneRKE2" "credentials" "namespace" }}
+{{- end }}
+{{- if or (index .Values "providers" "controlplaneRKE2" "configSecret") }}
+  configSecret:
+    name: {{ index .Values "providers" "controlplaneRKE2" "configSecret" "name" }}
+    namespace: {{ index .Values "providers" "controlplaneRKE2" "configSecret" "namespace" }}
+{{- end }}
+{{- if index .Values "providers" "controlplaneRKE2" "fetchConfig" }}
+  fetchConfig:
+    {{- if index .Values "providers" "controlplaneRKE2" "fetchConfig" "url" }}
+    url: {{ index .Values "providers" "controlplaneRKE2" "fetchConfig" "url" }}
+    {{- end }}
+    {{- if index .Values "providers" "controlplaneRKE2" "fetchConfig" "url" }}
+    oci: {{ index .Values "providers" "controlplaneRKE2" "fetchConfig" "url" }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rancher-turtles-providers/templates/infrastructure-aws.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-aws.yaml
@@ -1,0 +1,53 @@
+{{- if index .Values "providers" "infrastructureAWS" "enabled" }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ index .Values "providers" "infrastructureAWS" "namespace" }}
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: aws
+  namespace: {{ index .Values "providers" "infrastructureAWS" "namespace" }}
+spec:
+  name: aws
+  type: infrastructure
+{{- if index .Values  "providers" "infrastructureAWS" "version" }}
+  version: {{ index .Values "providers" "infrastructureAWS" "version" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureAWS" "enableAutomaticUpdate" }}
+  enableAutomaticUpdate: {{ index .Values "providers" "infrastructureAWS" "enableAutomaticUpdate" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureAWS" "features" }}
+  features:
+      machinePool: {{ index .Values "providers" "infrastructureAWS" "features" "machinePool" }}
+      clusterResourceSet: {{ index .Values "providers" "infrastructureAWS" "features" "clusterResourceSet" }}
+      clusterTopology: {{ index .Values "providers" "infrastructureAWS" "features" "clusterTopology" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureAWS" "variables" }}
+  variables:
+  {{- range $key, $val := .Values.providers.infrastructureAWS.variables }}
+    {{ $key }}: "{{ $val }}"
+  {{- end }}
+{{- end }}
+{{- if or (index .Values "providers" "infrastructureAWS" "credentials") }}
+  credentials:
+    name: {{ index .Values "providers" "infrastructureAWS" "credentials" "name" }}
+    namespace: {{ index .Values "providers" "infrastructureAWS" "credentials" "namespace" }}
+{{- end }}
+{{- if or (index .Values "providers" "infrastructureAWS" "configSecret") }}
+  configSecret:
+    name: {{ index .Values "providers" "infrastructureAWS" "configSecret" "name" }}
+    namespace: {{ index .Values "providers" "infrastructureAWS" "configSecret" "namespace" }}
+{{- end }}
+{{- if index .Values "providers" "infrastructureAWS" "fetchConfig" }}
+  fetchConfig:
+    {{- if index .Values "providers" "infrastructureAWS" "fetchConfig" "url" }}
+    url: {{ index .Values "providers" "infrastructureAWS" "fetchConfig" "url" }}
+    {{- end }}
+    {{- if index .Values "providers" "infrastructureAWS" "fetchConfig" "url" }}
+    oci: {{ index .Values "providers" "infrastructureAWS" "fetchConfig" "url" }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rancher-turtles-providers/templates/infrastructure-azure.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-azure.yaml
@@ -1,0 +1,53 @@
+{{- if index .Values "providers" "infrastructureAzure" "enabled" }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ index .Values "providers" "infrastructureAzure" "namespace" }}
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: azure
+  namespace: {{ index .Values "providers" "infrastructureAzure" "namespace" }}
+spec:
+  name: azure
+  type: infrastructure
+{{- if index .Values  "providers" "infrastructureAzure" "version" }}
+  version: {{ index .Values "providers" "infrastructureAzure" "version" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureAzure" "enableAutomaticUpdate" }}
+  enableAutomaticUpdate: {{ index .Values "providers" "infrastructureAzure" "enableAutomaticUpdate" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureAzure" "features" }}
+  features:
+      machinePool: {{ index .Values "providers" "infrastructureAzure" "features" "machinePool" }}
+      clusterResourceSet: {{ index .Values "providers" "infrastructureAzure" "features" "clusterResourceSet" }}
+      clusterTopology: {{ index .Values "providers" "infrastructureAzure" "features" "clusterTopology" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureAzure" "variables" }}
+  variables:
+  {{- range $key, $val := .Values.providers.infrastructureAzure.variables }}
+    {{ $key }}: "{{ $val }}"
+  {{- end }}
+{{- end }}
+{{- if or (index .Values "providers" "infrastructureAzure" "credentials") }}
+  credentials:
+    name: {{ index .Values "providers" "infrastructureAzure" "credentials" "name" }}
+    namespace: {{ index .Values "providers" "infrastructureAzure" "credentials" "namespace" }}
+{{- end }}
+{{- if or (index .Values "providers" "infrastructureAzure" "configSecret") }}
+  configSecret:
+    name: {{ index .Values "providers" "infrastructureAzure" "configSecret" "name" }}
+    namespace: {{ index .Values "providers" "infrastructureAzure" "configSecret" "namespace" }}
+{{- end }}
+{{- if index .Values "providers" "infrastructureAzure" "fetchConfig" }}
+  fetchConfig:
+    {{- if index .Values "providers" "infrastructureAzure" "fetchConfig" "url" }}
+    url: {{ index .Values "providers" "infrastructureAzure" "fetchConfig" "url" }}
+    {{- end }}
+    {{- if index .Values "providers" "infrastructureAzure" "fetchConfig" "url" }}
+    oci: {{ index .Values "providers" "infrastructureAzure" "fetchConfig" "url" }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rancher-turtles-providers/templates/infrastructure-docker.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-docker.yaml
@@ -1,0 +1,53 @@
+{{- if index .Values "providers" "infrastructureDocker" "enabled" }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ index .Values "providers" "infrastructureDocker" "namespace" }}
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: docker
+  namespace: {{ index .Values "providers" "infrastructureDocker" "namespace" }}
+spec:
+  name: docker
+  type: infrastructure
+{{- if index .Values  "providers" "infrastructureDocker" "version" }}
+  version: {{ index .Values "providers" "infrastructureDocker" "version" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureDocker" "enableAutomaticUpdate" }}
+  enableAutomaticUpdate: {{ index .Values "providers" "infrastructureDocker" "enableAutomaticUpdate" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureDocker" "features" }}
+  features:
+      machinePool: {{ index .Values "providers" "infrastructureDocker" "features" "machinePool" }}
+      clusterResourceSet: {{ index .Values "providers" "infrastructureDocker" "features" "clusterResourceSet" }}
+      clusterTopology: {{ index .Values "providers" "infrastructureDocker" "features" "clusterTopology" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureDocker" "variables" }}
+  variables:
+  {{- range $key, $val := .Values.providers.infrastructureDocker.variables }}
+    {{ $key }}: "{{ $val }}"
+  {{- end }}
+{{- end }}
+{{- if or (index .Values "providers" "infrastructureDocker" "credentials") }}
+  credentials:
+    name: {{ index .Values "providers" "infrastructureDocker" "credentials" "name" }}
+    namespace: {{ index .Values "providers" "infrastructureDocker" "credentials" "namespace" }}
+{{- end }}
+{{- if or (index .Values "providers" "infrastructureDocker" "configSecret") }}
+  configSecret:
+    name: {{ index .Values "providers" "infrastructureDocker" "configSecret" "name" }}
+    namespace: {{ index .Values "providers" "infrastructureDocker" "configSecret" "namespace" }}
+{{- end }}
+{{- if index .Values "providers" "infrastructureDocker" "fetchConfig" }}
+  fetchConfig:
+    {{- if index .Values "providers" "infrastructureDocker" "fetchConfig" "url" }}
+    url: {{ index .Values "providers" "infrastructureDocker" "fetchConfig" "url" }}
+    {{- end }}
+    {{- if index .Values "providers" "infrastructureDocker" "fetchConfig" "url" }}
+    oci: {{ index .Values "providers" "infrastructureDocker" "fetchConfig" "url" }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rancher-turtles-providers/templates/infrastructure-gcp.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-gcp.yaml
@@ -1,0 +1,53 @@
+{{- if index .Values "providers" "infrastructureGCP" "enabled" }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ index .Values "providers" "infrastructureGCP" "namespace" }}
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: infrastructure-gcp
+  namespace: {{ index .Values "providers" "infrastructureGCP" "namespace" }}
+spec:
+  name: gcp
+  type: infrastructure
+{{- if index .Values  "providers" "infrastructureGCP" "version" }}
+  version: {{ index .Values "providers" "infrastructureGCP" "version" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureGCP" "enableAutomaticUpdate" }}
+  enableAutomaticUpdate: {{ index .Values "providers" "infrastructureGCP" "enableAutomaticUpdate" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureGCP" "features" }}
+  features:
+      machinePool: {{ index .Values "providers" "infrastructureGCP" "features" "machinePool" }}
+      clusterResourceSet: {{ index .Values "providers" "infrastructureGCP" "features" "clusterResourceSet" }}
+      clusterTopology: {{ index .Values "providers" "infrastructureGCP" "features" "clusterTopology" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureGCP" "variables" }}
+  variables:
+  {{- range $key, $val := .Values.providers.infrastructureGCP.variables }}
+    {{ $key }}: "{{ $val }}"
+  {{- end }}
+{{- end }}
+{{- if or (index .Values "providers" "infrastructureGCP" "credentials") }}
+  credentials:
+    name: {{ index .Values "providers" "infrastructureGCP" "credentials" "name" }}
+    namespace: {{ index .Values "providers" "infrastructureGCP" "credentials" "namespace" }}
+{{- end }}
+{{- if or (index .Values "providers" "infrastructureGCP" "configSecret") }}
+  configSecret:
+    name: {{ index .Values "providers" "infrastructureGCP" "configSecret" "name" }}
+    namespace: {{ index .Values "providers" "infrastructureGCP" "configSecret" "namespace" }}
+{{- end }}
+{{- if index .Values "providers" "infrastructureGCP" "fetchConfig" }}
+  fetchConfig:
+    {{- if index .Values "providers" "infrastructureGCP" "fetchConfig" "url" }}
+    url: {{ index .Values "providers" "infrastructureGCP" "fetchConfig" "url" }}
+    {{- end }}
+    {{- if index .Values "providers" "infrastructureGCP" "fetchConfig" "url" }}
+    oci: {{ index .Values "providers" "infrastructureGCP" "fetchConfig" "url" }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rancher-turtles-providers/templates/infrastructure-vsphere.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-vsphere.yaml
@@ -1,0 +1,53 @@
+{{- if index .Values "providers" "infrastructureVSphere" "enabled" }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ index .Values "providers" "infrastructureVSphere" "namespace" }}
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: vsphere
+  namespace: {{ index .Values "providers" "infrastructureVSphere" "namespace" }}
+spec:
+  name: vsphere
+  type: infrastructure
+{{- if index .Values  "providers" "infrastructureVSphere" "version" }}
+  version: {{ index .Values "providers" "infrastructureVSphere" "version" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureVSphere" "enableAutomaticUpdate" }}
+  enableAutomaticUpdate: {{ index .Values "providers" "infrastructureVSphere" "enableAutomaticUpdate" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureVSphere" "features" }}
+  features:
+      machinePool: {{ index .Values "providers" "infrastructureVSphere" "features" "machinePool" }}
+      clusterResourceSet: {{ index .Values "providers" "infrastructureVSphere" "features" "clusterResourceSet" }}
+      clusterTopology: {{ index .Values "providers" "infrastructureVSphere" "features" "clusterTopology" }}
+{{- end }}
+{{- if index .Values  "providers" "infrastructureVSphere" "variables" }}
+  variables:
+  {{- range $key, $val := .Values.providers.infrastructureVSphere.variables }}
+    {{ $key }}: "{{ $val }}"
+  {{- end }}
+{{- end }}
+{{- if or (index .Values "providers" "infrastructureVSphere" "credentials") }}
+  credentials:
+    name: {{ index .Values "providers" "infrastructureVSphere" "credentials" "name" }}
+    namespace: {{ index .Values "providers" "infrastructureVSphere" "credentials" "namespace" }}
+{{- end }}
+{{- if or (index .Values "providers" "infrastructureVSphere" "configSecret") }}
+  configSecret:
+    name: {{ index .Values "providers" "infrastructureVSphere" "configSecret" "name" }}
+    namespace: {{ index .Values "providers" "infrastructureVSphere" "configSecret" "namespace" }}
+{{- end }}
+{{- if index .Values "providers" "infrastructureVSphere" "fetchConfig" }}
+  fetchConfig:
+    {{- if index .Values "providers" "infrastructureVSphere" "fetchConfig" "url" }}
+    url: {{ index .Values "providers" "infrastructureVSphere" "fetchConfig" "url" }}
+    {{- end }}
+    {{- if index .Values "providers" "infrastructureVSphere" "fetchConfig" "url" }}
+    oci: {{ index .Values "providers" "infrastructureVSphere" "fetchConfig" "url" }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rancher-turtles-providers/values.schema.json
+++ b/charts/rancher-turtles-providers/values.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Helm Chart Values Schema",
+  "$defs": {
+    "providerSchema": {
+      "type": "object",
+      "description": "Provider configuration.",
+      "required": [
+        "enabled",
+        "namespace"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enables the installation of this provider."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The namespace where the provider manifests will be applied."
+        },
+        "enableAutomaticUpdate": {
+          "type": "boolean",
+          "description": "Allows the provider to be updated automatically whenever this chart is updated."
+        },
+        "credentials": {
+          "type": "object",
+          "description": "Rancher Cloud credentials configuration.",
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the Rancher Cloud credential."
+            },
+            "namespace": {
+              "type": "string",
+              "description": "The namespace of the Rancher Cloud credential."
+            }
+          }
+        },
+        "configSecret": {
+          "type": "object",
+          "description": "Provider Secret configuration.",
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the Secret containing the provider configuration variables."
+            },
+            "namespace": {
+              "type": "string",
+              "description": "The namespace of the Secret containing the provider configuration variables."
+            }
+          }
+        },
+        "features": {
+          "type": "object",
+          "description": "Provider CAPI supported features configuration.",
+          "properties": {
+            "machinePool": {
+              "type": "boolean",
+              "description": "Enables CAPI MachinePool support."
+            },
+            "clusterResourceSet": {
+              "type": "boolean",
+              "description": "Enables CAPI ClusterResourceSet support."
+            },
+            "clusterTopology": {
+              "type": "boolean",
+              "description": "Enables CAPI ClusterClass support."
+            }
+          }
+        },
+        "variables": {
+          "type": "object",
+          "description": "Configures the provider variables that are applied to the manifest.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "fetchConfig": {
+          "type": "object",
+          "description": "Configuration to fetch the provider manifests.",
+          "oneOf": [ 
+            {
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "description": "The URL to be used for fetching the provider components and metadata."
+                }
+              }
+            },
+            {
+              "properties": {            
+                "oci": {
+                  "type": "string",
+                  "description": "OCI to be used for fetching the provider components and metadata."
+                }
+              }
+            } 
+          ]
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "providers": {
+      "type": "object",
+      "properties": {
+        "addonFleet": { "$ref": "#/$defs/providerSchema"},
+        "bootstrapKubeadm": { "$ref": "#/$defs/providerSchema"},
+        "bootstrapRKE2": { "$ref": "#/$defs/providerSchema"},
+        "controlplaneKubeadm": { "$ref": "#/$defs/providerSchema"},
+        "controlplaneRKE2": { "$ref": "#/$defs/providerSchema"},
+        "infrastructureAWS": { "$ref": "#/$defs/providerSchema"},
+        "infrastructureAzure": { "$ref": "#/$defs/providerSchema"},
+        "infrastructureDocker": { "$ref": "#/$defs/providerSchema"},
+        "infrastructureGCP": { "$ref": "#/$defs/providerSchema"},
+        "infrastructureVSphere": { "$ref": "#/$defs/providerSchema"}
+      }
+    }
+  }
+}

--- a/charts/rancher-turtles-providers/values.yaml
+++ b/charts/rancher-turtles-providers/values.yaml
@@ -1,0 +1,100 @@
+# Default values for rancher-turtles-providers.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# providers: Providers configuration.
+providers:
+  # addonFleet: Cluster API Add-on Provider for Fleet (CAAPF).
+  addonFleet:
+    # enabled: Enables the installation of this provider.
+    enabled: true
+    # namespace: The namespace where the provider manifests will be applied.
+    namespace: fleet-addon-system
+    # enableAutomaticUpdate: Allows the provider to be updated automatically whenever this chart is updated.
+    enableAutomaticUpdate: true
+  # bootstrapKubeadm: Kubeadm Bootstrap Provider.
+  bootstrapKubeadm:
+    # enabled: Enables the installation of this provider.
+    enabled: false
+    # namespace: The namespace where the provider manifests will be applied.
+    namespace: capi-kubeadm-bootstrap-system
+    # enableAutomaticUpdate: Allows the provider to be updated automatically whenever this chart is updated.
+    enableAutomaticUpdate: true
+  # bootstrapRKE2: RKE2 Bootstrap Provider.
+  bootstrapRKE2:
+    # enabled: Enables the installation of this provider.
+    enabled: true
+    # namespace: The namespace where the provider manifests will be applied.
+    namespace: rke2-bootstrap-system
+    # enableAutomaticUpdate: Allows the provider to be updated automatically whenever this chart is updated.
+    enableAutomaticUpdate: true
+  # controlplaneKubeadm: Kubeadm Control Plane Provider.
+  controlplaneKubeadm:
+    # enabled: Enables the installation of this provider.
+    enabled: false
+    # namespace: The namespace where the provider manifests will be applied.
+    namespace: capi-kubeadm-control-plane-system
+    # enableAutomaticUpdate: Allows the provider to be updated automatically whenever this chart is updated.
+    enableAutomaticUpdate: true
+  # controlplaneRKE2: RKE2 Control Plane Provider.
+  controlplaneRKE2:
+    # enabled: Enables the installation of this provider.
+    enabled: true
+    # namespace: The namespace where the provider manifests will be applied.
+    namespace: rke2-control-plane-system
+    # enableAutomaticUpdate: Allows the provider to be updated automatically whenever this chart is updated.
+    enableAutomaticUpdate: true
+  # infrastructureAWS: AWS Infrastructure Provider (CAPA).
+  infrastructureAWS:
+    # enabled: Enables the installation of this provider.
+    enabled: false
+    # namespace: The namespace where the provider manifests will be applied.
+    namespace: capa-system
+    # enableAutomaticUpdate: Allows the provider to be updated automatically whenever this chart is updated.
+    enableAutomaticUpdate: true
+    # variables: Configures the provider variables that are applied to the manifest.
+    variables:
+      AWS_B64ENCODED_CREDENTIALS: ""
+  # infrastructureAzure: Azure Infrastructure Provider (CAPZ).
+  infrastructureAzure:
+    # enabled: Enables the installation of this provider.
+    enabled: false
+    # namespace: The namespace where the provider manifests will be applied.
+    namespace: capz-system
+    # enableAutomaticUpdate: Allows the provider to be updated automatically whenever this chart is updated.
+    enableAutomaticUpdate: true
+    # variables: Configures the provider variables that are applied to the manifest.
+    variables:
+      EXP_AKS_RESOURCE_HEALTH: "true"
+  # infrastructureDocker: Docker Infrastructure Provider (CAPD).
+  infrastructureDocker:
+    # enabled: Enables the installation of this provider.
+    enabled: false
+    # namespace: The namespace where the provider manifests will be applied.
+    namespace: capd-system
+    # enableAutomaticUpdate: Allows the provider to be updated automatically whenever this chart is updated.
+    enableAutomaticUpdate: true
+  # infrastructureGCP: GCP Infrastructure Provider (CAPG).
+  infrastructureGCP:
+    # enabled: Enables the installation of this provider.
+    enabled: false
+    # namespace: The namespace where the provider manifests will be applied.
+    namespace: capg-system
+    # enableAutomaticUpdate: Allows the provider to be updated automatically whenever this chart is updated.
+    enableAutomaticUpdate: true
+    # variables: Configures the provider variables that are applied to the manifest.
+    variables:
+      EXP_CAPG_GKE: "true"
+      GCP_B64ENCODED_CREDENTIALS: ""
+  # infrastructureVSphere: vSphere Infrastructure Provider (CAPV).
+  infrastructureVSphere:
+    # enabled: Enables the installation of this provider.
+    enabled: false
+    # namespace: The namespace where the provider manifests will be applied.
+    namespace: capv-system
+    # enableAutomaticUpdate: Allows the provider to be updated automatically whenever this chart is updated.
+    enableAutomaticUpdate: true
+    # variables: Configures the provider variables that are applied to the manifest.
+    variables:
+      VSPHERE_USERNAME: ""
+      VSPHERE_PASSWORD: ""

--- a/charts/rancher-turtles/README.md
+++ b/charts/rancher-turtles/README.md
@@ -1,5 +1,5 @@
 # Rancher Turtles Chart
 
-This chart installs the Rancher Turtles operator and optionally the Cluster API Operator using Helm.
+This chart installs Rancher Turtles using Helm.
 
 Checkout the [documentation](https://turtles.docs.rancher.com) for further information.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an experimental separate chart to install all certified providers.
There is currently no release process for the new chart.
Installing the chart also requires all the providers (except the core one) to be uninstalled first, since they conflict with the Turtles chart.

Build with: 
```bash
RELEASE_TAG=v0.0.1 make build-providers-chart
```

Install:

```bash
helm upgrade --install rancher-turtles-providers out/charts/rancher-turtles-providers \
 --set providers.bootstrapKubeadm.enabled=true \
 --set providers.controlplaneKubeadm.enabled=true \
 --set providers.infrastructureAWS.enabled=true \
 --set providers.infrastructureAzure.enabled=true \
 --set providers.infrastructureDocker.enabled=true \
 --set providers.infrastructureGCP.enabled=true \
 --set providers.infrastructureVSphere.enabled=true \
 --timeout 180s
```

Uninstall:

```bash
helm uninstall rancher-turtles-providers
```

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1627

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
