### PR TITLE
fix: Prefix image repository with image registry for provider images

### DIFF
--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -83,6 +83,12 @@ jobs:
           kubectl --namespace cattle-system wait --for=create deployments/rancher-webhook --timeout=300s
           kubectl --namespace cattle-system wait --for=condition=Available deployment/rancher-webhook --timeout=300s
 
+      - name: Set default registry
+        run: |
+          kubectl patch setting.management.cattle.io -n cattle-system system-default-registry \
+            --type merge \
+            --patch '{"value":"registry.suse.com"}'
+
       - name: Run chart-testing (install)
         run: helm install rancher-turtles out/charts/rancher-turtles/ -n rancher-turtles-system --set namespace=rancher-turtles-system --create-namespace --wait --debug
 
@@ -166,7 +172,7 @@ jobs:
       - name: Check capi-controller-manager image is from kubernetes-sigs (community)
         run: |
           IMAGE=$(kubectl get deployment capi-controller-manager -n cattle-capi-system -o jsonpath='{.spec.template.spec.containers[0].image}')
-          if [[ "$IMAGE" != registry.k8s.io/cluster-api/cluster-api-controller* ]]; then
-            echo "capi-controller-manager does not use registry.k8s.io/cluster-api/cluster-api-controller based image"
+          if [[ "$IMAGE" != rancher/cluster-api-controller* ]]; then
+            echo "capi-controller-manager does not use rancher/cluster-api-controller based image"
             exit 1
           fi

--- a/charts/rancher-turtles/templates/deployment.yaml
+++ b/charts/rancher-turtles/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - args:
         - --leader-elect
-        - --feature-gates=agent-tls-mode={{ index .Values "features" "agent-tls-mode" "enabled"}},ui-plugin={{ index .Values "turtlesUI" "enabled"}},no-cert-manager={{ index .Values "features" "no-cert-manager" "enabled"}}
+        - --feature-gates=agent-tls-mode={{ index .Values "features" "agent-tls-mode" "enabled"}},ui-plugin={{ index .Values "turtlesUI" "enabled"}},no-cert-manager={{ index .Values "features" "no-cert-manager" "enabled"}},use-rancher-default-registry={{ index .Values "features" "use-rancher-default-registry" "enabled"}}
         {{- range .Values.managerArguments }}
         - {{ . }}
         {{- end }}  

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -39,6 +39,10 @@ features:
   no-cert-manager:
     # enabled: Turn on or off.
     enabled: false
+  # use-rancher-default-registry: Alpha feature to use Rancher's default registry for provider images.
+  use-rancher-default-registry:
+    # enabled: Turn on or off.
+    enabled: true
 # volumes: Volumes for controller pods.
 volumes:
   - name: clusterctl-config

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -31,6 +31,9 @@ const (
 
 	// NoCertManager if enabled Turtles will remove cert-manager, including Certificate and Issuer.
 	NoCertManager featuregate.Feature = "no-cert-manager"
+
+	// UseRancherDefaultRegistry if enabled Turtles will use the Rancher default registry for pulling provider images.
+	UseRancherDefaultRegistry featuregate.Feature = "use-rancher-default-registry"
 )
 
 func init() {
@@ -38,7 +41,8 @@ func init() {
 }
 
 var defaultGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	AgentTLSMode:  {Default: true, PreRelease: featuregate.Beta},
-	UIPlugin:      {Default: false, PreRelease: featuregate.Alpha},
-	NoCertManager: {Default: false, PreRelease: featuregate.Alpha},
+	AgentTLSMode:              {Default: true, PreRelease: featuregate.Beta},
+	UIPlugin:                  {Default: false, PreRelease: featuregate.Alpha},
+	NoCertManager:             {Default: false, PreRelease: featuregate.Alpha},
+	UseRancherDefaultRegistry: {Default: true, PreRelease: featuregate.Alpha},
 }

--- a/internal/controllers/clusterctl/config-community.yaml
+++ b/internal/controllers/clusterctl/config-community.yaml
@@ -15,4 +15,4 @@ data:
       type:         "CoreProvider"
     images:
       cluster-api:
-        repository: "registry.k8s.io/cluster-api"
+        repository: "rancher"

--- a/internal/controllers/clusterctl/config-prime.yaml
+++ b/internal/controllers/clusterctl/config-prime.yaml
@@ -68,5 +68,5 @@ data:
         repository: "registry.suse.com/rancher"
       infrastructure-vsphere:
         repository: "registry.suse.com/rancher"
-      addon-fleet:
+      addon-rancher-fleet:
         repository: "registry.suse.com/rancher"

--- a/internal/controllers/clusterctl/config_test.go
+++ b/internal/controllers/clusterctl/config_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	managementv3 "github.com/rancher/turtles/api/rancher/management/v3"
 	"github.com/rancher/turtles/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,6 +52,9 @@ var _ = Describe("ClusterConfig Tests", func() {
 
 		// Register the v1alpha1.ClusterctlConfig type
 		Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		// Register the management.Setting type
+		Expect(managementv3.AddToScheme(scheme)).To(Succeed())
 
 		// Override the configDefault variable to provide custom data for the test
 		configDefault := []byte(`
@@ -110,6 +114,12 @@ data:
 							},
 						},
 					},
+				},
+				&managementv3.Setting{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "system-default-registry",
+					},
+					Value: "registry.example.com",
 				},
 			).
 			Build()

--- a/internal/controllers/clusterctlconfig_controller.go
+++ b/internal/controllers/clusterctlconfig_controller.go
@@ -76,6 +76,7 @@ func (r *ClusterctlConfigReconciler) SetupWithManager(_ context.Context, mgr ctr
 //+kubebuilder:rbac:groups=turtles-capi.cattle.io,resources=clusterctlconfigs/status,verbs=get;list;watch;patch
 //+kubebuilder:rbac:groups=turtles-capi.cattle.io,resources=clusterctlconfigs/finalizers,verbs=get;list;watch;patch;update
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;patch
+//+kubebuilder:rbac:groups="management.cattle.io",resources=settings,verbs=get;list;watch
 
 // Reconcile reconciles the ClusterctlConfig object.
 func (r *ClusterctlConfigReconciler) Reconcile(ctx context.Context, _ reconcile.Request) (ctrl.Result, error) {

--- a/internal/controllers/sync_controller_test.go
+++ b/internal/controllers/sync_controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	managementv3 "github.com/rancher/turtles/api/rancher/management/v3"
 	turtlesv1 "github.com/rancher/turtles/api/v1alpha1"
 	"github.com/rancher/turtles/internal/sync"
 	corev1 "k8s.io/api/core/v1"
@@ -71,10 +72,21 @@ var _ = Describe("Reconcile CAPIProvider", Ordered, func() {
 
 		ns, err = testEnv.CreateNamespace(ctx, "capiprovider")
 		Expect(err).ToNot(HaveOccurred())
+		testEnv.Create(ctx, &managementv3.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "system-default-registry",
+			},
+			Value: "",
+		})
 	})
 
 	AfterEach(func() {
 		Expect(testEnv.Delete(ctx, ns)).Should(Succeed())
+		Expect(testEnv.Delete(ctx, &managementv3.Setting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "system-default-registry",
+			},
+		})).Should(Succeed())
 	})
 
 	It("Should create CAPIProvider secret", func() {

--- a/test/e2e/data/capi-operator/clusterctlconfig.yaml
+++ b/test/e2e/data/capi-operator/clusterctlconfig.yaml
@@ -7,3 +7,7 @@ spec:
   images:
   - name: infrastructure-docker
     repository: "gcr.io/k8s-staging-cluster-api"
+  - name: infrastructure-aws
+    repository: "registry.k8s.io/cluster-api-aws"
+  - name: infrastructure-gcp
+    repository: "registry.k8s.io/cluster-api-gcp"

--- a/tilt/project/Tiltfile
+++ b/tilt/project/Tiltfile
@@ -149,6 +149,7 @@ def update_manager(yaml, containerName, debug, env, name, project):
                         debugArgs.append(arg)
                     if debug_verbose:
                         debugArgs.append("--v=5")
+                    debugArgs.append("--feature-gates=agent-tls-mode=true,no-cert-manager=false,use-rancher-default-registry=true")
                     c["command"] = cmd
                     print(cmd)
                     if len(debugArgs) == 0:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This PR adds a new feature flag (which is enabled by default) that controls whether Turtles will use the Rancher default registry when pulling provider images.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1904 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
