### PR TITLE
[release-0.24] fix: Add post-delete hook that patches CRDs ahead of the 2.13 upgrade

### DIFF
--- a/charts/rancher-turtles/templates/post-delete-job.yaml
+++ b/charts/rancher-turtles/templates/post-delete-job.yaml
@@ -30,6 +30,13 @@ rules:
   - deployments
   verbs:
   - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -163,4 +170,31 @@ spec:
         - -n
         - {{ index .Values "cluster-api-operator" "cluster-api" "rke2" "controlPlane" "namespace" }}
         - --ignore-not-found=true
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: patch-crd-release-namespace
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "3"
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: post-delete-job
+      restartPolicy: Never
+      containers:
+      - name: capiproviders-clusterctlconfigs-crd-patch
+        image: {{ index .Values "rancherTurtles" "kubectlImage" }}
+        command: ["kubectl"]
+        args:
+        - patch
+        - crd
+        - capiproviders.turtles-capi.cattle.io
+        - clusterctlconfigs.turtles-capi.cattle.io
+        - --type=json
+        - -p
+        - '[{"op": "remove", "path": "/metadata/labels/app.kubernetes.io~1managed-by"},{"op": "remove", "path": "/metadata/annotations/meta.helm.sh~1release-name"},{"op": "remove", "path": "/metadata/annotations/meta.helm.sh~1release-namespace"}]'
 {{- end }}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR adds a post-delete Helm hook to prevent error when upgrading to Rancher 2.13.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1848 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
