### PR TITLE
cleanup release workflow and build action

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -20,15 +20,17 @@ jobs:
         include:
         - destination: ghcr
           registry: ghcr.io
+          org: RANCHER_ORG
+          image: IMAGE_NAME
           username: ${{ github.actor }}
           password: GITHUB_TOKEN
-          image: GHCR_IMAGE
           secret_registry: false
         - destination: prod
-          registry: REGISTRY_ENDPOINT
+          registry: PRIME_REGISTRY_ENDPOINT
+          org: RANCHER_ORG
+          image: IMAGE_NAME
           username: REGISTRY_USERNAME
           password: REGISTRY_PASSWORD
-          image: REGISTRY_IMAGE
           secret_registry: true
     name: Release
     uses: ./.github/workflows/release.yml
@@ -36,8 +38,9 @@ jobs:
       password: ${{ matrix.password }}
       username: ${{ matrix.username }}
       registry: ${{ matrix.registry }}
-      tag: ${{ github.ref_name }}
+      org: $${{ matrix.org }}
       image: ${{ matrix.image }}
+      tag: ${{ github.ref_name }}
       secret_registry: ${{ matrix.secret_registry }}
     secrets: inherit
 
@@ -47,11 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TAG: ${{ github.ref_name }}
-      CONTROLLER_IMG: ${{ vars.REGISTRY_IMAGE }}
-      PROD_REGISTRY: ${{ secrets.REGISTRY_ENDPOINT }}
-      PROD_ORG: rancher
+      ORG: ${{ vars.RANCHER_ORG }}
+      CONTROLLER_IMG: ${{ vars.IMAGE_NAME }}
       RELEASE_DIR: .cr-release-packages
-      CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
       - name: Checkout
@@ -62,17 +63,12 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: go.mod
-      - name: Get prod multiarch image digest
-        run: | 
-          docker pull ${{ env.CONTROLLER_IMG }}:${{ env.TAG }}
-          multiarch_digest=$( docker inspect --format='{{index .RepoDigests 0}}' ${{ env.CONTROLLER_IMG }}:${{ env.TAG }} | sed 's/.*@//' )
-          echo "multiarch_digest=${multiarch_digest}" >> $GITHUB_ENV
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Package operator chart
-        run: RELEASE_TAG=${GITHUB_REF##*/} CHART_PACKAGE_DIR=${RELEASE_DIR} REGISTRY=${{ env.PROD_REGISTRY }} ORG=${{ env.PROD_ORG }} make release
+        run: RELEASE_TAG=${GITHUB_REF##*/} CHART_PACKAGE_DIR=${RELEASE_DIR} CONTROLLER_IMG="${{ env.ORG }}/${{ env.CONTROLLER_IMG }}" ORG=${{ env.ORG }} make release
 
       - name: Install chart-releaser
         uses: helm/chart-releaser-action@v1.7.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ on:
         type: string
         description: Organization part of the image name
         required: false
-        default: "rancher"
 
 jobs:
   build:
@@ -56,9 +55,10 @@ jobs:
         id: image
         uses: ./.github/workflows/release_build
         with:
-          tag: ${{ inputs.tag }}
-          org: ${{ inputs.org }}
           registry: ${{ inputs.secret_registry && secrets[inputs.registry] || inputs.registry }}
+          org: ${{ vars[inputs.org] }}
+          image: ${{ vars[inputs.image] }}
+          tag: ${{ inputs.tag }}
           username: ${{ inputs.secret_registry && secrets[inputs.username] || inputs.username }}
           password: ${{ secrets[inputs.password] }}
 
@@ -78,9 +78,9 @@ jobs:
       - name: Sign image with cosign
         uses: ./.github/workflows/release_sign
         with:
-          image: ${{ vars[inputs.image] }}
+          image: ${{ inputs.secret_registry && secrets[inputs.registry] || inputs.registry }}/${{ vars[inputs.org] }}/${{ vars[inputs.image] }}
           digest: ${{ needs.build.outputs.digest }}
-          identity: https://github.com/${{ inputs.org }}/turtles/.github/workflows/release.yml@${{ github.ref }}
+          identity: https://github.com/${{ vars[inputs.org] }}/turtles/.github/workflows/release.yml@${{ github.ref }}
           oids-issuer: https://token.actions.githubusercontent.com
           registry: ${{ inputs.secret_registry && secrets[inputs.registry] || inputs.registry }}
           username: ${{ inputs.secret_registry && secrets[inputs.username] || inputs.username }}

--- a/.github/workflows/release_build/action.yaml
+++ b/.github/workflows/release_build/action.yaml
@@ -1,19 +1,24 @@
 name: "Build release"
 description: "Builds release image and pushes to the registry"
 inputs:
-  tag:
-    description: "Image tag"
+  registry:
+    description: "The registry to login"
+    required: true
     type: string
-    default: "github-actions"
   org:
     description: "Organization part of the image path"
     required: false
     default: "rancher"
     type: string
-  registry:
-    description: "The registry to login"
-    required: true
+  image:
+    description: "Name of the image that is built"
+    required: false
+    default: "turtles"
     type: string
+  tag:
+    description: "Image tag"
+    type: string
+    default: "github-actions"
   username:
     description: "The username to registry"
     required: true
@@ -51,6 +56,6 @@ runs:
         make docker-build-and-push TAG=${{ inputs.tag }} REGISTRY=${{ inputs.registry }} ORG=${{ inputs.org }} IID_FILE=${IID_FILE}
 
         digest=$(head -n 1 ${IID_FILE})
-        image=${{ inputs.registry }}/${{ inputs.org }}/turtles
+        image=${{ inputs.registry }}/${{ inputs.org }}/${{ inputs.image }}
         echo "digest=${digest}" >> $GITHUB_OUTPUT
         echo "image=${image}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR tries to resolve a few issues found on the existing release process, and cleans up some unused pieces of code/variables/secrets.
- We were using the full path to images, as in `<registry>/<org>/<image>`, as parameters and this will now use the specific values to form the full path dynamically.
- Rancher registry included a duplicate organization name in the path `rancher/rancher`, which we've been pushing (and pulling) images to (and from) until now. We should change this from now on.
- The new chart building for integrating Turtles in `rancher/charts` needs the image in `values.yaml` to contain `<org>/<image>`, e.g. `rancher/turtles`, as registry will be appended by Rancher for either community or prime.
- A step of the release process that was originally used for creating digest and that is no longer in use is removed from the workflow. Digests are already handled in the new [release workflow](https://github.com/rancher/turtles/blob/ed9d05cf36c9fc8daf834bb8afe7f45d9edd58cd/.github/workflows/release-v2.yaml#L141).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Let's create a release candidate and monitor how theses changes affect the release process and fix any issues. It's hard to troubleshoot otherwise.

New variables and secrets have been added to the repository settings and some, that will no longer be used after this change is merged, are still available in case we need to revert the changes. Once we've release successfully, I'll go ahead and remove the unused parameters.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
