### PR TITLE
Fix release notes generation

### DIFF
--- a/hack/make-release-notes.sh
+++ b/hack/make-release-notes.sh
@@ -19,13 +19,13 @@ set -o errexit
 set -o pipefail
 
 TOOLS_FOLDER=${1:-hack/tools/bin}
+CAPI_VERSION=${2}
 
 mkdir $TOOLS_FOLDER/cluster-api
 cd $TOOLS_FOLDER/cluster-api
 git init
 git remote add origin https://github.com/kubernetes-sigs/cluster-api.git 
-git fetch --depth 1 origin ce045ad2cddf21738799fcc310e847709b8ee41e
-git checkout FETCH_HEAD -- hack/tools/release/notes.go
-go build hack/tools/release/notes.go 
-mv notes $TOOLS_FOLDER
+git fetch --depth 1 origin tag $CAPI_VERSION
+git checkout FETCH_HEAD -- hack/tools
+go build -C hack/tools -o $TOOLS_FOLDER/notes -tags tools sigs.k8s.io/cluster-api/hack/tools/release/notes
 cd - && rm -rf $TOOLS_FOLDER/cluster-api


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR should fix the release notes not being generated anymore. 
The notes binary is now built using the supported CAPI_VERSION.

Note that the hardcoded `-branch=main` may bring issues when generating notes from a release branch, adding more than expected. This entire process probably needs some more toughts/refactor. This PR is mostly a quick fix so that CI can continue.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
