### PR TITLE
Add helm policy keep to installed providers

### DIFF
--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -103,8 +103,18 @@ jobs:
       - name: Wait for RKE2 control plane provider rollout
         run: sleep 30 && kubectl rollout status deployment rke2-control-plane-controller-manager -n rke2-control-plane-system --timeout=10m
 
+      - name: Wait for CAAPF provider rollout
+        run: sleep 30 && kubectl rollout status deployment caapf-controller-manager -n rancher-turtles-system --timeout=10m
+
       - name: Run chart-testing (un-install)
         run: helm uninstall rancher-turtles -n rancher-turtles-system --cascade foreground --wait --debug --timeout=10m
+
+      - name: Verify CAPIProvider CRs persist after uninstall
+        run: |
+          set -euo pipefail
+          kubectl get capiprovider rke2-bootstrap -n rke2-bootstrap-system
+          kubectl get capiprovider rke2-control-plane -n rke2-control-plane-system
+          kubectl get capiprovider fleet -n rancher-turtles-system
 
       - name: Run chart re-install
         run: helm install rancher-turtles out/charts/rancher-turtles/ -n rancher-turtles-system --create-namespace --wait --debug

--- a/charts/rancher-turtles/templates/addon-provider-fleet.yaml
+++ b/charts/rancher-turtles/templates/addon-provider-fleet.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "2"
+    "helm.sh/resource-policy": keep
 spec:
   enableAutomaticUpdate: true
   type: addon
@@ -21,6 +22,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "2"
+    "helm.sh/resource-policy": keep
 data:
   manifests: |-
     apiVersion: addons.cluster.x-k8s.io/v1alpha1

--- a/charts/rancher-turtles/templates/pre-delete-job.yaml
+++ b/charts/rancher-turtles/templates/pre-delete-job.yaml
@@ -59,9 +59,11 @@ spec:
           image: {{ index .Values "rancherTurtles" "kubectlImage" }}
           args:
           - delete
-          - capiproviders
-          - -A
-          - --all
+          - capiprovider
+          - cluster-api
+          - -n
+          - {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
+          - --ignore-not-found=true
           - --cascade=foreground
       restartPolicy: Never
 {{- end }}

--- a/charts/rancher-turtles/templates/rke2-bootstrap.yaml
+++ b/charts/rancher-turtles/templates/rke2-bootstrap.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "1"
+    "helm.sh/resource-policy": keep
   name: {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "bootstrap" "namespace" }}
 {{- end }}
 ---
@@ -19,6 +20,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "2"
+    "helm.sh/resource-policy": keep
 spec:
   name: rke2
   type: bootstrap

--- a/charts/rancher-turtles/templates/rke2-controlplane.yaml
+++ b/charts/rancher-turtles/templates/rke2-controlplane.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "1"
+    "helm.sh/resource-policy": keep
   name: {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "controlPlane" "namespace" }}
 {{- end }}
 ---
@@ -19,6 +20,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "2"
+    "helm.sh/resource-policy": keep
 spec:
   name: rke2
   type: controlPlane


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Add helm policy keep to installed providers in Turtles chart. That should help users migrate once we remove these templates from Turtles chart.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher/turtles/issues/1719

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
