### PR TITLE
test: cover `no-cert-manager` feature in e2e

### DIFF
--- a/.github/workflows/e2e-long.yaml
+++ b/.github/workflows/e2e-long.yaml
@@ -16,13 +16,13 @@ jobs:
   publish_e2e_image:
     uses: ./.github/workflows/e2e-image-publish.yaml
     secrets: inherit
-  e2e_import_gitops_v3:
+  e2e_import_gitops:
     needs: publish_e2e_image
     uses: ./.github/workflows/run-e2e-suite.yaml
     with:
-      test_suite: test/e2e/suites/import-gitops-v3
-      test_name: Import via GitOps [v3]
-      artifact_name: import_gitops_v3
+      test_suite: test/e2e/suites/import-gitops
+      test_name: Import via GitOps
+      artifact_name: import_gitops
       MANAGEMENT_CLUSTER_ENVIRONMENT: eks
     secrets: inherit
   e2e_v2prov:

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -26,11 +26,13 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
@@ -38,6 +40,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/cluster-api/util"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	turtlesv1 "github.com/rancher/turtles/api/v1alpha1"
 	etcdrestorev1 "github.com/rancher/turtles/exp/day2/api/v1alpha1"
@@ -75,8 +78,8 @@ func DumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterPr
 		// that cluster variable is not set even if the cluster exists, so we are calling DeleteAllClustersAndWait
 		// instead of DeleteClusterAndWait
 		framework.DeleteAllClustersAndWait(ctx, framework.DeleteAllClustersAndWaitInput{
-			ClusterProxy:    clusterProxy,
-			Namespace: namespace.Name,
+			ClusterProxy: clusterProxy,
+			Namespace:    namespace.Name,
 		}, intervalsGetter(specName, "wait-delete-cluster")...)
 
 		turtlesframework.Byf("Deleting namespace used for hosting the %q test spec", specName)
@@ -149,4 +152,78 @@ func ValidateE2EConfig(config *clusterctl.E2EConfig) {
 
 	_, err = strconv.ParseBool(config.GetVariableOrEmpty(SkipDeletionTestVar))
 	Expect(err).ToNot(HaveOccurred(), "Invalid test suite argument. Can't parse SKIP_DELETION_TEST %q", config.GetVariableOrEmpty(SkipDeletionTestVar))
+}
+
+func AzureServiceOperatorWaiter(bootstrapClusterProxy framework.ClusterProxy) func(ctx context.Context) {
+	return func(ctx context.Context) {
+		overallTimeout := 10 * time.Minute
+		pollInterval := 5 * time.Second
+		overallDeadline := time.Now().Add(overallTimeout)
+		podLabels := map[string]string{
+			"app.kubernetes.io/name": "azure-service-operator",
+			"control-plane":          "controller-manager",
+		}
+		lastPod := &corev1.Pod{}
+
+		for time.Now().Before(overallDeadline) {
+			var podList corev1.PodList
+			err := bootstrapClusterProxy.GetClient().List(ctx, &podList, &crclient.ListOptions{
+				Namespace:     "capz-system",
+				LabelSelector: labels.SelectorFromSet(podLabels),
+			})
+			Expect(err).ToNot(HaveOccurred(), "Failed to list azure-service-operator pods")
+
+			if len(podList.Items) == 0 {
+				By("Waiting for azure-service-operator pod to be created")
+				time.Sleep(pollInterval)
+				continue
+			}
+
+			pod := &podList.Items[0]
+			lastPod = pod
+
+			crashloop := false
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackOff" {
+					crashloop = true
+					break
+				}
+			}
+			if crashloop {
+				By("Restarting azure-service-operator pod due to CrashLoopBackOff")
+				err := bootstrapClusterProxy.GetClient().Delete(ctx, pod)
+				Expect(err).ToNot(HaveOccurred(), "Failed to delete azure-service-operator pod for restart")
+				time.Sleep(pollInterval)
+				continue
+			}
+
+			ready := false
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.Ready {
+					ready = true
+					break
+				}
+			}
+			if ready && pod.Status.Phase == corev1.PodRunning {
+				By("azure-service-operator pod is running and ready, continuing to monitor...")
+			}
+
+			time.Sleep(pollInterval)
+		}
+
+		Expect(lastPod).ToNot(BeNil(), "azure-service-operator pod should exist after 10 minutes of monitoring")
+
+		By("Performing final azure-service-operator pod status check")
+		Expect(lastPod.Status.Phase).To(Equal(corev1.PodRunning), "azure-service-operator pod should be in Running phase after 10 minutes")
+
+		finalReady := false
+		for _, cs := range lastPod.Status.ContainerStatuses {
+			if cs.Ready {
+				finalReady = true
+				break
+			}
+		}
+		Expect(lastPod.Status.Phase == corev1.PodRunning && finalReady).To(BeTrue(), "azure-service-operator pod should be both running and ready after 10 minutes")
+		By("azure-service-operator pod monitoring completed successfully - pod is running and ready")
+	}
 }

--- a/test/e2e/specs/import_gitops_mgmtv3.go
+++ b/test/e2e/specs/import_gitops_mgmtv3.go
@@ -52,7 +52,7 @@ import (
 	turtlesannotations "github.com/rancher/turtles/util/annotations"
 )
 
-type CreateMgmtV3UsingGitOpsSpecInput struct {
+type CreateUsingGitOpsSpecInput struct {
 	E2EConfig             *clusterctl.E2EConfig
 	BootstrapClusterProxy framework.ClusterProxy
 	ArtifactFolder        string `env:"ARTIFACTS_FOLDER"`
@@ -96,12 +96,12 @@ type CreateMgmtV3UsingGitOpsSpecInput struct {
 	AdditionalFleetGitRepos []turtlesframework.FleetCreateGitRepoInput
 }
 
-// CreateMgmtV3UsingGitOpsSpec implements a spec that will create a cluster via Fleet and test that it
+// CreateUsingGitOpsSpec implements a spec that will create a cluster via Fleet and test that it
 // automatically imports into Rancher Manager.
-func CreateMgmtV3UsingGitOpsSpec(ctx context.Context, inputGetter func() CreateMgmtV3UsingGitOpsSpecInput) {
+func CreateUsingGitOpsSpec(ctx context.Context, inputGetter func() CreateUsingGitOpsSpecInput) {
 	var (
 		specName              = "creategitops"
-		input                 CreateMgmtV3UsingGitOpsSpecInput
+		input                 CreateUsingGitOpsSpecInput
 		namespace             *corev1.Namespace
 		cancelWatches         context.CancelFunc
 		capiCluster           *types.NamespacedName
@@ -326,7 +326,7 @@ func CreateMgmtV3UsingGitOpsSpec(ctx context.Context, inputGetter func() CreateM
 
 			switch readyCondition.Status {
 			case corev1.ConditionTrue:
-				//Cluster is ready
+				// Cluster is ready
 				return nil
 			case corev1.ConditionFalse:
 				return fmt.Errorf("Cluster is not Ready")

--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -17,15 +17,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package import_gitops_v3
+package import_gitops
 
 import (
 	"context"
-	"time"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,7 +29,6 @@ import (
 	turtlesframework "github.com/rancher/turtles/test/framework"
 	"github.com/rancher/turtles/test/testenv"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
@@ -48,7 +42,7 @@ var _ = Describe("[Docker] [Kubeadm]  Create and delete CAPI cluster functionali
 		topologyNamespace = "creategitops-docker-kubeadm"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersOCIYAML: []testenv.OCIProvider{
@@ -60,11 +54,11 @@ var _ = Describe("[Docker] [Kubeadm]  Create and delete CAPI cluster functionali
 			WaitForDeployments: testenv.DefaultDeployments,
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIDockerKubeadmTopology,
-			ClusterName:                    "clusterv3-auto-import-kubeadm",
+			ClusterName:                    "cluster-docker-kubeadm",
 			ControlPlaneMachineCount:       ptr.To(1),
 			WorkerMachineCount:             ptr.To(1),
 			LabelNamespace:                 true,
@@ -104,7 +98,7 @@ var _ = Describe("[Docker] [RKE2] Create and delete CAPI cluster functionality s
 		topologyNamespace = "creategitops-docker-rke2"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersYAML: [][]byte{
@@ -113,11 +107,11 @@ var _ = Describe("[Docker] [RKE2] Create and delete CAPI cluster functionality s
 			WaitForDeployments: testenv.DefaultDeployments,
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIDockerRKE2Topology,
-			ClusterName:                    "clusterv3-auto-import-rke2",
+			ClusterName:                    "cluster-docker-rke2",
 			ControlPlaneMachineCount:       ptr.To(1),
 			WorkerMachineCount:             ptr.To(1),
 			LabelNamespace:                 true,
@@ -157,7 +151,7 @@ var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster clas
 		topologyNamespace = "creategitops-azure-aks"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -173,11 +167,11 @@ var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster clas
 				},
 			},
 			CustomWaiter: []func(ctx context.Context){
-				azureServiceOperatorWaiter(bootstrapClusterProxy), // workaround for https://github.com/rancher/turtles/issues/1584, remove when fixed
+				e2e.AzureServiceOperatorWaiter(bootstrapClusterProxy), // workaround for https://github.com/rancher/turtles/issues/1584, remove when fixed
 			},
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAzureAKSTopology,
@@ -204,7 +198,7 @@ var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster clas
 	})
 })
 
-var _ = Describe("[Azure] [Kubeadm] - [management.cattle.io/v3] Create and delete CAPI cluster from cluster class", Label(e2e.FullTestLabel, e2e.KubeadmTestLabel), func() {
+var _ = Describe("[Azure] [Kubeadm] - Create and delete CAPI cluster from cluster class", Label(e2e.FullTestLabel, e2e.KubeadmTestLabel), func() {
 	var topologyNamespace string
 
 	BeforeEach(func() {
@@ -214,7 +208,7 @@ var _ = Describe("[Azure] [Kubeadm] - [management.cattle.io/v3] Create and delet
 		topologyNamespace = "creategitops-azure-kubeadm"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -231,11 +225,11 @@ var _ = Describe("[Azure] [Kubeadm] - [management.cattle.io/v3] Create and delet
 				},
 			}, testenv.DefaultDeployments...),
 			CustomWaiter: []func(ctx context.Context){
-				azureServiceOperatorWaiter(bootstrapClusterProxy), // workaround for https://github.com/rancher/turtles/issues/1584, remove when fixed
+				e2e.AzureServiceOperatorWaiter(bootstrapClusterProxy), // workaround for https://github.com/rancher/turtles/issues/1584, remove when fixed
 			},
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAzureKubeadmTopology,
@@ -278,7 +272,7 @@ var _ = Describe("[Azure] [Kubeadm] - [management.cattle.io/v3] Create and delet
 	})
 })
 
-var _ = Describe("[Azure] [RKE2] - [management.cattle.io/v3] Create and delete CAPI cluster from cluster class", Label(e2e.FullTestLabel, e2e.Rke2TestLabel), func() {
+var _ = Describe("[Azure] [RKE2] - Create and delete CAPI cluster from cluster class", Label(e2e.FullTestLabel, e2e.Rke2TestLabel), func() {
 	var topologyNamespace string
 
 	BeforeEach(func() {
@@ -288,7 +282,7 @@ var _ = Describe("[Azure] [RKE2] - [management.cattle.io/v3] Create and delete C
 		topologyNamespace = "creategitops-azure-rke2"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -304,11 +298,11 @@ var _ = Describe("[Azure] [RKE2] - [management.cattle.io/v3] Create and delete C
 				},
 			},
 			CustomWaiter: []func(ctx context.Context){
-				azureServiceOperatorWaiter(bootstrapClusterProxy), // workaround for https://github.com/rancher/turtles/issues/1584, remove when fixed
+				e2e.AzureServiceOperatorWaiter(bootstrapClusterProxy), // workaround for https://github.com/rancher/turtles/issues/1584, remove when fixed
 			},
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAzureRKE2Topology,
@@ -354,7 +348,7 @@ var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster functionality shoul
 		komega.SetContext(ctx)
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -371,7 +365,7 @@ var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster functionality shoul
 			},
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAwsEKSMMP,
@@ -399,7 +393,7 @@ var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionali
 		topologyNamespace = "creategitops-aws-kubeadm"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -417,7 +411,7 @@ var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionali
 			}, testenv.DefaultDeployments...),
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAwsKubeadmTopology,
@@ -476,7 +470,7 @@ var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality 
 		topologyNamespace = "creategitops-aws-rke2"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -493,11 +487,11 @@ var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality 
 			},
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAwsEC2RKE2Topology,
-			ClusterName:                    "cluster-ec2-rke2",
+			ClusterName:                    "cluster-aws-rke2",
 			ControlPlaneMachineCount:       ptr.To(1),
 			WorkerMachineCount:             ptr.To(1),
 			LabelNamespace:                 true,
@@ -548,7 +542,7 @@ var _ = Describe("[GCP] [Kubeadm] Create and delete CAPI cluster functionality s
 		topologyNamespace = "creategitops-gcp-kubeadm"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -566,7 +560,7 @@ var _ = Describe("[GCP] [Kubeadm] Create and delete CAPI cluster functionality s
 			}, testenv.DefaultDeployments...),
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIGCPKubeadmTopology,
@@ -611,7 +605,7 @@ var _ = Describe("[GCP] [GKE] Create and delete CAPI cluster functionality shoul
 		komega.SetContext(ctx)
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -628,7 +622,7 @@ var _ = Describe("[GCP] [GKE] Create and delete CAPI cluster functionality shoul
 			},
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIGCPGKE,
@@ -656,7 +650,7 @@ var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster from cluste
 		topologyNamespace = "creategitops-vsphere-kubeadm"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		By("Running local vSphere tests, deploying vSphere infrastructure provider")
 
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
@@ -676,7 +670,7 @@ var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster from cluste
 			}, testenv.DefaultDeployments...),
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIvSphereKubeadmTopology,
@@ -731,7 +725,7 @@ var _ = Describe("[vSphere] [RKE2] Create and delete CAPI cluster functionality 
 		topologyNamespace = "creategitops-vsphere-rke2"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		By("Running local vSphere tests, deploying vSphere infrastructure provider")
 
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
@@ -750,7 +744,7 @@ var _ = Describe("[vSphere] [RKE2] Create and delete CAPI cluster functionality 
 			},
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIvSphereRKE2Topology,
@@ -794,77 +788,3 @@ var _ = Describe("[vSphere] [RKE2] Create and delete CAPI cluster functionality 
 		}
 	})
 })
-
-func azureServiceOperatorWaiter(bootstrapClusterProxy framework.ClusterProxy) func(ctx context.Context) {
-	return func(ctx context.Context) {
-		overallTimeout := 10 * time.Minute
-		pollInterval := 5 * time.Second
-		overallDeadline := time.Now().Add(overallTimeout)
-		podLabels := map[string]string{
-			"app.kubernetes.io/name": "azure-service-operator",
-			"control-plane":          "controller-manager",
-		}
-		lastPod := &corev1.Pod{}
-
-		for time.Now().Before(overallDeadline) {
-			var podList corev1.PodList
-			err := bootstrapClusterProxy.GetClient().List(ctx, &podList, &crclient.ListOptions{
-				Namespace:     "capz-system",
-				LabelSelector: labels.SelectorFromSet(podLabels),
-			})
-			Expect(err).ToNot(HaveOccurred(), "Failed to list azure-service-operator pods")
-
-			if len(podList.Items) == 0 {
-				By("Waiting for azure-service-operator pod to be created")
-				time.Sleep(pollInterval)
-				continue
-			}
-
-			pod := &podList.Items[0]
-			lastPod = pod
-
-			crashloop := false
-			for _, cs := range pod.Status.ContainerStatuses {
-				if cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackOff" {
-					crashloop = true
-					break
-				}
-			}
-			if crashloop {
-				By("Restarting azure-service-operator pod due to CrashLoopBackOff")
-				err := bootstrapClusterProxy.GetClient().Delete(ctx, pod)
-				Expect(err).ToNot(HaveOccurred(), "Failed to delete azure-service-operator pod for restart")
-				time.Sleep(pollInterval)
-				continue
-			}
-
-			ready := false
-			for _, cs := range pod.Status.ContainerStatuses {
-				if cs.Ready {
-					ready = true
-					break
-				}
-			}
-			if ready && pod.Status.Phase == corev1.PodRunning {
-				By("azure-service-operator pod is running and ready, continuing to monitor...")
-			}
-
-			time.Sleep(pollInterval)
-		}
-
-		Expect(lastPod).ToNot(BeNil(), "azure-service-operator pod should exist after 10 minutes of monitoring")
-
-		By("Performing final azure-service-operator pod status check")
-		Expect(lastPod.Status.Phase).To(Equal(corev1.PodRunning), "azure-service-operator pod should be in Running phase after 10 minutes")
-
-		finalReady := false
-		for _, cs := range lastPod.Status.ContainerStatuses {
-			if cs.Ready {
-				finalReady = true
-				break
-			}
-		}
-		Expect(lastPod.Status.Phase == corev1.PodRunning && finalReady).To(BeTrue(), "azure-service-operator pod should be both running and ready after 10 minutes")
-		By("azure-service-operator pod monitoring completed successfully - pod is running and ready")
-	}
-}

--- a/test/e2e/suites/import-gitops/suite_test.go
+++ b/test/e2e/suites/import-gitops/suite_test.go
@@ -17,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package import_gitops_v3
+package import_gitops
 
 import (
 	"context"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new test suite, which is a truncated version of the existing `import-gitops` for validating cluster import when `no-cert-manager` is enabled. Since in the future this will be the default mechanism for managing certificates, it's good that we can test multiple scenarios, which in this case are:
- Docker+RKE2
- AKS
- EKS
- GKE

Additionally, this also adds an extra commit that removes the old notation for `import-gitops` test suite, which still contains the `v3` suffix that does not add any relevant information anymore, as there's no `v1`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1677 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
