### PR TITLE
ci: use docker image for chart-testing cli

### DIFF
--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -32,16 +32,6 @@ jobs:
         with:
           version: v3.14.3
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.9'
-          check-latest: true
-
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.7.0
-        with:
-          version: v3.9.0
-
       - name: setupGo
         uses: actions/setup-go@v6.0.0
         with:
@@ -54,7 +44,7 @@ jobs:
         run: make release-chart
 
       - name: Run chart-testing (lint)
-        run: ct lint --validate-maintainers=false --charts out/charts/rancher-turtles/
+        run: make test-chart
 
       - name: Install kind
         run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

Attempt to remove the unallowed chart-testing action. 
As a replacement, the official docker image is used ([recommended](https://github.com/helm/chart-testing?tab=readme-ov-file#prerequisites) setup). 

Alternatively the chart-testing binary can be installed, but it depends on yamale, which depends on python. Therefore the docker image seems to be a better alternative.

Related to https://github.com/rancher/turtles/pull/1877#issuecomment-3510281707

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
