### PR TITLE
ci: wait for rancher-webhook when testing charts

### DIFF
--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -88,6 +88,11 @@ jobs:
       - name: Install Rancher
         run: helm install rancher rancher-alpha/rancher --namespace cattle-system --create-namespace --set bootstrapPassword=rancheradmin --set replicas=1 --set hostname="e2e.dev.rancher" --set 'extraEnv[0].name=CATTLE_FEATURES' --set 'extraEnv[0].value=turtles=false' --version ${{ env.RANCHER_VERSION }} --wait
 
+      - name: Wait for rancher-webhook
+        run: |
+          kubectl --namespace cattle-system wait --for=create deployments/rancher-webhook --timeout=300s
+          kubectl --namespace cattle-system wait --for=condition=Available deployment/rancher-webhook --timeout=300s
+
       - name: Run chart-testing (install)
         run: helm install rancher-turtles out/charts/rancher-turtles/ -n rancher-turtles-system --set namespace=rancher-turtles-system --create-namespace --wait --debug
 
@@ -156,6 +161,11 @@ jobs:
 
       - name: Install Rancher
         run: helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha && helm install rancher rancher-alpha/rancher --namespace cattle-system --create-namespace --set bootstrapPassword=rancheradmin --set replicas=1 --set hostname="e2e.dev.rancher" --set 'extraEnv[0].name=CATTLE_FEATURES' --set 'extraEnv[0].value=turtles=false' --version ${{ env.RANCHER_VERSION }} --wait
+
+      - name: Wait for rancher-webhook
+        run: |
+          kubectl --namespace cattle-system wait --for=create deployments/rancher-webhook --timeout=300s
+          kubectl --namespace cattle-system wait --for=condition=Available deployment/rancher-webhook --timeout=300s
 
       - name: Install rancher-turtles chart
         run: helm install rancher-turtles out/charts/rancher-turtles/ -n rancher-turtles-system --set namespace=rancher-turtles-system --create-namespace --wait --debug


### PR DESCRIPTION
**What this PR does / why we need it**:
Same change as https://github.com/rancher/turtles/pull/1846
Sporadically the tests fails when rancher-webhook pod is not available in time.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
