### PR TITLE
Add upper bound for rancher-version annotation

### DIFF
--- a/charts/rancher-turtles/Chart.yaml
+++ b/charts/rancher-turtles/Chart.yaml
@@ -18,7 +18,7 @@ annotations:
   catalog.cattle.io/namespace: rancher-turtles-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux
-  catalog.cattle.io/rancher-version: '>= 2.12.1-1'
+  catalog.cattle.io/rancher-version: '>= 2.12.1-0 < 2.13.0-0'
   catalog.cattle.io/release-name: rancher-turtles
   catalog.cattle.io/scope: management
   catalog.cattle.io/type: cluster-tool


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds rancher-version upper bound for turtles chart.
References:
- https://github.com/rancher/s390x-charts/blob/main/README.md#rancher-version-annotations
- https://github.com/rancher/provisioning/blob/main/charts/capi/Chart.yaml#L20C39-L20C61

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
