### PR TITLE
Display kind and docker version in e2e runs

### DIFF
--- a/.github/workflows/e2e-short.yaml
+++ b/.github/workflows/e2e-short.yaml
@@ -26,6 +26,10 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: go.mod
+      - name: Display kind version
+        run: kind version
+      - name: Display docker version
+        run: docker version
       - name: Run e2e tests
         run: make test-e2e
       - name: Collect run artifacts

--- a/.github/workflows/run-e2e-suite.yaml
+++ b/.github/workflows/run-e2e-suite.yaml
@@ -97,6 +97,10 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: go.mod
+      - name: Display kind version
+        run: kind version
+      - name: Display docker version
+        run: docker version
       - name: Docker login
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/run-vsphere-tests.yaml
+++ b/.github/workflows/run-vsphere-tests.yaml
@@ -40,6 +40,10 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: go.mod
+      - name: Display kind version
+        run: kind version
+      - name: Display docker version
+        run: docker version
       - name: Run e2e tests
         run: make test-e2e
       - name: Collect run artifacts

--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -63,6 +63,12 @@ jobs:
           cluster_name: kind
           node_image: kindest/node:v1.31.4
 
+      - name: Display kind version
+        run: kind version
+
+      - name: Display docker version
+        run: docker version
+
       - name: Add local docker image
         run: kind load docker-image ${{ env.MANIFEST_IMG }}:${{ env.TAG }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR dumps the `kind` and `docker` version when running e2e tests. 

There is no process to pin these versions, it depends on what is installed on the runner. 
Would be good to at least display somewhere the versions used for reference and to reproduce issues locally.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
