### PR TITLE
fix: legacy release workflow running on >=v0.25

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -1,0 +1,65 @@
+on:
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        description: Tag for the release
+        required: true
+
+      org:
+        type: string
+        description: Organization part of the image name
+        required: true
+
+      image:
+        type: string
+        description: Static image value for the build
+
+      release_dir:
+        type: string
+        description: Directory where release is stored
+        default: .cr-release-packages
+
+jobs:
+  release:
+    name: Create helm release
+    runs-on: ubuntu-latest
+    env:
+      CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: setupGo
+        uses: actions/setup-go@v6.1.0
+        with:
+          go-version-file: go.mod
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Package operator chart
+        run: RELEASE_TAG=${GITHUB_REF##*/} CHART_PACKAGE_DIR=${{ inputs.release_dir }} CONTROLLER_IMG="${{ inputs.org }}/${{ inputs.image }}" ORG=${{ inputs.org }} make release
+
+      - name: Install chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          install_only: true
+
+      - name: Prepare environment for the chart releaser
+        run: |
+          echo "CR_OWNER=$(cut -d '/' -f 1 <<< $GITHUB_REPOSITORY)" >> $GITHUB_ENV
+          echo "CR_GIT_REPO=$(cut -d '/' -f 2 <<< $GITHUB_REPOSITORY)" >> $GITHUB_ENV
+          rm -rf .cr-index
+          mkdir -p .cr-index
+
+      - name: Run chart-releaser upload
+        run: cr upload --skip-existing -c "$(git rev-parse HEAD)" --generate-release-notes --release-name-template "${{ inputs.tag }}" --make-release-latest=false
+
+      - name: Run chart-releaser index
+        run: cr index --push --release-name-template "${{ inputs.tag }}"

--- a/.github/workflows/release-v2.yaml
+++ b/.github/workflows/release-v2.yaml
@@ -3,7 +3,11 @@ name: Turtles release
 on:
   push:
     tags:
-      - 'v*'
+      # This is just a temporary filter while we maintain two release workflows.
+      # TODO: change to "v*" when this becomes the only one.
+      - "v0.2[5-9].*"
+      - "v0.[3-9]*"
+      - "v[1-9]*"
   workflow_dispatch:
 
 permissions:
@@ -182,3 +186,14 @@ jobs:
 
         cat provenance-slsav1.json
         cosign attest --yes --predicate provenance-slsav1.json --type slsaprovenance1 "${MULTI_PLATFORM_IMAGE}"
+
+  chart-release:
+    name: Helm chart release
+    uses: ./.github/workflows/chart-release.yml
+    needs:
+    - merge
+    with:
+      tag: ${{ github.ref_name }}
+      org: rancher
+      image: turtles
+    secrets: inherit

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -47,47 +47,12 @@ jobs:
       secret_registry: ${{ matrix.secret_registry }}
     secrets: inherit
 
-  release:
-    name: Create helm release
+  chart-release:
+    name: Helm chart release
+    uses: ./.github/workflows/chart-release.yml
     needs: [build-push-services]
-    runs-on: ubuntu-latest
-    env:
-      TAG: ${{ github.ref_name }}
-      ORG: ${{ vars.RANCHER_ORG }}
-      CONTROLLER_IMG: ${{ vars.IMAGE_NAME }}
-      RELEASE_DIR: .cr-release-packages
-      CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: setupGo
-        uses: actions/setup-go@v6.1.0
-        with:
-          go-version-file: go.mod
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Package operator chart
-        run: RELEASE_TAG=${GITHUB_REF##*/} CHART_PACKAGE_DIR=${RELEASE_DIR} CONTROLLER_IMG="${{ env.ORG }}/${{ env.CONTROLLER_IMG }}" ORG=${{ env.ORG }} make release
-
-      - name: Install chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
-        with:
-          install_only: true
-
-      - name: Prepare environment for the chart releaser
-        run: |
-          echo "CR_OWNER=$(cut -d '/' -f 1 <<< $GITHUB_REPOSITORY)" >> $GITHUB_ENV
-          echo "CR_GIT_REPO=$(cut -d '/' -f 2 <<< $GITHUB_REPOSITORY)" >> $GITHUB_ENV
-          rm -rf .cr-index
-          mkdir -p .cr-index
-
-      - name: Run chart-releaser upload
-        run: cr upload --skip-existing -c "$(git rev-parse HEAD)" --generate-release-notes --release-name-template "${{ env.TAG }}" --make-release-latest=false
-
-      - name: Run chart-releaser index
-        run: cr index --push --release-name-template "${{ env.TAG }}"
+    with:
+      tag: ${{ github.ref_name }}
+      org: ${{ vars.RANCHER_ORG }}
+      image: ${{ vars.IMAGE_NAME }}
+    secrets: inherit


### PR DESCRIPTION
**What this PR does / why we need it**:

Legacy release workflow, used for releasing Turtles as extension, is running on tags `>=v0.25.x` and pushing images to the Prime registry, even if they're just release candidates. This has to be avoided but, since `v0.24.x` is still supported, this action cannot simply be removed.

- Versions `>=v0.25.x` have to be avoided -> this workflow should only run on `<=v0.24.x`

This Action is also taking care of creating the Turtles Helm chart. As this needs to be used for both release processes, chart releaser should be taken out of this Action and into a separate workflow that runs for both `<=v0.24.x` and `>=v0.25.x`.

**Which issue(s) this PR fixes**:
Fixes #
This will only partially address #1915, as existing release candidate images must be removed from the registry.

**Special notes for your reviewer**:

- `release-workflow` or legacy workflow will only run for tags `<=v0.24.x`
- `release-v2` or new workflow will only run for tags `>=v0.25.0`
- Helm chart building and releasing is now a separate workflow that's called from both release processes.

Note: the filter on `release-v2` can be removed (change back to `v*`) when the legacy workflow is deprecated.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
