### PR TITLE
Use latest ngrok-operator version for dev env

### DIFF
--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -56,8 +56,7 @@ helm upgrade ngrok ngrok/ngrok-operator \
     --wait \
     --timeout 5m \
     --set credentials.apiKey=$NGROK_API_KEY \
-    --set credentials.authtoken=$NGROK_AUTHTOKEN \
-    --version v0.18.1
+    --set credentials.authtoken=$NGROK_AUTHTOKEN
 
 helm install rancher rancher-latest/rancher \
     --namespace cattle-system \

--- a/scripts/turtles-quickstart.sh
+++ b/scripts/turtles-quickstart.sh
@@ -215,8 +215,7 @@ EOF
           --wait \
           --timeout 5m \
           --set credentials.apiKey=$NGROK_API_KEY \
-          --set credentials.authtoken=$NGROK_AUTHTOKEN \
-          --version v0.18.1
+          --set credentials.authtoken=$NGROK_AUTHTOKEN
         INGRESS_CLASS="ngrok"
     else 
         show_step "Install Ingress NGINX controller on ${RANCHER_CLUSTER_NAME}"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the pinned ngrok-operator version. 
This seems to no longer be needed. 

If you are experiencing issues on pre-existing Domains, you may have to delete any existing (deprecated) Edge and Endpoint in the ngrok dashboard.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
