### PR TITLE
feat: Install Turtles as system chart in dev-env

### DIFF
--- a/charts/rancher-turtles/Chart.yaml
+++ b/charts/rancher-turtles/Chart.yaml
@@ -14,11 +14,11 @@ keywords:
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: Rancher Turtles - the Cluster API Extension
-  catalog.cattle.io/kube-version: '>= 1.31.4-0 < 1.34.0-0'
+  catalog.cattle.io/kube-version: ">= 1.31.4-0 < 1.34.0-0"
   catalog.cattle.io/namespace: cattle-turtles-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux
-  catalog.cattle.io/rancher-version: '>= 2.13.0-0 < 2.14.0-0'
+  catalog.cattle.io/rancher-version: ">= 2.13.0-0 < 2.14.0-0"
   catalog.cattle.io/release-name: rancher-turtles
   catalog.cattle.io/scope: management
   catalog.cattle.io/type: cluster-tool

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -4,9 +4,7 @@ namespace: cattle-turtles-system
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
-# Note that it should also match with the prefix (text before '-') of the namespace
-# field above.
-namePrefix: cattle-turtles-
+namePrefix: rancher-turtles-
 
 labels:
 - includeSelectors: true
@@ -14,10 +12,8 @@ labels:
     turtles-capi.cattle.io: "turtles"
 
 resources:
-- ../crd
 - ../rbac
 - ../manager
-- ../namespace
 #- ../certmanager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/config/namespace/kustomization.yaml
+++ b/config/namespace/kustomization.yaml
@@ -1,2 +1,3 @@
+namePrefix: cattle-turtles-
 resources:
 - namespace.yaml

--- a/scripts/build-local-rancher-charts.sh
+++ b/scripts/build-local-rancher-charts.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright © 2023 - 2025 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xe
+
+RANCHER_CHARTS_REPO_DIR=${RANCHER_CHARTS_REPO_DIR}
+RANCHER_CHART_DEV_VERSION=${RANCHER_CHART_DEV_VERSION}
+RANCHER_CHARTS_BASE_BRANCH=${RANCHER_CHARTS_BASE_BRANCH}
+CHART_RELEASE_DIR=${CHART_RELEASE_DIR}
+HELM=${HELM}
+
+# Cleanup
+rm -rf $RANCHER_CHARTS_REPO_DIR
+mkdir -p $RANCHER_CHARTS_REPO_DIR
+# Build and copy Turtles chart into Rancher Charts local repo
+git clone -b $RANCHER_CHARTS_BASE_BRANCH git@github.com:rancher/charts.git $RANCHER_CHARTS_REPO_DIR
+mkdir -p $RANCHER_CHARTS_REPO_DIR/charts/rancher-turtles/$RANCHER_CHART_DEV_VERSION
+cp -r $CHART_RELEASE_DIR/* $RANCHER_CHARTS_REPO_DIR/charts/rancher-turtles/$RANCHER_CHART_DEV_VERSION
+# Populate Chart.yaml with correct version
+yq -i '.version = "'$RANCHER_CHART_DEV_VERSION'"' $RANCHER_CHARTS_REPO_DIR/charts/rancher-turtles/$RANCHER_CHART_DEV_VERSION/Chart.yaml
+yq -i '.appVersion = "dev"' $RANCHER_CHARTS_REPO_DIR/charts/rancher-turtles/$RANCHER_CHART_DEV_VERSION/Chart.yaml
+yq -i '.urls[0] += "assets/rancher-turtles/rancher-turtles-'$RANCHER_CHART_DEV_VERSION'.tgz"' $RANCHER_CHARTS_REPO_DIR/charts/rancher-turtles/$RANCHER_CHART_DEV_VERSION/Chart.yaml
+# Populate release.yaml and index.yaml
+yq -i '.rancher-turtles += "'$RANCHER_CHART_DEV_VERSION'"' $RANCHER_CHARTS_REPO_DIR/release.yaml
+index_entry=$(yq -o=j -I=0 $RANCHER_CHARTS_REPO_DIR/charts/rancher-turtles/$RANCHER_CHART_DEV_VERSION/Chart.yaml)
+yq -i '.entries.rancher-turtles += '"$index_entry"'' $RANCHER_CHARTS_REPO_DIR/index.yaml
+# Package the chart
+$HELM package $RANCHER_CHARTS_REPO_DIR/charts/rancher-turtles/$RANCHER_CHART_DEV_VERSION --app-version=dev --version=$RANCHER_CHART_DEV_VERSION --destination=$RANCHER_CHARTS_REPO_DIR/assets/rancher-turtles
+# Commit all changes
+git -C $RANCHER_CHARTS_REPO_DIR add .
+git -C $RANCHER_CHARTS_REPO_DIR commit -m "Added test chart $RANCHER_CHART_DEV_VERSION"

--- a/test/e2e/data/gitea/ingress.yaml
+++ b/test/e2e/data/gitea/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gitea-http
+  namespace: default
+spec:
+  rules:
+  - host: gitea.${RANCHER_HOSTNAME}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: gitea-http
+            port:
+              number: 3000

--- a/test/e2e/data/gitea/values.yaml
+++ b/test/e2e/data/gitea/values.yaml
@@ -1,0 +1,18 @@
+gitea:
+  admin:
+    username: gitea
+  config:
+    database:
+      DB_TYPE: sqlite3
+    session:
+      PROVIDER: memory
+    cache:
+      ADAPTER: memory
+    queue:
+      TYPE: level
+persistence:
+  enabled: false
+postgresql:
+  enabled: false
+postgresql-ha:
+  enabled: false


### PR DESCRIPTION
This PR is related to https://github.com/rancher/turtles/issues/1816

Draft state as it's a proof of concept still.

Changes:

1. Fork and update the Rancher charts repo to add a dev build of Turtles
2. Add Gitea to the dev environment to serve Rancher system charts

How to test:
```bash
export RANCHER_HOSTNAME=my.test.example 
export NGROK_AUTHTOKEN=foo 
export NGROK_API_KEY=bar
make dev-env
```