### PR TITLE
test: cleanup import gitops suite/spec

### DIFF
--- a/.github/workflows/e2e-long.yaml
+++ b/.github/workflows/e2e-long.yaml
@@ -16,13 +16,13 @@ jobs:
   publish_e2e_image:
     uses: ./.github/workflows/e2e-image-publish.yaml
     secrets: inherit
-  e2e_import_gitops_v3:
+  e2e_import_gitops:
     needs: publish_e2e_image
     uses: ./.github/workflows/run-e2e-suite.yaml
     with:
-      test_suite: test/e2e/suites/import-gitops-v3
-      test_name: Import via GitOps [v3]
-      artifact_name: import_gitops_v3
+      test_suite: test/e2e/suites/import-gitops
+      test_name: Import via GitOps
+      artifact_name: import_gitops
       MANAGEMENT_CLUSTER_ENVIRONMENT: eks
     secrets: inherit
   e2e_v2prov:
@@ -36,6 +36,6 @@ jobs:
     secrets: inherit
   e2e_cleanup:
     if: always()
-    needs: [e2e_import_gitops_v3, e2e_v2prov]
+    needs: [e2e_import_gitops, e2e_v2prov]
     uses: ./.github/workflows/e2e-cleanup.yaml
     secrets: inherit

--- a/test/e2e/specs/import_gitops.go
+++ b/test/e2e/specs/import_gitops.go
@@ -52,7 +52,7 @@ import (
 	turtlesannotations "github.com/rancher/turtles/util/annotations"
 )
 
-type CreateMgmtV3UsingGitOpsSpecInput struct {
+type CreateUsingGitOpsSpecInput struct {
 	E2EConfig             *clusterctl.E2EConfig
 	BootstrapClusterProxy framework.ClusterProxy
 	ArtifactFolder        string `env:"ARTIFACTS_FOLDER"`
@@ -96,12 +96,12 @@ type CreateMgmtV3UsingGitOpsSpecInput struct {
 	AdditionalFleetGitRepos []turtlesframework.FleetCreateGitRepoInput
 }
 
-// CreateMgmtV3UsingGitOpsSpec implements a spec that will create a cluster via Fleet and test that it
+// CreateUsingGitOpsSpec implements a spec that will create a cluster via Fleet and test that it
 // automatically imports into Rancher Manager.
-func CreateMgmtV3UsingGitOpsSpec(ctx context.Context, inputGetter func() CreateMgmtV3UsingGitOpsSpecInput) {
+func CreateUsingGitOpsSpec(ctx context.Context, inputGetter func() CreateUsingGitOpsSpecInput) {
 	var (
 		specName              = "creategitops"
-		input                 CreateMgmtV3UsingGitOpsSpecInput
+		input                 CreateUsingGitOpsSpecInput
 		namespace             *corev1.Namespace
 		cancelWatches         context.CancelFunc
 		capiCluster           *types.NamespacedName
@@ -326,7 +326,7 @@ func CreateMgmtV3UsingGitOpsSpec(ctx context.Context, inputGetter func() CreateM
 
 			switch readyCondition.Status {
 			case corev1.ConditionTrue:
-				//Cluster is ready
+				// Cluster is ready
 				return nil
 			case corev1.ConditionFalse:
 				return fmt.Errorf("Cluster is not Ready")

--- a/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
+++ b/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
@@ -91,8 +91,8 @@ var _ = Describe("Chart upgrade functionality should work", Ordered, Label(e2e.S
 	Context("Provisioning a workload Cluster", func() {
 		// Provision a workload Cluster.
 		// This ensures that upgrading the chart will not unexpectedly lead to unready Cluster or Machines.
-		specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
-			return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
+			return specs.CreateUsingGitOpsSpecInput{
 				E2EConfig:                      e2e.LoadE2EConfig(),
 				BootstrapClusterProxy:          bootstrapClusterProxy,
 				ClusterTemplate:                e2e.CAPIDockerRKE2Topology,

--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -17,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package import_gitops_v3
+package import_gitops
 
 import (
 	"context"
@@ -48,7 +48,7 @@ var _ = Describe("[Docker] [Kubeadm]  Create and delete CAPI cluster functionali
 		topologyNamespace = "creategitops-docker-kubeadm"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersOCIYAML: []testenv.OCIProvider{
@@ -60,11 +60,11 @@ var _ = Describe("[Docker] [Kubeadm]  Create and delete CAPI cluster functionali
 			WaitForDeployments: testenv.DefaultDeployments,
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIDockerKubeadmTopology,
-			ClusterName:                    "clusterv3-auto-import-kubeadm",
+			ClusterName:                    "cluster-docker-kubeadm",
 			ControlPlaneMachineCount:       ptr.To(1),
 			WorkerMachineCount:             ptr.To(1),
 			LabelNamespace:                 true,
@@ -104,7 +104,7 @@ var _ = Describe("[Docker] [RKE2] Create and delete CAPI cluster functionality s
 		topologyNamespace = "creategitops-docker-rke2"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersYAML: [][]byte{
@@ -113,11 +113,11 @@ var _ = Describe("[Docker] [RKE2] Create and delete CAPI cluster functionality s
 			WaitForDeployments: testenv.DefaultDeployments,
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIDockerRKE2Topology,
-			ClusterName:                    "clusterv3-auto-import-rke2",
+			ClusterName:                    "cluster-docker-rke2",
 			ControlPlaneMachineCount:       ptr.To(1),
 			WorkerMachineCount:             ptr.To(1),
 			LabelNamespace:                 true,
@@ -157,7 +157,7 @@ var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster clas
 		topologyNamespace = "creategitops-azure-aks"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -177,7 +177,7 @@ var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster clas
 			},
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAzureAKSTopology,
@@ -204,7 +204,7 @@ var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster clas
 	})
 })
 
-var _ = Describe("[Azure] [Kubeadm] - [management.cattle.io/v3] Create and delete CAPI cluster from cluster class", Label(e2e.FullTestLabel, e2e.KubeadmTestLabel), func() {
+var _ = Describe("[Azure] [Kubeadm] Create and delete CAPI cluster from cluster class", Label(e2e.FullTestLabel, e2e.KubeadmTestLabel), func() {
 	var topologyNamespace string
 
 	BeforeEach(func() {
@@ -214,7 +214,7 @@ var _ = Describe("[Azure] [Kubeadm] - [management.cattle.io/v3] Create and delet
 		topologyNamespace = "creategitops-azure-kubeadm"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -235,7 +235,7 @@ var _ = Describe("[Azure] [Kubeadm] - [management.cattle.io/v3] Create and delet
 			},
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAzureKubeadmTopology,
@@ -278,7 +278,7 @@ var _ = Describe("[Azure] [Kubeadm] - [management.cattle.io/v3] Create and delet
 	})
 })
 
-var _ = Describe("[Azure] [RKE2] - [management.cattle.io/v3] Create and delete CAPI cluster from cluster class", Label(e2e.FullTestLabel, e2e.Rke2TestLabel), func() {
+var _ = Describe("[Azure] [RKE2] Create and delete CAPI cluster from cluster class", Label(e2e.FullTestLabel, e2e.Rke2TestLabel), func() {
 	var topologyNamespace string
 
 	BeforeEach(func() {
@@ -288,7 +288,7 @@ var _ = Describe("[Azure] [RKE2] - [management.cattle.io/v3] Create and delete C
 		topologyNamespace = "creategitops-azure-rke2"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -308,7 +308,7 @@ var _ = Describe("[Azure] [RKE2] - [management.cattle.io/v3] Create and delete C
 			},
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAzureRKE2Topology,
@@ -354,7 +354,7 @@ var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster functionality shoul
 		komega.SetContext(ctx)
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -371,7 +371,7 @@ var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster functionality shoul
 			},
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAwsEKSMMP,
@@ -399,7 +399,7 @@ var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionali
 		topologyNamespace = "creategitops-aws-kubeadm"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -417,7 +417,7 @@ var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionali
 			}, testenv.DefaultDeployments...),
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAwsKubeadmTopology,
@@ -476,7 +476,7 @@ var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality 
 		topologyNamespace = "creategitops-aws-rke2"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -493,11 +493,11 @@ var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality 
 			},
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIAwsEC2RKE2Topology,
-			ClusterName:                    "cluster-ec2-rke2",
+			ClusterName:                    "cluster-aws-rke2",
 			ControlPlaneMachineCount:       ptr.To(1),
 			WorkerMachineCount:             ptr.To(1),
 			LabelNamespace:                 true,
@@ -548,7 +548,7 @@ var _ = Describe("[GCP] [Kubeadm] Create and delete CAPI cluster functionality s
 		topologyNamespace = "creategitops-gcp-kubeadm"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -566,7 +566,7 @@ var _ = Describe("[GCP] [Kubeadm] Create and delete CAPI cluster functionality s
 			}, testenv.DefaultDeployments...),
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIGCPKubeadmTopology,
@@ -611,7 +611,7 @@ var _ = Describe("[GCP] [GKE] Create and delete CAPI cluster functionality shoul
 		komega.SetContext(ctx)
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			CAPIProvidersSecretsYAML: [][]byte{
@@ -628,7 +628,7 @@ var _ = Describe("[GCP] [GKE] Create and delete CAPI cluster functionality shoul
 			},
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIGCPGKE,
@@ -656,7 +656,7 @@ var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster from cluste
 		topologyNamespace = "creategitops-vsphere-kubeadm"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		By("Running local vSphere tests, deploying vSphere infrastructure provider")
 
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
@@ -676,7 +676,7 @@ var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster from cluste
 			}, testenv.DefaultDeployments...),
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIvSphereKubeadmTopology,
@@ -731,7 +731,7 @@ var _ = Describe("[vSphere] [RKE2] Create and delete CAPI cluster functionality 
 		topologyNamespace = "creategitops-vsphere-rke2"
 	})
 
-	specs.CreateMgmtV3UsingGitOpsSpec(ctx, func() specs.CreateMgmtV3UsingGitOpsSpecInput {
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		By("Running local vSphere tests, deploying vSphere infrastructure provider")
 
 		testenv.CAPIOperatorDeployProvider(ctx, testenv.CAPIOperatorDeployProviderInput{
@@ -750,7 +750,7 @@ var _ = Describe("[vSphere] [RKE2] Create and delete CAPI cluster functionality 
 			},
 		})
 
-		return specs.CreateMgmtV3UsingGitOpsSpecInput{
+		return specs.CreateUsingGitOpsSpecInput{
 			E2EConfig:                      e2e.LoadE2EConfig(),
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIvSphereRKE2Topology,

--- a/test/e2e/suites/import-gitops/suite_test.go
+++ b/test/e2e/suites/import-gitops/suite_test.go
@@ -17,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package import_gitops_v3
+package import_gitops
 
 import (
 	"context"


### PR DESCRIPTION
**What this PR does / why we need it**:

We no longer support using `v1` clusters but we still maintain the naming (and structure) of the `import-gitops` E2E test suite as it was when we had testing for both scenarios. This PR simply cleans this up.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
