### PR TITLE
ci: fix artifacts collection at the end of e2e tests

### DIFF
--- a/test/e2e/suites/capiprovider/suite_test.go
+++ b/test/e2e/suites/capiprovider/suite_test.go
@@ -104,7 +104,7 @@ var _ = SynchronizedAfterSuite(
 	},
 	func() {
 		By("Dumping artifacts from the bootstrap cluster")
-		testenv.DumpBootstrapCluster(ctx)
+		testenv.DumpBootstrapCluster(ctx, bootstrapClusterProxy.GetKubeconfigPath())
 
 		config := e2e.LoadE2EConfig()
 		// skipping error check since it is already done at the beginning of the test in e2e.ValidateE2EConfig()

--- a/test/e2e/suites/chart-upgrade/suite_test.go
+++ b/test/e2e/suites/chart-upgrade/suite_test.go
@@ -105,7 +105,7 @@ var _ = SynchronizedAfterSuite(
 	},
 	func() {
 		By("Dumping artifacts from the bootstrap cluster")
-		testenv.DumpBootstrapCluster(ctx)
+		testenv.DumpBootstrapCluster(ctx, bootstrapClusterProxy.GetKubeconfigPath())
 
 		config := e2e.LoadE2EConfig()
 		// skipping error check since it is already done at the beginning of the test in e2e.ValidateE2EConfig()

--- a/test/e2e/suites/import-gitops/suite_test.go
+++ b/test/e2e/suites/import-gitops/suite_test.go
@@ -107,7 +107,7 @@ var _ = SynchronizedAfterSuite(
 	},
 	func() {
 		By("Dumping artifacts from the bootstrap cluster")
-		testenv.DumpBootstrapCluster(ctx)
+		testenv.DumpBootstrapCluster(ctx, bootstrapClusterProxy.GetKubeconfigPath())
 
 		config := e2e.LoadE2EConfig()
 		// skipping error check since it is already done at the beginning of the test in e2e.ValidateE2EConfig()

--- a/test/e2e/suites/v2prov/suite_test.go
+++ b/test/e2e/suites/v2prov/suite_test.go
@@ -116,7 +116,7 @@ var _ = SynchronizedAfterSuite(
 	},
 	func() {
 		By("Dumping artifacts from the bootstrap cluster")
-		testenv.DumpBootstrapCluster(ctx)
+		testenv.DumpBootstrapCluster(ctx, bootstrapClusterProxy.GetKubeconfigPath())
 
 		config := e2e.LoadE2EConfig()
 		// skipping error check since it is already done at the beginning of the test in e2e.ValidateE2EConfig()

--- a/test/testenv/cleanup.go
+++ b/test/testenv/cleanup.go
@@ -141,8 +141,8 @@ func CollectArtifacts(ctx context.Context, input CollectArtifactsInput) error {
 	return nil
 }
 
-func DumpBootstrapCluster(ctx context.Context) {
-	err := CollectArtifacts(ctx, CollectArtifactsInput{})
+func DumpBootstrapCluster(ctx context.Context, kubeconfigPath string) {
+	err := CollectArtifacts(ctx, CollectArtifactsInput{KubeconfigPath: kubeconfigPath})
 	if err != nil {
 		fmt.Printf("Failed to artifacts for the bootstrap cluster: %v\n", err)
 		return


### PR DESCRIPTION
**What this PR does / why we need it**:
Looks like we don't collect logs anymore at the end of test runs, which makes debugging Cluster deletion failures problematic. 

Jobs end with:

```
  STEP: Dumping artifacts from the bootstrap cluster @ 11/11/25 02:01:36.978
  2025-11-11T02:01:36Z	INFO	No kubeconfig provided, skipping artifacts collection
```

Test run: https://github.com/rancher/turtles/actions/runs/19250611275/job/55034779705

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
