### PR TITLE
Use providers charts in e2e

### DIFF
--- a/.github/workflows/e2e-short.yaml
+++ b/.github/workflows/e2e-short.yaml
@@ -13,6 +13,7 @@ env:
   GINKGO_LABEL_FILTER: "short"
   TAG: v0.0.1
   SOURCE_REPO: https://github.com/${{ github.event.pull_request.head.repo.full_name }}
+  TURTLES_PROVIDERS: "docker,kubeadm"
 
 jobs:
   e2e:

--- a/.github/workflows/run-vsphere-tests.yaml
+++ b/.github/workflows/run-vsphere-tests.yaml
@@ -27,6 +27,7 @@ env:
   DOCKER_REGISTRY_USERNAME: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
   DOCKER_REGISTRY_CONFIG: ${{ secrets.DOCKER_REGISTRY_CONFIG }}
   GINKGO_NODES: 2
+  TURTLES_PROVIDERS: "vsphere,kubeadm"
 
 jobs:
   run_vsphere_e2e:

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,9 @@ SKIP_RESOURCE_CLEANUP ?= false
 USE_EXISTING_CLUSTER ?= false
 GINKGO_NOCOLOR ?= false
 GINKGO_LABEL_FILTER ?= short
+TURTLES_PROVIDERS ?= ALL
 GINKGO_TESTS ?= $(ROOT_DIR)/$(TEST_DIR)/e2e/suites/...
+TURTLES_MIGRATION_SCRIPT_PATH ?= $(ROOT_DIR)/scripts/migrate-providers-ownership.sh
 
 MANAGEMENT_CLUSTER_ENVIRONMENT ?= eks
 
@@ -633,7 +635,10 @@ HELM_BINARY_PATH=$(HELM) \
 CLUSTERCTL_BINARY_PATH=$(CLUSTERCTL) \
 SKIP_RESOURCE_CLEANUP=$(SKIP_RESOURCE_CLEANUP) \
 USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) \
-TURTLES_PATH=$(ROOT_DIR)/$(CHART_PACKAGE_DIR)/rancher-turtles-$(shell echo $(TAG) | cut -c 2-).tgz
+TURTLES_PROVIDERS=$(TURTLES_PROVIDERS) \
+TURTLES_MIGRATION_SCRIPT_PATH=$(TURTLES_MIGRATION_SCRIPT_PATH) \
+TURTLES_PATH=$(ROOT_DIR)/$(CHART_PACKAGE_DIR)/rancher-turtles-$(shell echo $(TAG) | cut -c 2-).tgz \
+TURTLES_PROVIDERS_PATH=$(ROOT_DIR)/$(CHART_PACKAGE_DIR)/rancher-turtles-providers-$(shell echo $(TAG) | cut -c 2-).tgz
 
 E2E_RUN_COMMAND=$(E2ECONFIG_VARS) $(GINKGO) -v --trace -p -procs=10 -poll-progress-after=$(GINKGO_POLL_PROGRESS_AFTER) \
 		-poll-progress-interval=$(GINKGO_POLL_PROGRESS_INTERVAL) --tags=e2e --focus="$(GINKGO_FOCUS)" --label-filter="$(GINKGO_LABEL_FILTER)" \
@@ -653,7 +658,7 @@ e2e-image: ## Build and push the image for e2e tests
 	CONTROLLER_IMG=$(REGISTRY)/$(ORG)/turtles-e2e $(MAKE) e2e-image-build
 	RELEASE_TAG=$(TAG) CONTROLLER_IMG=$(REGISTRY)/$(ORG)/turtles-e2e \
 	CONTROLLER_IMAGE_VERSION=$(TAG) \
-	$(MAKE) build-chart
+	$(MAKE) build-chart build-providers-chart
 
 .PHONY: e2e-image-build-and-push
 e2e-image-build-and-push: e2e-image

--- a/charts/rancher-turtles-providers/templates/infrastructure-gcp.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-gcp.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: CAPIProvider
 metadata:
-  name: infrastructure-gcp
+  name: gcp
   namespace: {{ index .Values "providers" "infrastructureGCP" "namespace" }}
 spec:
   name: gcp

--- a/charts/rancher-turtles-providers/values.yaml
+++ b/charts/rancher-turtles-providers/values.yaml
@@ -286,7 +286,7 @@ providers:
   # variables: Optional environment variables exposed to the controller manager.
     variables:
       EXP_CAPG_GKE: "true"
-      GCP_B64ENCODED_CREDENTIALS: ""
+  # GCP_B64ENCODED_CREDENTIALS: GCP service account credentials
   # credentials: Optional Secret reference containing Rancher credentials
   # credentials:
   #   name: ""

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -71,6 +71,40 @@ MANAGEMENT_CLUSTER_ENVIRONMENT=isolated-kind TAG=v0.0.1 GINKGO_LABEL_FILTER=shor
 
 Note that `SOURCE_REPO` needs to point to your forked repository, and `GITHUB_HEAD_REF` to your feature branch where commits have been pushed already.  
 
+## Providers chart usage in E2E
+
+The E2E suite installs the `rancher-turtles-providers` Helm chart via `test/testenv/providers.go`.
+
+Inputs:
+- HELM_BINARY_PATH: Path to the Helm binary used by the installer.
+- TURTLES_PROVIDERS_URL: Helm repo URL for the providers chart.
+- TURTLES_PROVIDERS_PATH: Local path to the `rancher-turtles-providers` chart.
+- TURTLES_PROVIDERS_REPO_NAME: Helm repo name to register.
+- TURTLES_PROVIDERS: Comma separated providers to enable on first install (note: this is only specific to e2e and not a helm chart option). Default "all".
+- TURTLES_MIGRATION_SCRIPT_PATH: Path to the providers ownership migration script.
+
+Enable providers:
+
+```bash
+# Enable everything
+export TURTLES_PROVIDERS=all
+# OR
+# Enable only Azure and AWS
+export TURTLES_PROVIDERS=azure,aws
+# OR
+# Enable CAPD and vSphere
+export TURTLES_PROVIDERS=capd,capv
+```
+
+If you are testing providers such as azure, aws, or gcp you will need to export the necessary environment variables.
+For vsphere, refer to [Running vSphere e2e tests locally](#running-vsphere-e2e-tests-locally) section.
+
+| Provider | Environment Variables                    |
+| -------- | ---------------------------------------- |
+| GCP      | CAPG_ENCODED_CREDS                       |
+| Azure    | AZURE_CLIENT_SECRET                      |
+| AWS      | AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY |
+
 ### Running vSphere e2e tests locally
 
 #### Prerequisites

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -87,6 +87,12 @@ variables:
   TURTLES_REPO_NAME: "turtles"
   TURTLES_URL: "https://rancher.github.io/turtles"
 
+  # Providers Chart
+  TURTLES_PROVIDERS: "ALL"
+  TURTLES_PROVIDERS_REPO_NAME: "turtles"
+  TURTLES_PROVIDERS_URL: "https://rancher.github.io/turtles"
+  TURTLES_PROVIDERS_PATH: "turtles/rancher-turtles-providers"
+
   # External Charts and Dependencies
   CERT_MANAGER_REPO_NAME: "jetstack"
   CERT_MANAGER_URL: "https://charts.jetstack.io"

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -171,6 +171,10 @@ const (
 	SkipResourceCleanupVar = "SKIP_RESOURCE_CLEANUP"
 	SkipDeletionTestVar    = "SKIP_DELETION_TEST"
 
+	TurtlesProvidersRepoNameVar = "TURTLES_PROVIDERS_REPO_NAME"
+	TurtlesProvidersUrlVar      = "TURTLES_PROVIDERS_URL"
+	TurtlesProvidersPathVar     = "TURTLES_PROVIDERS_PATH"
+
 	RKE2VersionVar = "RKE2_VERSION"
 
 	AzureSubIDVar        = "AZURE_SUBSCRIPTION_ID"
@@ -191,4 +195,8 @@ const (
 
 const (
 	CAPIVersion = "v1.10.5"
+)
+
+const (
+	ProvidersChartName = "rancher-turtles-providers"
 )

--- a/test/e2e/data/capi-operator/capg-variables.yaml
+++ b/test/e2e/data/capi-operator/capg-variables.yaml
@@ -11,4 +11,4 @@ metadata:
   namespace: capg-system
 type: Opaque
 stringData:
-  GCP_B64ENCODED_CREDENTIALS: "{{ .GCPEncodedCredentials }}"
+  GCP_B64ENCODED_CREDENTIALS: "${CAPG_ENCODED_CREDS}"

--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -20,21 +20,11 @@ limitations under the License.
 package import_gitops
 
 import (
-	"context"
-	"time"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/rancher/turtles/test/e2e"
 	"github.com/rancher/turtles/test/e2e/specs"
 	turtlesframework "github.com/rancher/turtles/test/framework"
-	"github.com/rancher/turtles/test/testenv"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
@@ -49,17 +39,6 @@ var _ = Describe("[Docker] [Kubeadm]  Create and delete CAPI cluster functionali
 	})
 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
-		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			CAPIProvidersOCIYAML: []testenv.OCIProvider{
-				{
-					Name: "docker",
-					File: string(e2e.CapiProvidersOci),
-				},
-			},
-			WaitForDeployments: testenv.DefaultDeployments,
-		})
-
 		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
@@ -105,14 +84,6 @@ var _ = Describe("[Docker] [RKE2] Create and delete CAPI cluster functionality s
 	})
 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
-		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			CAPIProvidersYAML: [][]byte{
-				e2e.CapiProviders,
-			},
-			WaitForDeployments: testenv.DefaultDeployments,
-		})
-
 		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
@@ -158,25 +129,6 @@ var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster clas
 	})
 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
-		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			CAPIProvidersSecretsYAML: [][]byte{
-				e2e.AzureIdentitySecret,
-			},
-			CAPIProvidersYAML: [][]byte{
-				e2e.AzureProvider,
-			},
-			WaitForDeployments: []testenv.NamespaceName{
-				{
-					Name:      "capz-controller-manager",
-					Namespace: "capz-system",
-				},
-			},
-			CustomWaiter: []func(ctx context.Context){
-				azureServiceOperatorWaiter(bootstrapClusterProxy), // workaround for https://github.com/rancher/turtles/issues/1584, remove when fixed
-			},
-		})
-
 		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
@@ -215,26 +167,6 @@ var _ = Describe("[Azure] [Kubeadm] Create and delete CAPI cluster from cluster 
 	})
 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
-		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			CAPIProvidersSecretsYAML: [][]byte{
-				e2e.AzureIdentitySecret,
-			},
-			CAPIProvidersYAML: [][]byte{
-				e2e.AzureProvider,
-				e2e.CapiProviders,
-			},
-			WaitForDeployments: append([]testenv.NamespaceName{
-				{
-					Name:      "capz-controller-manager",
-					Namespace: "capz-system",
-				},
-			}, testenv.DefaultDeployments...),
-			CustomWaiter: []func(ctx context.Context){
-				azureServiceOperatorWaiter(bootstrapClusterProxy), // workaround for https://github.com/rancher/turtles/issues/1584, remove when fixed
-			},
-		})
-
 		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
@@ -289,25 +221,6 @@ var _ = Describe("[Azure] [RKE2] Create and delete CAPI cluster from cluster cla
 	})
 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
-		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			CAPIProvidersSecretsYAML: [][]byte{
-				e2e.AzureIdentitySecret,
-			},
-			CAPIProvidersYAML: [][]byte{
-				e2e.AzureProvider,
-			},
-			WaitForDeployments: []testenv.NamespaceName{
-				{
-					Name:      "capz-controller-manager",
-					Namespace: "capz-system",
-				},
-			},
-			CustomWaiter: []func(ctx context.Context){
-				azureServiceOperatorWaiter(bootstrapClusterProxy), // workaround for https://github.com/rancher/turtles/issues/1584, remove when fixed
-			},
-		})
-
 		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
@@ -355,22 +268,6 @@ var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster functionality shoul
 	})
 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
-		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			CAPIProvidersSecretsYAML: [][]byte{
-				e2e.AWSIdentitySecret,
-			},
-			CAPIProvidersYAML: [][]byte{
-				e2e.AWSProvider,
-			},
-			WaitForDeployments: []testenv.NamespaceName{
-				{
-					Name:      "capa-controller-manager",
-					Namespace: "capa-system",
-				},
-			},
-		})
-
 		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
@@ -400,23 +297,6 @@ var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionali
 	})
 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
-		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			CAPIProvidersSecretsYAML: [][]byte{
-				e2e.AWSIdentitySecret,
-			},
-			CAPIProvidersYAML: [][]byte{
-				e2e.AWSProvider,
-				e2e.CapiProviders,
-			},
-			WaitForDeployments: append([]testenv.NamespaceName{
-				{
-					Name:      "capa-controller-manager",
-					Namespace: "capa-system",
-				},
-			}, testenv.DefaultDeployments...),
-		})
-
 		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
@@ -477,22 +357,6 @@ var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality 
 	})
 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
-		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			CAPIProvidersSecretsYAML: [][]byte{
-				e2e.AWSIdentitySecret,
-			},
-			CAPIProvidersYAML: [][]byte{
-				e2e.AWSProvider,
-			},
-			WaitForDeployments: []testenv.NamespaceName{
-				{
-					Name:      "capa-controller-manager",
-					Namespace: "capa-system",
-				},
-			},
-		})
-
 		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
@@ -549,23 +413,6 @@ var _ = Describe("[GCP] [Kubeadm] Create and delete CAPI cluster functionality s
 	})
 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
-		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			CAPIProvidersSecretsYAML: [][]byte{
-				e2e.GCPProviderSecret,
-			},
-			CAPIProvidersYAML: [][]byte{
-				e2e.GCPProvider,
-				e2e.CapiProviders,
-			},
-			WaitForDeployments: append([]testenv.NamespaceName{
-				{
-					Name:      "capg-controller-manager",
-					Namespace: "capg-system",
-				},
-			}, testenv.DefaultDeployments...),
-		})
-
 		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
@@ -612,22 +459,6 @@ var _ = Describe("[GCP] [GKE] Create and delete CAPI cluster functionality shoul
 	})
 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
-		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			CAPIProvidersSecretsYAML: [][]byte{
-				e2e.GCPProviderSecret,
-			},
-			CAPIProvidersYAML: [][]byte{
-				e2e.GCPProvider,
-			},
-			WaitForDeployments: []testenv.NamespaceName{
-				{
-					Name:      "capg-controller-manager",
-					Namespace: "capg-system",
-				},
-			},
-		})
-
 		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
@@ -658,23 +489,6 @@ var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster from cluste
 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		By("Running local vSphere tests, deploying vSphere infrastructure provider")
-
-		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			CAPIProvidersSecretsYAML: [][]byte{
-				e2e.VSphereProviderSecret,
-			},
-			CAPIProvidersYAML: [][]byte{
-				e2e.CapvProvider,
-				e2e.CapiProviders,
-			},
-			WaitForDeployments: append([]testenv.NamespaceName{
-				{
-					Name:      "capv-controller-manager",
-					Namespace: "capv-system",
-				},
-			}, testenv.DefaultDeployments...),
-		})
 
 		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
@@ -734,22 +548,6 @@ var _ = Describe("[vSphere] [RKE2] Create and delete CAPI cluster functionality 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		By("Running local vSphere tests, deploying vSphere infrastructure provider")
 
-		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			CAPIProvidersSecretsYAML: [][]byte{
-				e2e.VSphereProviderSecret,
-			},
-			CAPIProvidersYAML: [][]byte{
-				e2e.CapvProvider,
-			},
-			WaitForDeployments: []testenv.NamespaceName{
-				{
-					Name:      "capv-controller-manager",
-					Namespace: "capv-system",
-				},
-			},
-		})
-
 		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
@@ -794,77 +592,3 @@ var _ = Describe("[vSphere] [RKE2] Create and delete CAPI cluster functionality 
 		}
 	})
 })
-
-func azureServiceOperatorWaiter(bootstrapClusterProxy framework.ClusterProxy) func(ctx context.Context) {
-	return func(ctx context.Context) {
-		overallTimeout := 10 * time.Minute
-		pollInterval := 5 * time.Second
-		overallDeadline := time.Now().Add(overallTimeout)
-		podLabels := map[string]string{
-			"app.kubernetes.io/name": "azure-service-operator",
-			"control-plane":          "controller-manager",
-		}
-		lastPod := &corev1.Pod{}
-
-		for time.Now().Before(overallDeadline) {
-			var podList corev1.PodList
-			err := bootstrapClusterProxy.GetClient().List(ctx, &podList, &crclient.ListOptions{
-				Namespace:     "capz-system",
-				LabelSelector: labels.SelectorFromSet(podLabels),
-			})
-			Expect(err).ToNot(HaveOccurred(), "Failed to list azure-service-operator pods")
-
-			if len(podList.Items) == 0 {
-				By("Waiting for azure-service-operator pod to be created")
-				time.Sleep(pollInterval)
-				continue
-			}
-
-			pod := &podList.Items[0]
-			lastPod = pod
-
-			crashloop := false
-			for _, cs := range pod.Status.ContainerStatuses {
-				if cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackOff" {
-					crashloop = true
-					break
-				}
-			}
-			if crashloop {
-				By("Restarting azure-service-operator pod due to CrashLoopBackOff")
-				err := bootstrapClusterProxy.GetClient().Delete(ctx, pod)
-				Expect(err).ToNot(HaveOccurred(), "Failed to delete azure-service-operator pod for restart")
-				time.Sleep(pollInterval)
-				continue
-			}
-
-			ready := false
-			for _, cs := range pod.Status.ContainerStatuses {
-				if cs.Ready {
-					ready = true
-					break
-				}
-			}
-			if ready && pod.Status.Phase == corev1.PodRunning {
-				By("azure-service-operator pod is running and ready, continuing to monitor...")
-			}
-
-			time.Sleep(pollInterval)
-		}
-
-		Expect(lastPod).ToNot(BeNil(), "azure-service-operator pod should exist after 10 minutes of monitoring")
-
-		By("Performing final azure-service-operator pod status check")
-		Expect(lastPod.Status.Phase).To(Equal(corev1.PodRunning), "azure-service-operator pod should be in Running phase after 10 minutes")
-
-		finalReady := false
-		for _, cs := range lastPod.Status.ContainerStatuses {
-			if cs.Ready {
-				finalReady = true
-				break
-			}
-		}
-		Expect(lastPod.Status.Phase == corev1.PodRunning && finalReady).To(BeTrue(), "azure-service-operator pod should be both running and ready after 10 minutes")
-		By("azure-service-operator pod monitoring completed successfully - pod is running and ready")
-	}
-}

--- a/test/e2e/suites/import-gitops/suite_test.go
+++ b/test/e2e/suites/import-gitops/suite_test.go
@@ -77,7 +77,10 @@ var _ = SynchronizedBeforeSuite(
 
 		testenv.DeployRancherTurtles(ctx, testenv.DeployRancherTurtlesInput{
 			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
-			AdditionalValues:      map[string]string{},
+		})
+
+		testenv.DeployRancherTurtlesProviders(ctx, testenv.DeployRancherTurtlesProvidersInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
 		})
 
 		data, err := json.Marshal(e2e.Setup{

--- a/test/testenv/providers.go
+++ b/test/testenv/providers.go
@@ -1,0 +1,520 @@
+/*
+Copyright © 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testenv
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/turtles/test/e2e"
+	turtlesframework "github.com/rancher/turtles/test/framework"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	opframework "sigs.k8s.io/cluster-api-operator/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	bootstrapKubeadmPath    = "providers.bootstrapKubeadm.enabled"
+	controlplaneKubeadmPath = "providers.controlplaneKubeadm.enabled"
+	dockerPath              = "providers.infrastructureDocker.enabled"
+	awsPath                 = "providers.infrastructureAWS.enabled"
+	azurePath               = "providers.infrastructureAzure.enabled"
+	gcpPath                 = "providers.infrastructureGCP.enabled"
+	vspherePath             = "providers.infrastructureVSphere.enabled"
+
+	defaultOCIRegistry = "registry.rancher.com/rancher/cluster-api-controller-components"
+
+	providerKubeadmBootstrap    = "kubeadm-bootstrap"
+	providerKubeadmControlPlane = "kubeadm-control-plane"
+	providerDocker              = "docker"
+	providerAWS                 = "aws"
+	providerAzure               = "azure"
+	providerGCP                 = "gcp"
+	providerVSphere             = "vsphere"
+
+	deployCAPIControllerManager = "capi-controller-manager"
+	namespaceCAPISystem         = "capi-system"
+
+	deployKubeadmBootstrapControllerManager = "capi-kubeadm-bootstrap-controller-manager"
+	namespaceKubeadmBootstrapSystem         = "capi-kubeadm-bootstrap-system"
+
+	deployKubeadmControlPlaneControllerManager = "capi-kubeadm-control-plane-controller-manager"
+	namespaceKubeadmControlPlaneSystem         = "capi-kubeadm-control-plane-system"
+
+	deployCAPDControllerManager = "capd-controller-manager"
+	namespaceCAPDSystem         = "capd-system"
+
+	deployCAPAControllerManager = "capa-controller-manager"
+	namespaceCAPASystem         = "capa-system"
+
+	deployCAPZControllerManager = "capz-controller-manager"
+	namespaceCAPZSystem         = "capz-system"
+
+	deployCAPGControllerManager = "capg-controller-manager"
+	namespaceCAPGSystem         = "capg-system"
+
+	deployCAPVControllerManager = "capv-controller-manager"
+	namespaceCAPVSystem         = "capv-system"
+)
+
+// DeployRancherTurtlesProvidersInput represents the input parameters for installing the
+// rancher-turtles-providers chart.
+type DeployRancherTurtlesProvidersInput struct {
+	// BootstrapClusterProxy is the cluster proxy for the bootstrap cluster.
+	BootstrapClusterProxy framework.ClusterProxy
+
+	// HelmBinaryPath is the path to the Helm binary.
+	HelmBinaryPath string `env:"HELM_BINARY_PATH"`
+
+	// ProvidersChartUrl is the URL of the rancher-turtles-providers chart repository.
+	ProvidersChartUrl string `env:"TURTLES_PROVIDERS_URL"`
+
+	// ProvidersChartPath is the path to the rancher-turtles-providers chart.
+	ProvidersChartPath string `env:"TURTLES_PROVIDERS_PATH"`
+
+	// ProvidersChartRepoName is the name of the Helm repo.
+	ProvidersChartRepoName string `env:"TURTLES_PROVIDERS_REPO_NAME" envDefault:"turtles"`
+
+	// Version is the chart version to install.
+	Version string
+
+	// AdditionalValues are additional Helm values to pass to the chart (for example to
+	// enable specific infrastructure providers).
+	AdditionalValues map[string]string
+
+	// WaitDeploymentsReadyInterval is the interval used when waiting for provider
+	// deployments to become available (e.g. "15m,10s").
+	WaitDeploymentsReadyInterval []interface{} `envDefault:"15m,10s"`
+
+	// ProviderList is an optional comma-separated list of providers to enable on first install.
+	// Examples: "all", "azure,aws".
+	ProviderList string `env:"TURTLES_PROVIDERS" envDefault:"all"`
+
+	// MigrationScriptPath is the path to the providers ownership migration script.
+	MigrationScriptPath string `env:"TURTLES_MIGRATION_SCRIPT_PATH"`
+}
+
+// DeployRancherTurtlesProviders installs the rancher-turtles-providers chart with provided values and waits for deployments.
+func DeployRancherTurtlesProviders(ctx context.Context, input DeployRancherTurtlesProvidersInput) {
+	Expect(turtlesframework.Parse(&input)).To(Succeed(), "Failed to parse environment variables")
+
+	Expect(ctx).NotTo(BeNil(), "ctx is required for DeployRancherTurtlesProviders")
+	Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "BootstrapClusterProxy is required for DeployRancherTurtlesProviders")
+	Expect(input.HelmBinaryPath).ToNot(BeEmpty(), "HelmBinaryPath is required for DeployRancherTurtlesProviders")
+
+	chartPath := input.ProvidersChartPath
+
+	if chartPath != "" {
+		By(fmt.Sprintf("Using local chart path: %s", chartPath))
+	} else if input.Version != "" && input.ProvidersChartUrl == "" {
+		chartPath = "rancher-turtles-providers-external/rancher-turtles-providers"
+
+		By("Adding external rancher-turtles-providers chart repo")
+		addChart := &opframework.HelmChart{
+			BinaryPath:      input.HelmBinaryPath,
+			Name:            "rancher-turtles-providers-external",
+			Path:            input.ProvidersChartPath,
+			Commands:        opframework.Commands(opframework.Repo, opframework.Add),
+			AdditionalFlags: opframework.Flags("--force-update"),
+			Kubeconfig:      input.BootstrapClusterProxy.GetKubeconfigPath(),
+		}
+		_, err := addChart.Run(nil)
+		Expect(err).ToNot(HaveOccurred())
+	} else if input.ProvidersChartUrl != "" {
+		By("Adding rancher-turtles-providers chart repo")
+		addChart := &opframework.HelmChart{
+			BinaryPath:      input.HelmBinaryPath,
+			Name:            input.ProvidersChartRepoName,
+			Path:            input.ProvidersChartUrl,
+			Commands:        opframework.Commands(opframework.Repo, opframework.Add),
+			AdditionalFlags: opframework.Flags("--force-update"),
+			Kubeconfig:      input.BootstrapClusterProxy.GetKubeconfigPath(),
+		}
+		_, err := addChart.Run(nil)
+		Expect(err).ToNot(HaveOccurred())
+		chartPath = fmt.Sprintf("%s/%s", input.ProvidersChartRepoName, e2e.ProvidersChartName)
+	}
+
+	values := map[string]string{}
+
+	selectedList := strings.TrimSpace(strings.ToLower(input.ProviderList))
+	if selectedList == "all" {
+		enableAllProviders(values)
+	} else if selectedList != "" {
+		providerList := strings.Split(selectedList, ",")
+		for _, p := range providerList {
+			provider := strings.TrimSpace(strings.ToLower(p))
+			switch provider {
+			case "kubeadm":
+				values[bootstrapKubeadmPath] = "true"
+				values[controlplaneKubeadmPath] = "true"
+			case "docker", "capd":
+				values[dockerPath] = "true"
+			case "aws", "capa":
+				values[awsPath] = "true"
+			case "azure", "capz":
+				values[azurePath] = "true"
+			case "gcp", "capg":
+				values[gcpPath] = "true"
+			case "vsphere", "capv":
+				values[vspherePath] = "true"
+			case "", "all":
+			default:
+				log.FromContext(ctx).Info("Unknown provider in TURTLES_PROVIDERS, ignoring", "provider", provider)
+			}
+		}
+	}
+
+	By("Installing rancher-turtles-providers chart")
+
+	maps.Copy(values, input.AdditionalValues) // Merge additional values into the values map
+
+	enabledProviders := getEnabledCAPIProviders(values)
+
+	applyProviderSecrets(ctx, input, enabledProviders)
+
+	providerWaiters := []func(ctx context.Context){}
+	configureProviderDefaults(ctx, input, values, enabledProviders)
+	configureProviderWaiters(input, enabledProviders, &providerWaiters)
+	adoptArgs := getAdoptArgsForEnabledProviders(enabledProviders, values)
+	log.FromContext(ctx).Info("Providers adoption args prepared", "args", adoptArgs, "enabled", enabledProviders)
+	runProviderMigration(ctx, input.MigrationScriptPath, input.BootstrapClusterProxy.GetKubeconfigPath(), adoptArgs...)
+
+	command := []string{
+		"upgrade", e2e.ProvidersChartName, chartPath,
+		"--install",
+		"--dependency-update",
+		"-n", e2e.RancherTurtlesNamespace,
+		"--create-namespace",
+		"--wait",
+		"--reuse-values",
+		"--timeout", "10m",
+		"--kubeconfig", input.BootstrapClusterProxy.GetKubeconfigPath(),
+	}
+
+	if input.Version != "" {
+		command = append(command, "--version", input.Version)
+	}
+
+	for k, v := range values {
+		if strings.Contains(k, ".variables.") { // Provider variables must be strings
+			command = append(command, "--set-string", fmt.Sprintf("%s=%s", k, v))
+			continue
+		}
+		command = append(command, "--set", fmt.Sprintf("%s=%s", k, v))
+	}
+
+	fullCommand := append([]string{input.HelmBinaryPath}, command...)
+	log.FromContext(ctx).Info("Executing:", "install", strings.Join(fullCommand, " "))
+
+	By("Installing providers chart...")
+	cmd := exec.Command(input.HelmBinaryPath, command...)
+	cmd.WaitDelay = 10 * time.Minute
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		Expect(fmt.Errorf("Unable to install providers chart: %w\nOutput: %s, Command: %s", err, out, strings.Join(fullCommand, " "))).ToNot(HaveOccurred())
+	}
+
+	deploymentsToWait := getDeploymentsForEnabledProviders(enabledProviders)
+	if len(deploymentsToWait) > 0 {
+		By("Waiting for provider deployments to be ready")
+		Expect(input.WaitDeploymentsReadyInterval).ToNot(BeNil(), "WaitDeploymentsReadyInterval is required when waiting for deployments")
+		for _, nn := range deploymentsToWait {
+			turtlesframework.Byf("Waiting for deployment %s/%s to be available", nn.Namespace, nn.Name)
+			framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
+				Getter: input.BootstrapClusterProxy.GetClient(),
+				Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+					Name:      nn.Name,
+					Namespace: nn.Namespace,
+				}},
+			}, input.WaitDeploymentsReadyInterval...)
+		}
+	}
+
+	for _, waiter := range providerWaiters {
+		By("Executing provider-specific custom waiter function")
+		waiter(ctx)
+	}
+}
+
+func runProviderMigration(ctx context.Context, scriptPath, kubeconfigPath string, extraArgs ...string) {
+	if _, err := os.Stat(scriptPath); err != nil {
+		Expect(fmt.Errorf("migration script not found: %s", scriptPath)).ToNot(HaveOccurred())
+	}
+
+	By("Running providers ownership migration script")
+	args := []string{"--kubeconfig", kubeconfigPath}
+	if len(extraArgs) > 0 {
+		args = append(args, extraArgs...)
+	}
+	cmd := exec.Command(scriptPath, args...)
+	cmd.Env = append(os.Environ(),
+		"RELEASE_NAME="+e2e.ProvidersChartName,
+		"RELEASE_NAMESPACE="+e2e.RancherTurtlesNamespace,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		Expect(fmt.Errorf("migration script failed: %w\nOutput: %s", err, out)).ToNot(HaveOccurred())
+	}
+
+	log.FromContext(ctx).Info("migration completed", "output", string(out))
+}
+
+func enableAllProviders(values map[string]string) {
+	values[bootstrapKubeadmPath] = "true"
+	values[controlplaneKubeadmPath] = "true"
+	values[dockerPath] = "true"
+	values[awsPath] = "true"
+	values[azurePath] = "true"
+	values[gcpPath] = "true"
+	values[vspherePath] = "true"
+}
+
+func getAdoptArgsForEnabledProviders(enabled []string, values map[string]string) []string {
+	adopt := []string{}
+
+	getNamespaceWithDefault := func(key, defaultNamespace string) string { // Try to get namespace from values or use default
+		if namespace, ok := values[key]; ok && strings.TrimSpace(namespace) != "" {
+			return strings.TrimSpace(namespace)
+		}
+		return defaultNamespace
+	}
+
+	namespaces := map[string]string{
+		providerKubeadmBootstrap:    getNamespaceWithDefault("providers.bootstrapKubeadm.namespace", namespaceKubeadmBootstrapSystem),
+		providerKubeadmControlPlane: getNamespaceWithDefault("providers.controlplaneKubeadm.namespace", namespaceKubeadmControlPlaneSystem),
+		providerDocker:              getNamespaceWithDefault("providers.infrastructureDocker.namespace", namespaceCAPDSystem),
+		providerAWS:                 getNamespaceWithDefault("providers.infrastructureAWS.namespace", namespaceCAPASystem),
+		providerAzure:               getNamespaceWithDefault("providers.infrastructureAzure.namespace", namespaceCAPZSystem),
+		providerGCP:                 getNamespaceWithDefault("providers.infrastructureGCP.namespace", namespaceCAPGSystem),
+		providerVSphere:             getNamespaceWithDefault("providers.infrastructureVSphere.namespace", namespaceCAPVSystem),
+	}
+
+	for _, name := range enabled {
+		if namespace, ok := namespaces[name]; ok && namespace != "" {
+			adopt = append(adopt, "--adopt", fmt.Sprintf("%s:%s", name, namespace))
+		}
+	}
+
+	return adopt
+}
+
+func getEnabledCAPIProviders(values map[string]string) []string {
+	out := []string{}
+	if values[bootstrapKubeadmPath] == "true" {
+		out = append(out, providerKubeadmBootstrap)
+	}
+	if values[controlplaneKubeadmPath] == "true" {
+		out = append(out, providerKubeadmControlPlane)
+	}
+	if values[dockerPath] == "true" {
+		out = append(out, providerDocker)
+	}
+	if values[awsPath] == "true" {
+		out = append(out, providerAWS)
+	}
+	if values[azurePath] == "true" {
+		out = append(out, providerAzure)
+	}
+	if values[gcpPath] == "true" {
+		out = append(out, providerGCP)
+	}
+	if values[vspherePath] == "true" {
+		out = append(out, providerVSphere)
+	}
+	return out
+}
+
+func getDeploymentsForEnabledProviders(enabled []string) []NamespaceName {
+	deployments := []NamespaceName{
+		{Name: deployCAPIControllerManager, Namespace: namespaceCAPISystem},
+	}
+
+	for _, name := range enabled {
+		switch name {
+		case providerKubeadmBootstrap:
+			deployments = append(deployments, NamespaceName{Name: deployKubeadmBootstrapControllerManager, Namespace: namespaceKubeadmBootstrapSystem})
+		case providerKubeadmControlPlane:
+			deployments = append(deployments, NamespaceName{Name: deployKubeadmControlPlaneControllerManager, Namespace: namespaceKubeadmControlPlaneSystem})
+		case providerDocker:
+			deployments = append(deployments, NamespaceName{Name: deployCAPDControllerManager, Namespace: namespaceCAPDSystem})
+		case providerAWS:
+			deployments = append(deployments, NamespaceName{Name: deployCAPAControllerManager, Namespace: namespaceCAPASystem})
+		case providerAzure:
+			deployments = append(deployments, NamespaceName{Name: deployCAPZControllerManager, Namespace: namespaceCAPZSystem})
+		case providerGCP:
+			deployments = append(deployments, NamespaceName{Name: deployCAPGControllerManager, Namespace: namespaceCAPGSystem})
+		case providerVSphere:
+			deployments = append(deployments, NamespaceName{Name: deployCAPVControllerManager, Namespace: namespaceCAPVSystem})
+		}
+	}
+
+	return deployments
+}
+
+func configureProviderDefaults(ctx context.Context, input DeployRancherTurtlesProvidersInput, values map[string]string, enabled []string) {
+	for _, name := range enabled {
+		switch name {
+		case providerAWS:
+			values["providers.infrastructureAWS.variables.EXP_MACHINE_POOL"] = "true"
+			values["providers.infrastructureAWS.variables.EXP_EXTERNAL_RESOURCE_GC"] = "true"
+			values["providers.infrastructureAWS.variables.CAPA_LOGLEVEL"] = "5"
+			values["providers.infrastructureAWS.manager.syncPeriod"] = "5m"
+		case providerDocker:
+			By("Configuring Docker provider with OCI registry")
+			clusterctl := turtlesframework.GetClusterctl(ctx, turtlesframework.GetClusterctlInput{
+				GetLister:          input.BootstrapClusterProxy.GetClient(),
+				ConfigMapNamespace: "rancher-turtles-system",
+				ConfigMapName:      "clusterctl-config",
+			})
+			dockerVersion := getProviderVersion(clusterctl, "docker")
+			Expect(dockerVersion).ToNot(BeEmpty(), "Docker provider version must be available in clusterctl config")
+
+			values["providers.infrastructureDocker.fetchConfig.oci"] = fmt.Sprintf("%s:%s", defaultOCIRegistry, dockerVersion)
+			By("Using Docker provider version " + dockerVersion + " from OCI registry")
+		}
+	}
+}
+
+func configureProviderWaiters(input DeployRancherTurtlesProvidersInput, enabled []string, customWaiters *[]func(ctx context.Context)) {
+	for _, name := range enabled {
+		switch name {
+		case providerAzure:
+			*customWaiters = append(*customWaiters, azureServiceOperatorWaiter(input.BootstrapClusterProxy))
+		}
+	}
+}
+
+func applyProviderSecrets(ctx context.Context, input DeployRancherTurtlesProvidersInput, enabled []string) {
+	for _, name := range enabled {
+		switch name {
+		case providerAzure:
+			By("Applying Azure provider secret")
+			Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+				Proxy:    input.BootstrapClusterProxy,
+				Template: e2e.AzureIdentitySecret,
+			})).To(Succeed(), "Failed to apply Azure provider secret")
+		case providerAWS:
+			By("Applying AWS provider secret")
+			Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+				Proxy:    input.BootstrapClusterProxy,
+				Template: e2e.AWSIdentitySecret,
+			})).To(Succeed(), "Failed to apply AWS provider secret")
+		case providerGCP:
+			By("Applying GCP provider secret")
+			Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+				Proxy:    input.BootstrapClusterProxy,
+				Template: e2e.GCPProviderSecret,
+			})).To(Succeed(), "Failed to apply GCP provider secret")
+		case providerVSphere:
+			By("Applying vSphere provider secret")
+			Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+				Proxy:    input.BootstrapClusterProxy,
+				Template: e2e.VSphereProviderSecret,
+			})).To(Succeed(), "Failed to apply vSphere provider secret")
+		}
+	}
+}
+
+// azureServiceOperatorWaiter returns a custom waiter function for Azure service operator
+// Workaround for https://github.com/rancher/turtles/issues/1584 - should be removed when fixed
+func azureServiceOperatorWaiter(bootstrapClusterProxy framework.ClusterProxy) func(ctx context.Context) {
+	return func(ctx context.Context) {
+		overallTimeout := 10 * time.Minute
+		pollInterval := 5 * time.Second
+		overallDeadline := time.Now().Add(overallTimeout)
+		podLabels := map[string]string{
+			"app.kubernetes.io/name": "azure-service-operator",
+			"control-plane":          "controller-manager",
+		}
+		lastPod := &corev1.Pod{}
+
+		for time.Now().Before(overallDeadline) {
+			var podList corev1.PodList
+			err := bootstrapClusterProxy.GetClient().List(ctx, &podList, &crclient.ListOptions{
+				Namespace:     namespaceCAPZSystem,
+				LabelSelector: labels.SelectorFromSet(podLabels),
+			})
+			Expect(err).ToNot(HaveOccurred(), "Failed to list azure-service-operator pods")
+
+			if len(podList.Items) == 0 {
+				By("Waiting for azure-service-operator pod to be created")
+				time.Sleep(pollInterval)
+				continue
+			}
+
+			pod := &podList.Items[0]
+			lastPod = pod
+
+			crashloop := false
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackOff" {
+					crashloop = true
+					break
+				}
+			}
+			if crashloop {
+				By("Restarting azure-service-operator pod due to CrashLoopBackOff")
+				err := bootstrapClusterProxy.GetClient().Delete(ctx, pod)
+				Expect(err).ToNot(HaveOccurred(), "Failed to delete azure-service-operator pod for restart")
+				time.Sleep(pollInterval)
+				continue
+			}
+
+			ready := false
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.Ready {
+					ready = true
+					break
+				}
+			}
+			if ready && pod.Status.Phase == corev1.PodRunning {
+				By("azure-service-operator pod is running and ready, continuing to monitor...")
+			}
+
+			time.Sleep(pollInterval)
+		}
+
+		Expect(lastPod).ToNot(BeNil(), "azure-service-operator pod should exist after 10 minutes of monitoring")
+
+		By("Performing final azure-service-operator pod status check")
+		Expect(lastPod.Status.Phase).To(Equal(corev1.PodRunning), "azure-service-operator pod should be in Running phase after 10 minutes")
+
+		finalReady := false
+		for _, cs := range lastPod.Status.ContainerStatuses {
+			if cs.Ready {
+				finalReady = true
+				break
+			}
+		}
+		Expect(lastPod.Status.Phase == corev1.PodRunning && finalReady).To(BeTrue(), "azure-service-operator pod should be both running and ready after 10 minutes")
+		By("azure-service-operator pod monitoring completed successfully - pod is running and ready")
+	}
+}

--- a/test/testenv/rancher.go
+++ b/test/testenv/rancher.go
@@ -116,11 +116,11 @@ type deployRancherValuesFile struct {
 }
 
 type ngrokCredentials struct {
-	NgrokAPIKey    string `json:"apiKey"`
-	NgrokAuthToken string `json:"authtoken"`
+	NgrokAPIKey    string `json:"apiKey" yaml:"apiKey"`
+	NgrokAuthToken string `json:"authtoken" yaml:"authtoken"`
 }
 type deployRancherIngressValuesFile struct {
-	Credentials ngrokCredentials `json:"credentials"`
+	Credentials ngrokCredentials `json:"credentials" yaml:"credentials"`
 }
 
 // DeployRancher deploys Rancher using the provided input parameters.


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Summary of changes introduced in this PR:
- Added a helper for deploying the providers chart.
- Updated the gitops import suite to use the providers chart for provider deployment.
- Left all other tests unchanged, usage of the chart remains optional.
- Improved the upgrade test to verify that installing this chart on top of Turtles does not cause any issues.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher/turtles/issues/1633

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
