### PR TITLE
ci: enable debug verbosity on e2e providers

### DIFF
--- a/charts/rancher-turtles-providers/values.schema.json
+++ b/charts/rancher-turtles-providers/values.schema.json
@@ -24,11 +24,11 @@
         },
         "version": {
           "type": "string",
-      "description": "Optional provider version."
+          "description": "Optional provider version."
         },
         "credentials": {
           "type": "object",
-      "description": "Optional Secret reference containing Rancher credentials",
+          "description": "Optional Secret reference containing Rancher credentials",
           "required": [
             "name",
             "namespace"
@@ -46,7 +46,7 @@
         },
         "configSecret": {
           "type": "object",
-      "description": "ConfigSecret is the object with name and namespace of the Secret providing the configuration variables for the current provider instance, like e.g. credentials.",
+          "description": "ConfigSecret is the object with name and namespace of the Secret providing the configuration variables for the current provider instance, like e.g. credentials.",
           "required": [
             "name",
             "namespace"
@@ -64,7 +64,7 @@
         },
         "features": {
           "type": "object",
-      "description": "Optional feature flags for this provider.",
+          "description": "Optional feature flags for this provider.",
           "properties": {
             "machinePool": {
               "type": "boolean",
@@ -82,25 +82,31 @@
         },
         "variables": {
           "type": "object",
-      "description": "Optional environment variables exposed to the controller manager.",
+          "description": "Optional environment variables exposed to the controller manager.",
           "additionalProperties": {
             "type": "string"
           }
         },
         "manager": {
           "type": "object",
-      "description": "Optional controller manager settings.",
+          "description": "Optional controller manager settings.",
           "properties": {
             "syncPeriod": {
               "type": "string",
               "description": "Controller sync period duration, e.g. '5m'"
+            },
+            "verbosity": {
+              "type": "number",
+              "description": "Verbosity set the logs verbosity. Defaults to 1.",
+              "minimum": 1,
+              "maximum": 5
             }
           }
         },
         "fetchConfig": {
           "type": "object",
-      "description": "Override default artifact source via URL or OCI (specify one).",
-          "oneOf": [ 
+          "description": "Override default artifact source via URL or OCI (specify one).",
+          "oneOf": [
             {
               "properties": {
                 "url": {
@@ -109,18 +115,22 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["url"]
+              "required": [
+                "url"
+              ]
             },
             {
-              "properties": {            
+              "properties": {
                 "oci": {
                   "type": "string",
                   "description": "OCI to be used for fetching the provider components and metadata."
                 }
               },
               "additionalProperties": false,
-              "required": ["oci"]
-            } 
+              "required": [
+                "oci"
+              ]
+            }
           ]
         }
       }
@@ -130,19 +140,39 @@
   "properties": {
     "providers": {
       "type": "object",
-    "description": "Providers configuration.",
+      "description": "Providers configuration.",
       "properties": {
-        "addonFleet": { "$ref": "#/$defs/providerSchema"},
-        "bootstrapKubeadm": { "$ref": "#/$defs/providerSchema"},
-        "bootstrapRKE2": { "$ref": "#/$defs/providerSchema"},
-        "controlplaneKubeadm": { "$ref": "#/$defs/providerSchema"},
-        "controlplaneRKE2": { "$ref": "#/$defs/providerSchema"},
-        "infrastructureAWS": { "$ref": "#/$defs/providerSchema"},
-        "infrastructureAzure": { "$ref": "#/$defs/providerSchema"},
-        "infrastructureDocker": { "$ref": "#/$defs/providerSchema"},
-        "infrastructureGCP": { "$ref": "#/$defs/providerSchema"},
-        "infrastructureVSphere": { "$ref": "#/$defs/providerSchema"}
+        "addonFleet": {
+          "$ref": "#/$defs/providerSchema"
+        },
+        "bootstrapKubeadm": {
+          "$ref": "#/$defs/providerSchema"
+        },
+        "bootstrapRKE2": {
+          "$ref": "#/$defs/providerSchema"
+        },
+        "controlplaneKubeadm": {
+          "$ref": "#/$defs/providerSchema"
+        },
+        "controlplaneRKE2": {
+          "$ref": "#/$defs/providerSchema"
+        },
+        "infrastructureAWS": {
+          "$ref": "#/$defs/providerSchema"
+        },
+        "infrastructureAzure": {
+          "$ref": "#/$defs/providerSchema"
+        },
+        "infrastructureDocker": {
+          "$ref": "#/$defs/providerSchema"
+        },
+        "infrastructureGCP": {
+          "$ref": "#/$defs/providerSchema"
+        },
+        "infrastructureVSphere": {
+          "$ref": "#/$defs/providerSchema"
+        }
       }
-  }
+    }
   }
 }

--- a/charts/rancher-turtles-providers/values.yaml
+++ b/charts/rancher-turtles-providers/values.yaml
@@ -37,6 +37,7 @@ providers:
   # manager: Optional controller manager settings.
   # manager:
   #   syncPeriod: "5m"
+  #   verbosity: 5
   # bootstrapKubeadm: Kubeadm Bootstrap Provider.
   bootstrapKubeadm:
     # enabled: Enables the installation of this provider.
@@ -70,6 +71,7 @@ providers:
   # manager: Optional controller manager settings.
   # manager:
   #   syncPeriod: "5m"
+  #   verbosity: 5
   # bootstrapRKE2: RKE2 Bootstrap Provider.
   bootstrapRKE2:
     # enabled: Enables the installation of this provider.
@@ -103,6 +105,7 @@ providers:
   # manager: Optional controller manager settings.
   # manager:
   #   syncPeriod: "5m"
+  #   verbosity: 5
   # controlplaneKubeadm: Kubeadm Control Plane Provider.
   controlplaneKubeadm:
     # enabled: Enables the installation of this provider.
@@ -136,6 +139,7 @@ providers:
   # manager: Optional controller manager settings.
   # manager:
   #   syncPeriod: "5m"
+  #   verbosity: 5
   # controlplaneRKE2: RKE2 Control Plane Provider.
   controlplaneRKE2:
     # enabled: Enables the installation of this provider.
@@ -169,6 +173,7 @@ providers:
   # manager: Optional controller manager settings.
   # manager:
   #   syncPeriod: "5m"
+  #   verbosity: 5
   # infrastructureAWS: AWS Infrastructure Provider (CAPA).
   infrastructureAWS:
     # enabled: Enables the installation of this provider.
@@ -202,6 +207,7 @@ providers:
   # manager: Optional controller manager settings.
   # manager:
   #   syncPeriod: "5m"
+  #   verbosity: 5
   # infrastructureAzure: Azure Infrastructure Provider (CAPZ).
   infrastructureAzure:
     # enabled: Enables the installation of this provider.
@@ -235,6 +241,7 @@ providers:
   # manager: Optional controller manager settings.
   # manager:
   #   syncPeriod: "5m"
+  #   verbosity: 5
   # infrastructureDocker: Docker Infrastructure Provider (CAPD).
   infrastructureDocker:
     # enabled: Enables the installation of this provider.
@@ -268,6 +275,7 @@ providers:
   # manager: Optional controller manager settings.
   # manager:
   #   syncPeriod: "5m"
+  #   verbosity: 5
   # infrastructureGCP: GCP Infrastructure Provider (CAPG).
   infrastructureGCP:
     # enabled: Enables the installation of this provider.
@@ -302,6 +310,7 @@ providers:
   # manager: Optional controller manager settings.
   # manager:
   #   syncPeriod: "5m"
+  #   verbosity: 5
   infrastructureVSphere:
     # enabled: Enables the installation of this provider.
     enabled: false
@@ -335,3 +344,4 @@ providers:
   # manager: Optional controller manager settings.
   # manager:
   #   syncPeriod: "5m"
+  #   verbosity: 5

--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -118,14 +118,23 @@ install_local_providers_chart() {
 
     helm upgrade --install rancher-turtles-providers out/charts/rancher-turtles-providers \
         -n cattle-turtles-system \
+        --set providers.bootstrapRKE2.manager.verbosity=5 \
+        --set providers.controlplaneRKE2.manager.verbosity=5 \
         --set providers.bootstrapKubeadm.enabled=true \
+        --set providers.bootstrapKubeadm.manager.verbosity=5 \
         --set providers.controlplaneKubeadm.enabled=true \
+        --set providers.controlplaneKubeadm.manager.verbosity=5 \
         --set providers.infrastructureDocker.enabled=true \
+        --set providers.infrastructureDocker.manager.verbosity=5 \
         --set providers.infrastructureAWS.enabled=true \
+        --set providers.infrastructureAWS.manager.verbosity=5 \
         --set providers.infrastructureAzure.enabled=true \
+        --set providers.infrastructureAzure.manager.verbosity=5 \
         --set providers.infrastructureGCP.enabled=true \
+        --set providers.infrastructureGCP.manager.verbosity=5 \
         --set providers.infrastructureGCP.variables.GCP_B64ENCODED_CREDENTIALS="" \
         --set providers.infrastructureVSphere.enabled=true \
+        --set providers.infrastructureVSphere.manager.verbosity=5 \
         --create-namespace --wait \
         --timeout 180s
 }

--- a/test/testenv/providers.go
+++ b/test/testenv/providers.go
@@ -41,13 +41,19 @@ import (
 )
 
 const (
-	bootstrapKubeadmPath    = "providers.bootstrapKubeadm.enabled"
-	controlplaneKubeadmPath = "providers.controlplaneKubeadm.enabled"
-	dockerPath              = "providers.infrastructureDocker.enabled"
-	awsPath                 = "providers.infrastructureAWS.enabled"
-	azurePath               = "providers.infrastructureAzure.enabled"
-	gcpPath                 = "providers.infrastructureGCP.enabled"
-	vspherePath             = "providers.infrastructureVSphere.enabled"
+	providerEnabledKey   = "enabled"
+	providerVerbosityKey = "manager.verbosity"
+	debugVerbosityValue  = "5"
+
+	bootstrapRKE2Path       = "providers.bootstrapRKE2."
+	controlplaneRKE2Path    = "providers.controlplaneRKE2."
+	bootstrapKubeadmPath    = "providers.bootstrapKubeadm."
+	controlplaneKubeadmPath = "providers.controlplaneKubeadm."
+	dockerPath              = "providers.infrastructureDocker."
+	awsPath                 = "providers.infrastructureAWS."
+	azurePath               = "providers.infrastructureAzure."
+	gcpPath                 = "providers.infrastructureGCP."
+	vspherePath             = "providers.infrastructureVSphere."
 
 	defaultOCIRegistry = "registry.rancher.com/rancher/cluster-api-controller-components"
 
@@ -172,19 +178,29 @@ func DeployRancherTurtlesProviders(ctx context.Context, input DeployRancherTurtl
 		for _, p := range providerList {
 			provider := strings.TrimSpace(strings.ToLower(p))
 			switch provider {
+			case "rke2":
+				values[bootstrapRKE2Path+providerVerbosityKey] = debugVerbosityValue
+				values[controlplaneRKE2Path+providerVerbosityKey] = debugVerbosityValue
 			case "kubeadm":
-				values[bootstrapKubeadmPath] = "true"
-				values[controlplaneKubeadmPath] = "true"
+				values[bootstrapKubeadmPath+providerEnabledKey] = "true"
+				values[bootstrapKubeadmPath+providerVerbosityKey] = debugVerbosityValue
+				values[controlplaneKubeadmPath+providerEnabledKey] = "true"
+				values[controlplaneKubeadmPath+providerVerbosityKey] = debugVerbosityValue
 			case "docker", "capd":
-				values[dockerPath] = "true"
+				values[dockerPath+providerEnabledKey] = "true"
+				values[dockerPath+providerVerbosityKey] = debugVerbosityValue
 			case "aws", "capa":
-				values[awsPath] = "true"
+				values[awsPath+providerEnabledKey] = "true"
+				values[awsPath+providerVerbosityKey] = debugVerbosityValue
 			case "azure", "capz":
-				values[azurePath] = "true"
+				values[azurePath+providerEnabledKey] = "true"
+				values[azurePath+providerVerbosityKey] = debugVerbosityValue
 			case "gcp", "capg":
-				values[gcpPath] = "true"
+				values[gcpPath+providerEnabledKey] = "true"
+				values[gcpPath+providerVerbosityKey] = debugVerbosityValue
 			case "vsphere", "capv":
-				values[vspherePath] = "true"
+				values[vspherePath+providerEnabledKey] = "true"
+				values[vspherePath+providerVerbosityKey] = debugVerbosityValue
 			case "", "all":
 			default:
 				log.FromContext(ctx).Info("Unknown provider in TURTLES_PROVIDERS, ignoring", "provider", provider)
@@ -295,13 +311,22 @@ func runProviderMigration(ctx context.Context, scriptPath, kubeconfigPath string
 }
 
 func enableAllProviders(values map[string]string) {
-	values[bootstrapKubeadmPath] = "true"
-	values[controlplaneKubeadmPath] = "true"
-	values[dockerPath] = "true"
-	values[awsPath] = "true"
-	values[azurePath] = "true"
-	values[gcpPath] = "true"
-	values[vspherePath] = "true"
+	values[bootstrapRKE2Path+providerVerbosityKey] = debugVerbosityValue
+	values[controlplaneRKE2Path+providerVerbosityKey] = debugVerbosityValue
+	values[bootstrapKubeadmPath+providerEnabledKey] = "true"
+	values[bootstrapKubeadmPath+providerVerbosityKey] = debugVerbosityValue
+	values[controlplaneKubeadmPath+providerEnabledKey] = "true"
+	values[controlplaneKubeadmPath+providerVerbosityKey] = debugVerbosityValue
+	values[dockerPath+providerEnabledKey] = "true"
+	values[dockerPath+providerVerbosityKey] = debugVerbosityValue
+	values[awsPath+providerEnabledKey] = "true"
+	values[awsPath+providerVerbosityKey] = debugVerbosityValue
+	values[azurePath+providerEnabledKey] = "true"
+	values[azurePath+providerVerbosityKey] = debugVerbosityValue
+	values[gcpPath+providerEnabledKey] = "true"
+	values[gcpPath+providerVerbosityKey] = debugVerbosityValue
+	values[vspherePath+providerEnabledKey] = "true"
+	values[vspherePath+providerVerbosityKey] = debugVerbosityValue
 }
 
 func getAdoptArgsForEnabledProviders(enabled []string, values map[string]string) []string {
@@ -335,25 +360,25 @@ func getAdoptArgsForEnabledProviders(enabled []string, values map[string]string)
 
 func getEnabledCAPIProviders(values map[string]string) []string {
 	out := []string{}
-	if values[bootstrapKubeadmPath] == "true" {
+	if values[bootstrapKubeadmPath+providerEnabledKey] == "true" {
 		out = append(out, providerKubeadmBootstrap)
 	}
-	if values[controlplaneKubeadmPath] == "true" {
+	if values[controlplaneKubeadmPath+providerEnabledKey] == "true" {
 		out = append(out, providerKubeadmControlPlane)
 	}
-	if values[dockerPath] == "true" {
+	if values[dockerPath+providerEnabledKey] == "true" {
 		out = append(out, providerDocker)
 	}
-	if values[awsPath] == "true" {
+	if values[awsPath+providerEnabledKey] == "true" {
 		out = append(out, providerAWS)
 	}
-	if values[azurePath] == "true" {
+	if values[azurePath+providerEnabledKey] == "true" {
 		out = append(out, providerAzure)
 	}
-	if values[gcpPath] == "true" {
+	if values[gcpPath+providerEnabledKey] == "true" {
 		out = append(out, providerGCP)
 	}
-	if values[vspherePath] == "true" {
+	if values[vspherePath+providerEnabledKey] == "true" {
 		out = append(out, providerVSphere)
 	}
 	return out


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR exposes `verbosity` on the providers chart and uses it to enable debug logging on e2e and dev-env installed providers.
This will hopefully make debugging failures easier.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
