### PR TITLE
:bug: fix: wrong github token value in core capi workflow

### DIFF
--- a/.github/workflows/fetch-core-capi-airgapped.yml
+++ b/.github/workflows/fetch-core-capi-airgapped.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   TURTLES_REF: "${{ github.ref_name }}"
-  GH_TOKEN: "${{ secrets.GH_TOKEN }}"
+  GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
 jobs:
   create-core-capi-turtles-pr:


### PR DESCRIPTION
**What this PR does / why we need it**:

The recently introduced GitHub Action that retrieves the core CAPI manifest is failing to authenticate as it uses an incorrect token name: https://github.com/rancher/turtles/actions/runs/18546504619/job/52865509132.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
