### PR TITLE
Fix unit test flake

### DIFF
--- a/internal/controllers/import_controller_v3_test.go
+++ b/internal/controllers/import_controller_v3_test.go
@@ -378,11 +378,14 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		cluster := rancherClusters.Items[0]
 		Expect(cluster.Name).To(ContainSubstring("c-"))
 
+		_, err := testEnv.CreateNamespaceWithName(ctx, cluster.Name)
+		Expect(err).ToNot(HaveOccurred())
+
 		conditions.Set(&cluster, conditions.TrueCondition(managementv3.ClusterConditionReady))
 		Expect(conditions.IsTrue(&cluster, managementv3.ClusterConditionReady)).To(BeTrue())
 		Expect(cl.Status().Update(ctx, &cluster)).To(Succeed())
 
-		_, err := r.Reconcile(ctx, reconcile.Request{
+		_, err = r.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: capiCluster.Namespace,
 				Name:      capiCluster.Name,


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This is an attempt to fix this flake https://github.com/rancher/turtles/actions/runs/19466936244/job/55704048678?pr=1881

Namespace management in env test is hard, other tests seem to call create namespace explicitly in each test, also removing namespace in after each block is not guaranteed to work.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
