### PR TITLE
fix: updatecli paths to community/prime clusterctl config files

### DIFF
--- a/updatecli/updatecli.d/manifest.yaml
+++ b/updatecli/updatecli.d/manifest.yaml
@@ -101,11 +101,20 @@ sources:
 
 # update config.yaml accordingly
 targets:
-  bumpcapi:
-    name: bump core capi
+  bumpcapiprime:
+    name: bump core capi - prime
     kind: file
     spec:
-      file: ./internal/controllers/clusterctl/config-default.yaml
+      file: ./internal/controllers/clusterctl/config-prime.yaml
+      matchpattern: 'https://github.com/rancher-sandbox/cluster-api/releases/(.*)/'
+      replacepattern: 'https://github.com/rancher-sandbox/cluster-api/releases/{{ source "capirelease" }}/'
+    scmid: turtles
+    sourceid: capirelease # Will be ignored as `replacepattern` is specified
+  bumpcapicommunity:
+    name: bump core capi - community
+    kind: file
+    spec:
+      file: ./internal/controllers/clusterctl/config-community.yaml
       matchpattern: 'https://github.com/rancher-sandbox/cluster-api/releases/(.*)/'
       replacepattern: 'https://github.com/rancher-sandbox/cluster-api/releases/{{ source "capirelease" }}/'
     scmid: turtles
@@ -114,7 +123,7 @@ targets:
     name: bump docker capi
     kind: file
     spec:
-      file: ./internal/controllers/clusterctl/config-default.yaml
+      file: ./internal/controllers/clusterctl/config-prime.yaml
       matchpattern: 'https://github.com/kubernetes-sigs/cluster-api/releases/(.*)/'
       replacepattern: 'https://github.com/kubernetes-sigs/cluster-api/releases/{{ source "capirelease" }}/'
     scmid: turtles
@@ -141,7 +150,7 @@ targets:
     name: bump caprke2 provider
     kind: file
     spec:
-      file: ./internal/controllers/clusterctl/config-default.yaml
+      file: ./internal/controllers/clusterctl/config-prime.yaml
       matchpattern: 'https://github.com/rancher/cluster-api-provider-rke2/releases/(.*)/'
       replacepattern: 'https://github.com/rancher/cluster-api-provider-rke2/releases/{{ source "caprke2release" }}/'
     scmid: turtles
@@ -150,7 +159,7 @@ targets:
     name: bump capz provider
     kind: file
     spec:
-      file: ./internal/controllers/clusterctl/config-default.yaml
+      file: ./internal/controllers/clusterctl/config-prime.yaml
       matchpattern: 'https://github.com/rancher-sandbox/cluster-api-provider-azure/releases/(.*)/'
       replacepattern: 'https://github.com/rancher-sandbox/cluster-api-provider-azure/releases/{{ source "capzrelease" }}/'
     scmid: turtles
@@ -159,7 +168,7 @@ targets:
     name: bump capa provider
     kind: file
     spec:
-      file: ./internal/controllers/clusterctl/config-default.yaml
+      file: ./internal/controllers/clusterctl/config-prime.yaml
       matchpattern: 'https://github.com/rancher-sandbox/cluster-api-provider-aws/releases/(.*)/'
       replacepattern: 'https://github.com/rancher-sandbox/cluster-api-provider-aws/releases/{{ source "caparelease" }}/'
     scmid: turtles
@@ -168,7 +177,7 @@ targets:
     name: bump capg provider
     kind: file
     spec:
-      file: ./internal/controllers/clusterctl/config-default.yaml
+      file: ./internal/controllers/clusterctl/config-prime.yaml
       matchpattern: 'https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/(.*)/'
       replacepattern: 'https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/{{ source "capgrelease" }}/'
     scmid: turtles
@@ -177,7 +186,7 @@ targets:
     name: bump capv provider
     kind: file
     spec:
-      file: ./internal/controllers/clusterctl/config-default.yaml
+      file: ./internal/controllers/clusterctl/config-prime.yaml
       matchpattern: 'https://github.com/rancher-sandbox/cluster-api-provider-vsphere/releases/(.*)/'
       replacepattern: 'https://github.com/rancher-sandbox/cluster-api-provider-vsphere/releases/{{ source "capvrelease" }}/'
     scmid: turtles
@@ -186,7 +195,7 @@ targets:
     name: bump capi fleet addon provider
     kind: file
     spec:
-      file: ./internal/controllers/clusterctl/config-default.yaml
+      file: ./internal/controllers/clusterctl/config-prime.yaml
       matchpattern: 'https://github.com/rancher/cluster-api-addon-provider-fleet/releases/(.*)/'
       replacepattern: 'https://github.com/rancher/cluster-api-addon-provider-fleet/releases/{{ source "capifleetrelease" }}/'
     scmid: turtles


### PR DESCRIPTION
**What this PR does / why we need it**:

After creating two separate clusterctl configuration files for `prime` and `community` releases, the existing `updatecli` configuration for bumping core CAPI and CAPI providers is no longer functional. This change points the automation to the correct filepaths, including:
- Core CAPI only for community.
- Core CAPI + CAPI Providers for prime.

As @furkatgofurov7 pointed out, the changes applied by the automation may not be enough to bump core CAPI in certain situations, as more changes may be required for the update, but I think it's good to have the predictable part of it automated and apply any other edits/additions on top of it. It should be fine for most provider updates, as those are usually more straight forward. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

If we continue to close the automatic PRs and apply upgrades manually, we can consider deprecating this automation in the future.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
