### PR TITLE
ci: wait for rancher-webhook before installing providers

### DIFF
--- a/test/testenv/providers.go
+++ b/test/testenv/providers.go
@@ -192,6 +192,12 @@ func DeployRancherTurtlesProviders(ctx context.Context, input DeployRancherTurtl
 		}
 	}
 
+	By("Waiting for rancher webhook rollout")
+	framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
+		Getter:     input.BootstrapClusterProxy.GetClient(),
+		Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "rancher-webhook", Namespace: e2e.RancherNamespace}},
+	}, e2e.LoadE2EConfig().GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher")...)
+
 	By("Installing rancher-turtles-providers chart")
 
 	maps.Copy(values, input.AdditionalValues) // Merge additional values into the values map


### PR DESCRIPTION
**What this PR does / why we need it**:
Attempt to fix https://github.com/rancher/turtles/actions/runs/18859976994/job/53816301571

Test run: https://github.com/rancher/turtles/actions/runs/18882012324 (almost passed, it's flaky)
vSphere run: https://github.com/rancher/turtles/actions/runs/18881576503

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
