### PR TITLE
fix: duplicate externally managed annotation value

### DIFF
--- a/internal/controllers/helpers.go
+++ b/internal/controllers/helpers.go
@@ -54,7 +54,6 @@ const (
 	v1ClusterMigrated         = "cluster-api.cattle.io/migrated"
 	fleetNamespaceMigrated    = "cluster-api.cattle.io/fleet-namespace-migrated"
 	fleetDisabledLabel        = "cluster-api.cattle.io/disable-fleet-auto-import"
-	externalFleetAnnotation   = "provisioning.cattle.io/externally-managed"
 
 	defaultRequeueDuration = 1 * time.Minute
 	trueValue              = "true"

--- a/internal/controllers/import_controller_v3.go
+++ b/internal/controllers/import_controller_v3.go
@@ -591,8 +591,8 @@ func (r *CAPIImportManagementV3Reconciler) optOutOfFleetManagement(ctx context.C
 		annotations = map[string]string{}
 	}
 
-	if _, found := annotations[externalFleetAnnotation]; !found {
-		annotations[externalFleetAnnotation] = trueValue
+	if _, found := annotations[turtlesannotations.ExternalFleetAnnotation]; !found {
+		annotations[turtlesannotations.ExternalFleetAnnotation] = trueValue
 		rancherCluster.SetAnnotations(annotations)
 
 		log.Info("Added fleet annotation to Rancher cluster")


### PR DESCRIPTION
**What this PR does / why we need it**:

Noticed that there's a duplicate definition of the annotation `provisioning.cattle.io/externally-managed` and the constant value from `util/annotations/helpers.go`, where all other annotations are defined, is not used.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
