### PR TITLE
ci: bump k8s to 1.34 in e2e

### DIFF
--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -88,6 +88,11 @@ jobs:
       - name: Install Rancher
         run: helm install rancher rancher-alpha/rancher --namespace cattle-system --create-namespace --set bootstrapPassword=rancheradmin --set replicas=1 --set hostname="e2e.dev.rancher" --set 'extraEnv[0].name=CATTLE_FEATURES' --set 'extraEnv[0].value=turtles=false' --version ${{ env.RANCHER_VERSION }} --wait
 
+      - name: Wait for rancher-webhook
+        run: |
+          kubectl --namespace cattle-system wait --for=create deployments/rancher-webhook --timeout=300s
+          kubectl --namespace cattle-system wait --for=condition=Available deployment/rancher-webhook --timeout=300s
+
       - name: Run chart-testing (install)
         run: helm install rancher-turtles out/charts/rancher-turtles/ -n rancher-turtles-system --set namespace=rancher-turtles-system --create-namespace --wait --debug
 
@@ -157,6 +162,11 @@ jobs:
       - name: Install Rancher
         run: helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha && helm install rancher rancher-alpha/rancher --namespace cattle-system --create-namespace --set bootstrapPassword=rancheradmin --set replicas=1 --set hostname="e2e.dev.rancher" --set 'extraEnv[0].name=CATTLE_FEATURES' --set 'extraEnv[0].value=turtles=false' --version ${{ env.RANCHER_VERSION }} --wait
 
+      - name: Wait for rancher-webhook
+        run: |
+          kubectl --namespace cattle-system wait --for=create deployments/rancher-webhook --timeout=300s
+          kubectl --namespace cattle-system wait --for=condition=Available deployment/rancher-webhook --timeout=300s
+      
       - name: Install rancher-turtles chart
         run: helm install rancher-turtles out/charts/rancher-turtles/ -n rancher-turtles-system --set namespace=rancher-turtles-system --create-namespace --wait --debug
 

--- a/charts/rancher-turtles/Chart.yaml
+++ b/charts/rancher-turtles/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: Rancher Turtles - the Cluster API Extension
-  catalog.cattle.io/kube-version: ">= 1.31.4-0 < 1.34.0-0"
+  catalog.cattle.io/kube-version: ">= 1.31.4-0 < 1.35.0-0"
   catalog.cattle.io/namespace: cattle-turtles-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux

--- a/charts/rancher-turtles/questions.yml
+++ b/charts/rancher-turtles/questions.yml
@@ -32,7 +32,7 @@ questions:
     label: Remove cert-manager
     group: "Rancher Turtles Features Settings"
   - variable: kubectlImage
-    default: "registry.k8s.io/kubernetes/kubectl:v1.32.3"
+    default: "registry.k8s.io/kubernetes/kubectl:v1.34.1"
     description: "Specify the image to use when running kubectl in jobs."
     type: string
     label: Kubectl Image

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -28,7 +28,7 @@ imagePullSecrets: []
 # rancherInstalled: True if Rancher already installed is in the cluster, this is the preferred installation way.
 rancherInstalled: true
 # kubectlImage: Image for kubectl tasks.
-kubectlImage: registry.k8s.io/kubernetes/kubectl:v1.32.3
+kubectlImage: registry.k8s.io/kubernetes/kubectl:v1.34.1
 # shellImage: Image for shell tasks.
 shellImage: rancher/kuberlr-kubectl:v5.0.0
 # features: Optional and experimental features.

--- a/examples/applications/cni/calico/helm-chart.yaml
+++ b/examples/applications/cni/calico/helm-chart.yaml
@@ -4,7 +4,7 @@ metadata:
   name: calico-cni
 spec:
   helm:
-    version: v3.29.3
+    version: v3.31.0
     releaseName: projectcalico
     repo: https://docs.tigera.io/calico/charts
     chart: tigera-operator

--- a/examples/clusterclasses/docker/rke2/clusterclass-docker-rke2.yaml
+++ b/examples/clusterclasses/docker/rke2/clusterclass-docker-rke2.yaml
@@ -172,7 +172,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.32.8
+      customImage: kindest/node:v1.34.0
       bootstrapTimeout: 15m
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/examples/clusters/docker/rke2/cluster.yaml
+++ b/examples/clusters/docker/rke2/cluster.yaml
@@ -24,8 +24,8 @@ spec:
     - name: rke2CNI
       value: none
     - name: dockerImage
-      value: kindest/node:v1.32.8
-    version: v1.32.9+rke2r1
+      value: kindest/node:v1.34.0
+    version: v1.34.1+rke2r1
     workers:
       machineDeployments:
       - class: default-worker

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -26,7 +26,7 @@ fi
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
-MINIMUM_KUBECTL_VERSION=v1.32.0
+MINIMUM_KUBECTL_VERSION=v1.34.1
 goarch="$(go env GOARCH)"
 goos="$(go env GOOS)"
 

--- a/scripts/kind-cluster-with-extramounts.yaml
+++ b/scripts/kind-cluster-with-extramounts.yaml
@@ -3,7 +3,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: capi-test
 nodes:
 - role: control-plane
-  image: kindest/node:v1.32.8
+  image: kindest/node:v1.34.0
   extraMounts:
     - hostPath: /var/run/docker.sock
       containerPath: /var/run/docker.sock

--- a/scripts/turtles-quickstart.sh
+++ b/scripts/turtles-quickstart.sh
@@ -23,7 +23,7 @@ RANCHER_IMAGE=${RANCHER_IMAGE:-rancher/rancher:$RANCHER_VERSION}
 RANCHER_CLUSTER_NAME=${RANCHER_CLUSTER_NAME:-rancher-cluster}
 RANCHER_TURTLES_VERSION=${RANCHER_TURTLES_VERSION:-v0.24.1}
 CAPI_CLUSTER_NAME=${CAPI_CLUSTER_NAME:-capi-cluster1}
-KIND_IMAGE_VERSION=${KIND_IMAGE_VERSION:-v1.32.8}
+KIND_IMAGE_VERSION=${KIND_IMAGE_VERSION:-v1.34.0}
 
 CONFIG_DIR="/tmp/turtles"
 mkdir -p $CONFIG_DIR
@@ -416,7 +416,7 @@ EOF
     export NAMESPACE=capi-clusters
     export CONTROL_PLANE_MACHINE_COUNT=1
     export WORKER_MACHINE_COUNT=1
-    export KUBERNETES_VERSION=v1.32.3
+    export KUBERNETES_VERSION=v1.34.0
 
     curl -s https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/cluster-templates/docker-kubeadm.yaml | envsubst > ${CONFIG_DIR}/${CAPI_CLUSTER_NAME}.yaml
 

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -38,23 +38,31 @@ variables:
   SECRET_KEYS: "NGROK_AUTHTOKEN,NGROK_API_KEY,RANCHER_HOSTNAME,RANCHER_PASSWORD,CAPG_ENCODED_CREDS,AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AZURE_SUBSCRIPTION_ID,AZURE_CLIENT_ID,AZURE_CLIENT_SECRET,AZURE_TENANT_ID,GCP_PROJECT,GCP_NETWORK_NAME,GCP_IMAGE_ID,VSPHERE_TLS_THUMBPRINT,VSPHERE_SERVER,VSPHERE_DATACENTER,VSPHERE_DATASTORE,VSPHERE_FOLDER,VSPHERE_TEMPLATE,VSPHERE_NETWORK,VSPHERE_RESOURCE_POOL,VSPHERE_USERNAME,VSPHERE_PASSWORD,VSPHERE_KUBE_VIP_IP_KUBEADM,VSPHERE_KUBE_VIP_IP_RKE2,DOCKER_REGISTRY_TOKEN,DOCKER_REGISTRY_USERNAME,DOCKER_REGISTRY_CONFIG"
 
   # Kubernetes Configuration
-  KUBERNETES_VERSION: "v1.32.3"
-  KUBERNETES_MANAGEMENT_VERSION: "v1.32.3"
-  RKE2_VERSION: "v1.32.9+rke2r1"
+  KUBERNETES_VERSION: "v1.34.0" # Depends on kindest/node
+  KUBERNETES_MANAGEMENT_VERSION: "v1.34.0" # Depends on kindest/node
+  RKE2_VERSION: "v1.34.1+rke2r1"
   RKE2_CNI: "none"
 
   # Azure Configuration
   #
   # Azure Kubeadm tests need specific k8s version.
   # This is due to the limited availability of published AMIs.
-  # For example: https://portal.azure.com/#@suseazuredev.onmicrosoft.com/resource/providers/Microsoft.Compute/locations/FranceCentral/CommunityGalleries/ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019/Images/capi-ubun2-2204/overview
-  AZURE_KUBERNETES_VERSION: "v1.32.0"
+  # For example: https://portal.azure.com/#view/Microsoft_Azure_ComputeHub/ComputeHubMenuBlade/~/communityImagesBrowse
+  #              Filter `capi-ubun2-2404` images. Beware: not all versions are published on all regions.
+  AZURE_KUBERNETES_VERSION: "v1.34.1"
+  AZURE_AKS_VERSION: "v1.33.3"
 
   # AWS Configuration
   #
   # AWS Kubeadm tests need specific k8s version.
   # This is due to the limited availability of published AMIs.
   # For a complete list, run: clusterawsadm ami list
+  # Alternatively, seach for `capa-ami` in https://eu-west-2.console.aws.amazon.com/ec2/home?region=eu-west-2#AMICatalog:
+  #
+  # Note: the same version variable is also used for EKS. 
+  # EKS also needs versioned images, that may not be available for recent versions of k8s.
+  # To verify availability, you can run: aws ssm get-parameter --name /aws/service/eks/optimized-ami/1.34/amazon-linux-2/recommended/image_id
+  # Recent versions will return a 'ParameterNotFound' error, preventing EKS from deploying.
   AWS_KUBERNETES_VERSION: "v1.32.0"
   AWS_REGION: "eu-west-2"
   KUBERNETES_MANAGEMENT_AWS_REGION: "eu-west-2"
@@ -65,6 +73,14 @@ variables:
   AWS_AMI_ID: "ami-096c298c2ab1493d7" # Public upstream AMI
 
   # GCP Configuration
+  #
+  # GCP images are manually built and pushed to the e2e GCP Project.
+  # For more information on how to build the image, see: https://cluster-api-gcp.sigs.k8s.io/prerequisites#building-images
+  # For example to build a specific version image:
+  #   PACKER_FLAGS="--var 'use_internal_ip=true'  --var 'kubernetes_semver=v1.34.1' --var 'kubernetes_series=v1.34' --var 'kubernetes_deb_version=1.34.1-1.1'" make build-gce-ubuntu-2404
+  # The actual GCP_IMAGE_ID value is loaded from ci secrets.
+  GCP_IMAGE_ID: ""
+  GCP_KUBERNETES_VERSION: "v1.32.3" # Depends on a new image to be built with the kubeadm components matching the k8s version.
   GCP_MACHINE_TYPE: "n1-standard-2"
   
   # CLI Tool Paths

--- a/test/e2e/data/cluster-templates/azure-aks-topology.yaml
+++ b/test/e2e/data/cluster-templates/azure-aks-topology.yaml
@@ -38,7 +38,7 @@ spec:
       value: highlander-e2e-azure-aks
     - name: azureClusterIdentityName
       value: cluster-identity
-    version: ${KUBERNETES_VERSION}
+    version: ${AZURE_AKS_VERSION}
     workers:
       machinePools:
       - class: default-system

--- a/test/e2e/data/cluster-templates/gcp-kubeadm-topology.yaml
+++ b/test/e2e/data/cluster-templates/gcp-kubeadm-topology.yaml
@@ -35,4 +35,4 @@ spec:
         value: ${GCP_IMAGE_ID}
       - name: machineType
         value: ${GCP_MACHINE_TYPE}
-    version: ${KUBERNETES_VERSION}
+    version: ${GCP_KUBERNETES_VERSION}

--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -183,9 +183,6 @@ var _ = Describe("[Azure] [Kubeadm] Create and delete CAPI cluster from cluster 
 			CapiClusterOwnerNamespaceLabel: e2e.CapiClusterOwnerNamespaceLabel,
 			OwnedLabelName:                 e2e.OwnedLabelName,
 			TopologyNamespace:              topologyNamespace,
-			AdditionalTemplateVariables: map[string]string{
-				e2e.KubernetesVersionVar: e2e.LoadE2EConfig().GetVariableOrEmpty(e2e.AzureKubernetesVersionVar), // override the default k8s version
-			},
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "azure-cluster-class-kubeadm",
@@ -287,9 +284,6 @@ var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster from cluster class"
 			CapiClusterOwnerNamespaceLabel: e2e.CapiClusterOwnerNamespaceLabel,
 			OwnedLabelName:                 e2e.OwnedLabelName,
 			TopologyNamespace:              topologyNamespace,
-			AdditionalTemplateVariables: map[string]string{
-				e2e.KubernetesVersionVar: e2e.LoadE2EConfig().GetVariableOrEmpty(e2e.AWSKubernetesVersionVar), // override the default k8s version
-			},
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "aws-cluster-classes-eks",
@@ -328,10 +322,7 @@ var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionali
 			CapiClusterOwnerLabel:          e2e.CapiClusterOwnerLabel,
 			CapiClusterOwnerNamespaceLabel: e2e.CapiClusterOwnerNamespaceLabel,
 			OwnedLabelName:                 e2e.OwnedLabelName,
-			AdditionalTemplateVariables: map[string]string{
-				e2e.KubernetesVersionVar: e2e.LoadE2EConfig().GetVariableOrEmpty(e2e.AWSKubernetesVersionVar), // override the default k8s version
-			},
-			TopologyNamespace: topologyNamespace,
+			TopologyNamespace:              topologyNamespace,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "aws-cluster-classes-regular",


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This PR bumps k8s version used for testing to 1.34
Note for AWS the highest available image is 1.32.6, but only affects EC2+Kubeadm, not EC2+RKE2.
EKS version also has been moved to the default KUBERNETES_VERSION, since for this one there is no dependency on community images.

vSphere tests: https://github.com/rancher/turtles/actions/runs/18904764623

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
