### PR TITLE
Bump forward CAPA to v2.9.1 patch release

### DIFF
--- a/internal/controllers/clusterctl/config-prime.yaml
+++ b/internal/controllers/clusterctl/config-prime.yaml
@@ -16,7 +16,7 @@ data:
 
     # Infrastructure providers
     - name:         "aws"
-      url:          "https://github.com/rancher-sandbox/cluster-api-provider-aws/releases/v2.9.0/infrastructure-components.yaml"
+      url:          "https://github.com/rancher-sandbox/cluster-api-provider-aws/releases/v2.9.1/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "azure"
       url:          "https://github.com/rancher-sandbox/cluster-api-provider-azure/releases/v1.21.0/infrastructure-components.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:
To fix the issue reported by @alexander-demicev:

```
Recent CAPI providers bump installs 2 incompatible versions of CAPZ/CAPA. AzureManagedClusterTemplate and AWSManagedClusterTemplate use the same short name `amct`
The test can pass sometimes if  AzureManagedClusterTemplate is registered first, in this case there is no conflict. AWSManagedClusterTemplate is not used in our tests this is why we don't see any issues with it yet.
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
