### PR TITLE
ci: bump k8s to 1.34 for Azure tests

### DIFF
--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -47,8 +47,12 @@ variables:
   #
   # Azure Kubeadm tests need specific k8s version.
   # This is due to the limited availability of published AMIs.
-  # For example: https://portal.azure.com/#@suseazuredev.onmicrosoft.com/resource/providers/Microsoft.Compute/locations/FranceCentral/CommunityGalleries/ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019/Images/capi-ubun2-2204/overview
-  AZURE_KUBERNETES_VERSION: "v1.32.0"
+  # For example: https://portal.azure.com/#view/Microsoft_Azure_ComputeHub/ComputeHubMenuBlade/~/communityImagesBrowse
+  #              Filter `capi-ubun2-2404` images. Beware: not all versions are published on all regions.
+  AZURE_KUBERNETES_VERSION: "v1.34.1"
+  AZURE_RKE2_VERSION: "v1.34.1+rke2r1"
+  # For AKS available versions, run: az aks get-versions --location westeurope
+  AZURE_AKS_VERSION: "v1.33.3"
 
   # AWS Configuration
   #

--- a/test/e2e/data/cluster-templates/azure-rke2-topology.yaml
+++ b/test/e2e/data/cluster-templates/azure-rke2-topology.yaml
@@ -44,7 +44,7 @@ spec:
       value: highlander-e2e-azure-rke2
     - name: azureClusterIdentityName
       value: cluster-identity
-    version: ${RKE2_VERSION}
+    version: ${AZURE_RKE2_VERSION}
     workers:
       machineDeployments:
       - class: rke2-default-worker


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps CAPZ tests to 1.34. 
AKS still at 1.33 since 1.34 is only available on preview. 

Test run: https://github.com/rancher/turtles/actions/runs/19071731334 (note v2 prov tests are flaky)

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
