### PR TITLE
[release/v0.25] remove clusterclass-operations from values.yaml

### DIFF
--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -41,16 +41,6 @@ features:
   no-cert-manager:
     # enabled: Turn on or off.
     enabled: false
-  # clusterclass-operations: Alpha feature. Manages cluster class ops. Not ready for testing yet.
-  clusterclass-operations:
-    # enabled: Turn on or off.
-    enabled: false
-    # image: Image for cluster class ops.
-    image: controller
-    # imageVersion: Image tag.
-    imageVersion: v0.0.0
-    # imagePullPolicy: Pull policy.
-    imagePullPolicy: IfNotPresent
 # volumes: Volumes for controller pods.
 volumes:
   - name: clusterctl-config


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up to: https://github.com/rancher/turtles/pull/1783 to cleanup leftover clusterclass-operations from values.yaml
Backport of #1800 

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
