### PR TITLE
Use go.mod to setup go version in workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5.5.0
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
           check-latest: true
           cache: true
       - name: Verify

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     - name: setupGo
       uses: actions/setup-go@v5.5.0
       with:
-        go-version: '=1.24.4'
+        go-version-file: go.mod
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # tag=v3.5.0
       with:
-        go-version: 1.24.4
+        go-version-file: go.mod
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2

--- a/.github/workflows/e2e-image-publish.yaml
+++ b/.github/workflows/e2e-image-publish.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: setupGo
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: "=1.24.4"
+          go-version-file: go.mod
       - name: Docker login
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/e2e-short.yaml
+++ b/.github/workflows/e2e-short.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: setupGo
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: "=1.24.4"
+          go-version-file: go.mod
       - name: Run e2e tests
         run: make test-e2e
       - name: Collect run artifacts

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5.5.0
         with:
-          go-version: '=1.24.4'
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/nightly-test-release.yaml
+++ b/.github/workflows/nightly-test-release.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: setupGo
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: '=1.24.4'
+          go-version-file: go.mod
       - name: Package operator chart
         run: RELEASE_TAG=${{ env.RELEASE_TAG }} CHART_PACKAGE_DIR=${RELEASE_DIR} REGISTRY=${{ env.PROD_REGISTRY }} ORG=${{ env.PROD_ORG }} make release
 

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: setupGo
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: '=1.24.4'
+          go-version-file: go.mod
       - name: Get prod multiarch image digest
         run: | 
           docker pull ${{ env.CONTROLLER_IMG }}:${{ env.TAG }}

--- a/.github/workflows/release_build/action.yaml
+++ b/.github/workflows/release_build/action.yaml
@@ -36,7 +36,7 @@ runs:
     - name: setupGo
       uses: actions/setup-go@v4
       with:
-        go-version: "=1.24.4"
+        go-version-file: go.mod
     - name: Docker login to ghcr registry
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/run-e2e-suite.yaml
+++ b/.github/workflows/run-e2e-suite.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: setupGo
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: "=1.24.4"
+          go-version-file: go.mod
       - name: Docker login
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/run-vsphere-tests.yaml
+++ b/.github/workflows/run-vsphere-tests.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: setupGo
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: "=1.24.4"
+          go-version-file: go.mod
       - name: Run e2e tests
         run: make test-e2e
       - name: Collect run artifacts

--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: setupGo
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: '=1.24.4'
+          go-version-file: go.mod
 
       - name: Build docker image
         run: make docker-build


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the hardcoded go versions in all workflows. go.mod is now the source of truth.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
