### PR TITLE
Bump CAPI operator patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/cluster-api v1.10.6
-	sigs.k8s.io/cluster-api-operator v0.23.0
+	sigs.k8s.io/cluster-api-operator v0.23.1
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -389,8 +389,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcp
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/cluster-api v1.10.6 h1:0bnLTpT47R8KIvGZ3tTGek0DwMIc8fZi6IxA3Mlqq4g=
 sigs.k8s.io/cluster-api v1.10.6/go.mod h1:vymugs3Jm3gxHVMuVqdzgp6BVy/SEqQVyUg/UM7bnT4=
-sigs.k8s.io/cluster-api-operator v0.23.0 h1:0BJK4w4MPnlLyhsuTnPwNp+vM6hoeS35QgUlSTOW+vs=
-sigs.k8s.io/cluster-api-operator v0.23.0/go.mod h1:RlYJMSCB5nzCnc0NSVDs55onzS3tmh0R531agHPmY+Y=
+sigs.k8s.io/cluster-api-operator v0.23.1 h1:PGOSh6hwALohyNVxOlT6hOBpwfKDob0NfCX0Q4+pbjA=
+sigs.k8s.io/cluster-api-operator v0.23.1/go.mod h1:7dG1JiBw9l0LzmxS38cqcr/ujEmltV9px1WtpViPLjM=
 sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+n0DGU=
 sigs.k8s.io/controller-runtime v0.20.4/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=

--- a/test/go.mod
+++ b/test/go.mod
@@ -19,7 +19,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/cluster-api v1.10.6
-	sigs.k8s.io/cluster-api-operator v0.23.0
+	sigs.k8s.io/cluster-api-operator v0.23.1
 	sigs.k8s.io/cluster-api-operator/test v0.23.0
 	sigs.k8s.io/cluster-api/test v1.10.6
 	sigs.k8s.io/controller-runtime v0.20.4

--- a/test/go.sum
+++ b/test/go.sum
@@ -476,8 +476,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcp
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/cluster-api v1.10.6 h1:0bnLTpT47R8KIvGZ3tTGek0DwMIc8fZi6IxA3Mlqq4g=
 sigs.k8s.io/cluster-api v1.10.6/go.mod h1:vymugs3Jm3gxHVMuVqdzgp6BVy/SEqQVyUg/UM7bnT4=
-sigs.k8s.io/cluster-api-operator v0.23.0 h1:0BJK4w4MPnlLyhsuTnPwNp+vM6hoeS35QgUlSTOW+vs=
-sigs.k8s.io/cluster-api-operator v0.23.0/go.mod h1:RlYJMSCB5nzCnc0NSVDs55onzS3tmh0R531agHPmY+Y=
+sigs.k8s.io/cluster-api-operator v0.23.1 h1:PGOSh6hwALohyNVxOlT6hOBpwfKDob0NfCX0Q4+pbjA=
+sigs.k8s.io/cluster-api-operator v0.23.1/go.mod h1:7dG1JiBw9l0LzmxS38cqcr/ujEmltV9px1WtpViPLjM=
 sigs.k8s.io/cluster-api-operator/test v0.23.0 h1:YkllfgDMfYjBcBBhr942zTUsWjFK+DpVVyt9YaC0QsY=
 sigs.k8s.io/cluster-api-operator/test v0.23.0/go.mod h1:5xj/hXY1WU/oswO+B/hd+sYaKicCh0jxxV5WrFbljoo=
 sigs.k8s.io/cluster-api/test v1.10.6 h1:xMRVX91mmvcWihzFpj9a7Zc5Np+zB6zfYoVD6tyww/s=


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Bump brings latest fix for allowing non-canonical image reference for CAPI providers, for example: `rancher/image`, before this PR only `docker.io/rancher/image` was supported

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
