### PR TITLE
Use bash in release-against-rancher.sh for pushd/popd support

### DIFF
--- a/.github/scripts/release-against-rancher.sh
+++ b/.github/scripts/release-against-rancher.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Bumps Turtles version in a locally checked out rancher/rancher repository
 #


### PR DESCRIPTION
**What this PR does / why we need it**:

To fix errors from rancher/rancher [automation](https://github.com/rancher/turtles/actions/runs/17972126898/job/51117048173) workflow
where previously started with `#!/bin/sh`, which uses dash on Ubuntu runners.
dash does not support `pushd/popd`, causing the workflow to fail with:
`
Run cd rancher
  cd rancher
  BRANCH="bump-turtles-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
  echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
  git checkout -b "$BRANCH" "$RANCHER_REF"
  ../turtles/.github/scripts/release-against-rancher.sh . "$NEW_TURTLES" false
  shell: /usr/bin/bash -e {0}
  env:
    RANCHER_REF: main
    TURTLES_REF: main
    PREV_TURTLES: v0.25.0-rc.0
    NEW_TURTLES: v0.25.0-rc.1
    GH_TOKEN: ***
Switched to a new branch 'bump-turtles-17972126898-1'
../turtles/.github/scripts/release-against-rancher.sh: 78: pushd: not found
Error: Process completed with exit code 127.
`

PR updates the script to `#!/bin/bash` so it runs with bash and supports all required built-ins.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
