### PR TITLE
chart: enable optional fetchConfig for fleet provider

### DIFF
--- a/charts/rancher-turtles/templates/addon-provider-fleet.yaml
+++ b/charts/rancher-turtles/templates/addon-provider-fleet.yaml
@@ -13,6 +13,15 @@ spec:
   additionalManifests:
     name: fleet-addon-config
     namespace: '{{ .Values.rancherTurtles.namespace }}'
+{{- if or (index .Values "cluster-api-operator" "cluster-api" "fleet" "addon" "fetchConfig" "url") (index .Values "cluster-api-operator" "cluster-api" "fleet" "addon" "fetchConfig" "selector") }}
+  fetchConfig:
+    {{- if index .Values "cluster-api-operator" "cluster-api" "fleet" "addon" "fetchConfig" "url" }}
+    url: {{ index .Values "cluster-api-operator" "cluster-api" "fleet" "addon" "fetchConfig" "url" }}
+    {{- end }}
+    {{- if index .Values "cluster-api-operator" "cluster-api" "fleet" "addon" "fetchConfig" "selector" }}
+    selector: {{ index .Values "cluster-api-operator" "cluster-api" "fleet" "addon" "fetchConfig" "selector" }}
+    {{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -140,3 +140,8 @@ cluster-api-operator:
           url: ""
           # selector: Config selector.
           selector: ""
+    fleet:
+      addon:
+        fetchConfig:
+          url: ""
+          selector: ""


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently it's not possible to configure the fetchConfig like with the other included CAPIProvider resources, which means deploying in an airgap scenario won't work without modifying that resource.

This addition enables configuration to be specified in a consistent way for the included providers, e.g:

```
cluster-api-operator:
  cluster-api:
    core:
      fetchConfig:
        selector: "{\"matchLabels\": {\"provider-components\": \"core\"}}"
    rke2:
      bootstrap:
        fetchConfig:
          selector: "{\"matchLabels\": {\"provider-components\": \"rke2-bootstrap\"}}"
      controlPlane:
        fetchConfig:
          selector: "{\"matchLabels\": {\"provider-components\": \"rke2-control-plane\"}}"
    fleet:
      addon:
        fetchConfig:
          selector: "{\"matchLabels\": {\"provider-components\": \"fleet\"}}"
```
kind/bug
