### PR TITLE
switch deprecated rancher/kubectl image to rancher/kuberlr-kubectl

### DIFF
--- a/charts/rancher-turtles/questions.yml
+++ b/charts/rancher-turtles/questions.yml
@@ -31,9 +31,3 @@ questions:
     type: boolean
     label: Remove cert-manager
     group: "Rancher Turtles Features Settings"
-  - variable: kubectlImage
-    default: "registry.k8s.io/kubernetes/kubectl:v1.34.1"
-    description: "Specify the image to use when running kubectl in jobs."
-    type: string
-    label: Kubectl Image
-    group: "Rancher Turtles Features Settings"

--- a/charts/rancher-turtles/templates/clusterctl-cm-cleanup-job.yaml
+++ b/charts/rancher-turtles/templates/clusterctl-cm-cleanup-job.yaml
@@ -54,22 +54,23 @@ spec:
     spec:
       serviceAccountName: pre-upgrade-job
       containers:
-        - name: rancher-clusterctl-configmap-cleanup
-          image: {{ .Values.kubectlImage }}
-          args:
-          - delete
-          - configmap
-          - --namespace={{ .Values.namespace }}
-          - clusterctl-config
-          - --ignore-not-found=true
-          securityContext:
-            seccompProfile:
-              type: RuntimeDefault
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            runAsNonRoot: true
-            runAsUser: 1000
+      - name: rancher-clusterctl-configmap-cleanup
+        image: {{ .Values.shellImage }}
+        command: ["kubectl"]
+        args:
+        - delete
+        - configmap
+        - --namespace={{ .Values.namespace }}
+        - clusterctl-config
+        - --ignore-not-found=true
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
       restartPolicy: Never
 {{- end }}

--- a/charts/rancher-turtles/templates/post-delete-job.yaml
+++ b/charts/rancher-turtles/templates/post-delete-job.yaml
@@ -61,23 +61,23 @@ spec:
     spec:
       serviceAccountName: post-delete-job
       containers:
-        - name: cluster-api-operator-mutatingwebhook-cleanup
-          image: {{ .Values.kubectlImage }}
-          command: ["kubectl"]
-          args:
-          - delete
-          - mutatingwebhookconfigurations.admissionregistration.k8s.io
-          - capi-mutating-webhook-configuration
-          - --ignore-not-found=true
-          securityContext:
-            seccompProfile:
-              type: RuntimeDefault
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            runAsNonRoot: true
-            runAsUser: 1000
+      - name: cluster-api-operator-mutatingwebhook-cleanup
+        image: {{ .Values.shellImage }}
+        command: ["kubectl"]
+        args:
+        - delete
+        - mutatingwebhookconfigurations.admissionregistration.k8s.io
+        - capi-mutating-webhook-configuration
+        - --ignore-not-found=true
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
       restartPolicy: Never
 ---
 apiVersion: batch/v1
@@ -94,23 +94,23 @@ spec:
     spec:
       serviceAccountName: post-delete-job
       containers:
-        - name: cluster-api-operator-validatingwebhook-cleanup
-          image: {{ .Values.kubectlImage }}
-          command: ["kubectl"]
-          args:
-          - delete
-          - validatingwebhookconfigurations.admissionregistration.k8s.io
-          - capi-validating-webhook-configuration
-          - --ignore-not-found=true
-          securityContext:
-            seccompProfile:
-              type: RuntimeDefault
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            runAsNonRoot: true
-            runAsUser: 1000
+      - name: cluster-api-operator-validatingwebhook-cleanup
+        image: {{ .Values.shellImage }}
+        command: ["kubectl"]
+        args:
+        - delete
+        - validatingwebhookconfigurations.admissionregistration.k8s.io
+        - capi-validating-webhook-configuration
+        - --ignore-not-found=true
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
       restartPolicy: Never
 ---
 apiVersion: batch/v1
@@ -129,7 +129,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: delete-capi-controller-manager
-        image: {{ .Values.kubectlImage }}
+        image: {{ .Values.shellImage }}
         command: ["kubectl"]
         args:
         - delete

--- a/charts/rancher-turtles/templates/pre-delete-job.yaml
+++ b/charts/rancher-turtles/templates/pre-delete-job.yaml
@@ -55,24 +55,25 @@ spec:
     spec:
       serviceAccountName: pre-delete-job
       containers:
-        - name: rancher-capiprovider-cleanup
-          image: {{ .Values.kubectlImage }}
-          args:
-          - delete
-          - capiprovider
-          - cluster-api
-          - -n
-          - {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
-          - --ignore-not-found=true
-          - --cascade=foreground
-          securityContext:
-            seccompProfile:
-              type: RuntimeDefault
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            runAsNonRoot: true
-            runAsUser: 1000
+      - name: rancher-capiprovider-cleanup
+        image: {{ .Values.shellImage }}
+        command: ["kubectl"]
+        args:
+        - delete
+        - capiprovider
+        - cluster-api
+        - -n
+        - {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
+        - --ignore-not-found=true
+        - --cascade=foreground
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
       restartPolicy: Never
 {{- end }}

--- a/charts/rancher-turtles/values.schema.json
+++ b/charts/rancher-turtles/values.schema.json
@@ -42,9 +42,6 @@
     "rancherInstalled": {
       "type": "boolean"
     },
-    "kubectlImage": {
-      "type": "string"
-    },
     "shellImage": {
       "type": "string"
     },

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -27,8 +27,6 @@ managerArguments: []
 imagePullSecrets: []
 # rancherInstalled: True if Rancher already installed is in the cluster, this is the preferred installation way.
 rancherInstalled: true
-# kubectlImage: Image for kubectl tasks.
-kubectlImage: registry.k8s.io/kubernetes/kubectl:v1.34.1
 # shellImage: Image for shell tasks.
 shellImage: rancher/kuberlr-kubectl:v5.0.0
 # features: Optional and experimental features.


### PR DESCRIPTION
**What this PR does / why we need it**:

So far we've used the `rancher/kubectl` image in the chart but this has since been deprecated (see [repository](https://github.com/rancher/kubectl)). The suggested alternative is `rancher/kuberlr-kubectl`, which we're already using (as `shellImage`) in a post-upgrade job where the distroless `rancher/kubectl` cannot be used.

This will also partially address https://github.com/rancher/turtles/issues/1864, as `rancher/kubectl` is not in the list of mirrored images and hence is not valid for air-gapped installations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
