### PR TITLE
[do-not-merge] fix: revert removal of pre-install job

### DIFF
--- a/charts/rancher-turtles/templates/pre-install-job.yaml
+++ b/charts/rancher-turtles/templates/pre-install-job.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.rancherInstalled }}
+apiVersion: management.cattle.io/v3
+kind: Feature
+metadata:
+  name: embedded-cluster-api
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+spec:
+  value: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pre-install-job
+  namespace: '{{ .Values.namespace }}'
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pre-install-job-delete-webhooks
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pre-install-job-webhook-cleanup
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+subjects:
+  - kind: ServiceAccount
+    name: pre-install-job
+    namespace: '{{ .Values.namespace }}'
+roleRef:
+  kind: ClusterRole
+  name: pre-install-job-delete-webhooks
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rancher-mutatingwebhook-cleanup
+  namespace: '{{ .Values.namespace }}'
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "2"
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: pre-install-job
+      containers:
+        - name: rancher-mutatingwebhook-cleanup
+          image: {{ index .Values "kubectlImage" }}
+          args:
+          - delete
+          - mutatingwebhookconfigurations.admissionregistration.k8s.io
+          - mutating-webhook-configuration
+          - --ignore-not-found=true
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rancher-validatingwebhook-cleanup
+  namespace: '{{ .Values.namespace }}'
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "2"
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: pre-install-job
+      containers:
+        - name: rancher-validatingwebhook-cleanup
+          image: {{ index .Values "kubectlImage" }}
+          args:
+          - delete
+          - validatingwebhookconfigurations.admissionregistration.k8s.io
+          - validating-webhook-configuration
+          - --ignore-not-found=true
+      restartPolicy: Never
+{{- end }}

--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -75,16 +75,6 @@ envsubst <test/e2e/data/rancher/ingress.yaml | kubectl apply -f -
 envsubst <test/e2e/data/rancher/rancher-setting-patch.yaml | kubectl apply -f -
 kubectl apply -f test/e2e/data/rancher/system-store-setting-patch.yaml
 
-pre_install_configuration() {
-    kubectl apply -f test/e2e/data/rancher/pre-turtles-install.yaml
-    kubectl delete \
-        mutatingwebhookconfiguration mutating-webhook-configuration \
-        --ignore-not-found
-    kubectl delete \
-        validatingwebhookconfiguration validating-webhook-configuration \
-        --ignore-not-found
-}
-
 # Install the locally build chart of Rancher Turtles
 install_local_rancher_turtles_chart() {
     # Remove the previous chart directory
@@ -125,9 +115,6 @@ install_local_providers_chart() {
         --create-namespace --wait \
         --timeout 180s
 }
-
-# patch the removed pre-install hook
-pre_install_configuration
 
 echo "Installing local Rancher Turtles chart for development..."
 install_local_rancher_turtles_chart

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -136,9 +136,6 @@ var (
 
 	//go:embed data/test-providers/clusterctlconfig-updated.yaml
 	ClusterctlConfigUpdated []byte
-
-	//go:embed data/rancher/pre-turtles-install.yaml
-	RancherTurtlesPreInstall []byte
 )
 
 const (

--- a/test/e2e/data/rancher/pre-turtles-install.yaml
+++ b/test/e2e/data/rancher/pre-turtles-install.yaml
@@ -1,6 +1,0 @@
-apiVersion: management.cattle.io/v3
-kind: Feature
-metadata:
-  name: embedded-cluster-api
-spec:
-  value: false

--- a/test/testenv/turtles.go
+++ b/test/testenv/turtles.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testenv
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os/exec"
@@ -159,31 +158,6 @@ func DeployRancherTurtles(ctx context.Context, input DeployRancherTurtlesInput) 
 		}
 		_, err := addChart.Run(nil)
 		Expect(err).ToNot(HaveOccurred())
-	}
-
-	// this is a temporary workaround for installing turtles chart as extension
-	// after the pre-install hook has been removed and before it becomes a part of Rancher.
-	By("Disabling Rancher embedded CAPI")
-	Expect(turtlesframework.Apply(ctx, input.BootstrapClusterProxy, e2e.RancherTurtlesPreInstall)).To(Succeed())
-	webhooks := map[string]string{
-		"mutatingwebhookconfiguration":   "mutating-webhook-configuration",
-		"validatingwebhookconfiguration": "validating-webhook-configuration",
-	}
-	for wtype, wname := range webhooks {
-		By("Removing " + wname + " webhook")
-		cmd := exec.Command("kubectl", []string{
-			"--kubeconfig", input.BootstrapClusterProxy.GetKubeconfigPath(),
-			"delete",
-			wtype, wname,
-			"--ignore-not-found",
-		}...)
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		cmd.WaitDelay = time.Minute
-
-		err := cmd.Run()
-		Expect(err).ToNot(HaveOccurred(), "Failed to remove webhook %s: %s", wname, stderr.String())
 	}
 
 	By("Installing rancher-turtles chart")


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade from `rancher:v2.12.2` to `rancher:v2.13-head` is [failing](https://github.com/rancher/rancher/issues/52319) because webhooks are not cleaned-up. This reverts the commit where we removed this functionality. It's a full revert of the original commit, which also includes disabling `embedded-cluster-api` feature. This is not related to the bug but it does no harm having it and simplifies the fix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
