### PR TITLE
Fix RKE2 ClusterClasses and disable day2 from test environments

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -52,22 +52,6 @@ projects = {
         "label": "turtles",
         "binary_name" : "manager"
     },
-    "turtles-day2": {
-        "context": "exp/day2",
-        "image": "ghcr.io/rancher/turtles-day2-operations:dev",
-        "live_reload_deps": [
-            "main.go",
-            "go.mod",
-            "go.sum",
-            "controllers",
-            "webhooks",
-        ],
-        "kustomize_dir": "config/default",
-        "label": "turtles-day2",
-        "command": ["/manager"],
-        "args": ["--feature-gates=etcd-backup-restore=true"],
-        "binary_name" : "turtles-day2-operations"
-    },
     "turtles-capiproviders": {
         "context": ".",
         "live_reload_deps": [
@@ -77,20 +61,6 @@ projects = {
         "label": "turtles-capiproviders",
         "op": "apply"
     },
-    "turtles-clusterclass-operations": {
-        "context": "exp/clusterclass",
-        "image": "ghcr.io/rancher/turtles-clusterclass-operations:dev",
-        "live_reload_deps": [
-            "main.go",
-            "go.mod",
-            "go.sum",
-            "internal/",
-        ],
-        "kustomize_dir": "config/default",
-        "label": "turtles-clusterclass-operations",
-        "command": ["/manager"],
-        "binary_name" : "turtles-clusterclass-operations"
-    }
 }
 
 # Users may define their own Tilt customizations in tilt.d. This directory is excluded from git and these files will

--- a/examples/clusterclasses/docker/rke2/clusterclass-docker-rke2.yaml
+++ b/examples/clusterclasses/docker/rke2/clusterclass-docker-rke2.yaml
@@ -86,15 +86,18 @@ spec:
               controlPlane: true
           jsonPatches:
             - op: add
-              path: /spec/template/spec/privateRegistriesConfig/configs
+              path: /spec/template/spec/privateRegistriesConfig
               valueFrom:
                 template: |-
-                   {{- if .dockerAuthSecret }}
+                  {{- if .dockerAuthSecret }}
+                  configs:
                     "registry-1.docker.io":
                       authSecret:
                         name: {{ .dockerAuthSecret }}
                         namespace: {{ .builtin.cluster.namespace }}
-                    {{- end }}
+                  {{- else }}
+                  {}
+                  {{- end }}
         - selector:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
             kind: RKE2ConfigTemplate
@@ -104,14 +107,17 @@ spec:
                 - default-worker
           jsonPatches:
             - op: add
-              path: /spec/template/spec/privateRegistriesConfig/configs
+              path: /spec/template/spec/privateRegistriesConfig
               valueFrom:
                 template: |-
                   {{- if .dockerAuthSecret }}
-                  "registry-1.docker.io":
-                    authSecret:
-                      name: {{ .dockerAuthSecret }}
-                      namespace: {{ .builtin.cluster.namespace }}
+                  configs:
+                    "registry-1.docker.io":
+                      authSecret:
+                        name: {{ .dockerAuthSecret }}
+                        namespace: {{ .builtin.cluster.namespace }}
+                  {{- else }}
+                  {}
                   {{- end }}
 
 ---

--- a/examples/clusterclasses/vsphere/rke2/clusterclass-rke2-example.yaml
+++ b/examples/clusterclasses/vsphere/rke2/clusterclass-rke2-example.yaml
@@ -317,16 +317,21 @@ spec:
             # Register SL Micro 6.1 and add the SL Micro Extras repository
             - transactional-update register -r {{ .productKey }}
             - transactional-update register -p SL-Micro-Extras/6.1/x86_64
+            {{- else }}
+            []
             {{- end }}
       - op: add
-        path: /spec/template/spec/privateRegistriesConfig/configs
+        path: /spec/template/spec/privateRegistriesConfig
         valueFrom:
           template: |-
             {{- if .dockerAuthSecret }}
-            "registry-1.docker.io":
-              authSecret:
-                name: {{ .dockerAuthSecret }}
-                namespace: {{ .builtin.cluster.namespace }}
+            configs:
+              "registry-1.docker.io":
+                authSecret:
+                  name: {{ .dockerAuthSecret }}
+                  namespace: {{ .builtin.cluster.namespace }}
+            {{- else }}
+            {}
             {{- end }}
       selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -354,16 +359,21 @@ spec:
             # Register SL Micro 6.1 and add the SL Micro Extras repository
             - transactional-update register -r {{ .productKey }}
             - transactional-update register -p SL-Micro-Extras/6.1/x86_64
+            {{- else }}
+            []
             {{- end }}
       - op: add
-        path: /spec/template/spec/privateRegistriesConfig/configs
+        path: /spec/template/spec/privateRegistriesConfig
         valueFrom:
           template: |-
             {{- if .dockerAuthSecret }}
-            "registry-1.docker.io":
-              authSecret:
-                name: {{ .dockerAuthSecret }}
-                namespace: {{ .builtin.cluster.namespace }}
+            configs:
+              "registry-1.docker.io":
+                authSecret:
+                  name: {{ .dockerAuthSecret }}
+                  namespace: {{ .builtin.cluster.namespace }}
+            {{- else }}
+            {}
             {{- end }}
       selector:
         apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/examples/clusters/docker/rke2/cluster.yaml
+++ b/examples/clusters/docker/rke2/cluster.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     cluster-api.cattle.io/rancher-auto-import: "true"
     cni: calico
-  annotations:
-    cluster-api.cattle.io/upstream-system-agent: "true"
 spec:
   clusterNetwork:
     pods:

--- a/internal/controllers/clusterctl/config-default.yaml
+++ b/internal/controllers/clusterctl/config-default.yaml
@@ -36,7 +36,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.9.5/bootstrap-components.yaml"
       type:         "BootstrapProvider"
     - name:         "rke2"
-      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.19.0/bootstrap-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.20.0/bootstrap-components.yaml"
       type:         "BootstrapProvider"
 
     # ControlPlane providers
@@ -44,7 +44,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.9.5/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
     - name:         "rke2"
-      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.19.0/control-plane-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.20.0/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
 
     # Addon providers

--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -93,10 +93,10 @@ install_local_rancher_turtles_chart() {
     # feature flags enabled to run day2 & clusterclass controllers
     helm upgrade --install rancher-turtles out/charts/rancher-turtles \
         -n rancher-turtles-system \
-        --set rancherTurtles.features.day2operations.enabled=true \
+        --set rancherTurtles.features.day2operations.enabled=false \
         --set rancherTurtles.features.day2operations.imageVersion=dev \
-        --set rancherTurtles.features.day2operations.etcdBackupRestore.enabled=true \
-        --set rancherTurtles.features.clusterclass-operations.enabled=true \
+        --set rancherTurtles.features.day2operations.etcdBackupRestore.enabled=false \
+        --set rancherTurtles.features.clusterclass-operations.enabled=false \
         --set rancherTurtles.features.clusterclass-operations.imageVersion=dev \
         --set rancherTurtles.imageVersion=dev \
         --dependency-update \

--- a/test/e2e/data/cluster-templates/docker-rke2-topology.yaml
+++ b/test/e2e/data/cluster-templates/docker-rke2-topology.yaml
@@ -3,8 +3,6 @@ kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
-  annotations:
-    cluster-api.cattle.io/upstream-system-agent: "true"
   labels:
     cni: calico
 spec:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This PR fixes the drift causing constant rollouts with caprke2 0.20.0



<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
