### PR TITLE
fix: Drop CAPRKE2 from expected set of default deployments

### DIFF
--- a/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
+++ b/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
@@ -88,7 +88,27 @@ var _ = Describe("Chart upgrade functionality should work", Ordered, Label(e2e.S
 			CAPIProvidersYAML: [][]byte{
 				e2e.CapiProviders,
 			},
-			WaitForDeployments: testenv.DefaultDeployments,
+			WaitForDeployments: []testenv.NamespaceName{
+				{
+					Name:      "capi-controller-manager",
+					Namespace: "capi-system",
+				}, {
+					Name:      "capi-kubeadm-bootstrap-controller-manager",
+					Namespace: "capi-kubeadm-bootstrap-system",
+				}, {
+					Name:      "capi-kubeadm-control-plane-controller-manager",
+					Namespace: "capi-kubeadm-control-plane-system",
+				}, {
+					Name:      "capd-controller-manager",
+					Namespace: "capd-system",
+				}, {
+					Name:      "rke2-bootstrap-controller-manager",
+					Namespace: "rke2-bootstrap-system",
+				}, {
+					Name:      "rke2-control-plane-controller-manager",
+					Namespace: "rke2-control-plane-system",
+				},
+			},
 		})
 	})
 

--- a/test/testenv/turtles.go
+++ b/test/testenv/turtles.go
@@ -49,12 +49,6 @@ var DefaultDeployments = []NamespaceName{
 	}, {
 		Name:      "capd-controller-manager",
 		Namespace: "capd-system",
-	}, {
-		Name:      "rke2-bootstrap-controller-manager",
-		Namespace: "rke2-bootstrap-system",
-	}, {
-		Name:      "rke2-control-plane-controller-manager",
-		Namespace: "rke2-control-plane-system",
 	},
 }
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR should fix the  BeforeSuite for the v2prov e2e tests. CAPRKE2 is no longer expected to be running after installing the rancher-turtles chart. This part was missed from https://github.com/rancher/turtles/pull/1789.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
