### PR TITLE
doc: Add ADR for updated release process

### DIFF
--- a/docs/adr/0017-release-process.md
+++ b/docs/adr/0017-release-process.md
@@ -35,11 +35,11 @@ For the intermediate phase:
 For the final phase:
 - Turtles is released with Rancher.
 - upon creating a tag, the release process will produce 2 different container images, one for community users and another one for Prime users.
-- the community image will be pushed to DockerHub whereas the Prime images will be pushed to the staging Prime registry.
+- the community image will be pushed to Docker Hub whereas the Prime images will be pushed to the staging Prime registry.
 
 The following graph shows what happens when a new tag gets created, which triggers a new release:
 ```mermaid
-graph BT
+graph TD
     A[rancher/turtles repository]
     A -->|builds Community image/ pushes entity only| D[Docker Hub]
     A -->|builds Prime image/ pushes entity, .sig, .att and .sbom| E[Staging Prime Registry]
@@ -47,4 +47,5 @@ graph BT
 
 ## Consequences
 
-- Since the community images will be different from the Prime images, we don't need to worry about which versions will become part of the Prime suite. As long as the staging Prime registry has the correct image built for Prime and any associated SLSA artifacts, any of these versions can become part of a Rancher release [using the existing chart release process](https://github.com/rancher/charts/wiki/1%E2%80%90Developing#making-changes-to-packages).
+- Since the community images will be different from the Prime images, we don't need to worry about which versions will become part of the Prime suite. As long as the staging Prime registry has the correct image built for Prime and any associated SLSA artifacts, any of these versions can become part of a Rancher release during the chart release process.
+- The Turtles chart needs to be updated to respect the `system-default-registry` setting as this will allow for the correct image to be pulled. 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Add an ADR to describe what the release process should look like. It is mostly identical to the Fleet release process, the only difference being, Turtles will produce 2 different container images, one for community and one for Prime users.

As a reminder, the Fleet release process:
-  runs upon creating new tags or triggered manually
- uses goreleaser to build container images
- pushes container images to both DockerHub and the Prime staging registry
- if releasing a hotfix specifically, then container images are pushed only to Prime staging registry

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1658 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
