### PR TITLE
Print error in artifacts collection instead of failing the suite

### DIFF
--- a/test/e2e/specs/import_gitops.go
+++ b/test/e2e/specs/import_gitops.go
@@ -375,21 +375,15 @@ func CreateUsingGitOpsSpec(ctx context.Context, inputGetter func() CreateUsingGi
 	AfterEach(func() {
 		By(fmt.Sprintf("Collecting artifacts for %s/%s", input.ClusterName, specName))
 
-		err := testenv.CollectArtifacts(ctx, testenv.CollectArtifactsInput{
+		testenv.TryCollectArtifacts(ctx, testenv.CollectArtifactsInput{
 			Path:                    input.ClusterName + "-bootstrap-" + specName,
 			BootstrapKubeconfigPath: input.BootstrapClusterProxy.GetKubeconfigPath(),
 		})
-		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to collect artifacts for the bootstrap cluster")
-		}
 
-		err = testenv.CollectArtifacts(ctx, testenv.CollectArtifactsInput{
+		testenv.TryCollectArtifacts(ctx, testenv.CollectArtifactsInput{
 			KubeconfigPath: originalKubeconfig.TempFilePath,
 			Path:           input.ClusterName + "-workload-" + specName,
 		})
-		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to collect artifacts for the child cluster")
-		}
 
 		// If SKIP_RESOURCE_CLEANUP=true & if the SkipDeletionTest is true, all the resources should stay as they are,
 		// nothing should be deleted. If SkipDeletionTest is true, deleting the git repo will delete the clusters too.

--- a/test/e2e/suites/v2prov/v2prov_test.go
+++ b/test/e2e/suites/v2prov/v2prov_test.go
@@ -30,7 +30,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	provisioningv1 "github.com/rancher/turtles/api/rancher/provisioning/v1"
 	"github.com/rancher/turtles/test/e2e"
@@ -171,24 +170,18 @@ var _ = Describe("[v2prov] [Azure] Creating a cluster with v2prov should still w
 	AfterEach(func() {
 		By(fmt.Sprintf("Collecting artifacts for %s/%s", clusterName, specName))
 
-		err := testenv.CollectArtifacts(ctx, testenv.CollectArtifactsInput{
+		testenv.TryCollectArtifacts(ctx, testenv.CollectArtifactsInput{
 			Path:                    clusterName + "-bootstrap-" + specName,
 			BootstrapKubeconfigPath: bootstrapClusterProxy.GetKubeconfigPath(),
 		})
-		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to collect artifacts for the bootstrap cluster")
-		}
 
-		err = testenv.CollectArtifacts(ctx, testenv.CollectArtifactsInput{
+		testenv.TryCollectArtifacts(ctx, testenv.CollectArtifactsInput{
 			KubeconfigPath: rancherKubeconfig.TempFilePath,
 			Path:           clusterName + "-workload-" + specName,
 		})
-		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to collect artifacts for the child cluster")
-		}
 
 		By("Deleting cluster from Rancher")
-		err = bootstrapClusterProxy.GetClient().Delete(ctx, rancherCluster)
+		err := bootstrapClusterProxy.GetClient().Delete(ctx, rancherCluster)
 		Expect(err).NotTo(HaveOccurred(), "Failed to delete rancher cluster")
 
 		By("Waiting for the rancher cluster record to be removed")


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Sometime when artifact collection fails we can't read the error because it's encoded and the whole suite fails. This PR make artifact collection optional and changes output print.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
