### PR TITLE
fix: Use CAPIProvider's name to select resources

### DIFF
--- a/internal/provider/wrangler.go
+++ b/internal/provider/wrangler.go
@@ -459,9 +459,17 @@ func providerDeploymentRestart(ctx context.Context, cl client.Client, provider *
 }
 
 func getSelector(provider *turtlesv1.CAPIProvider) ([]client.ListOption, error) {
-	matchingLabels := []string{
-		provider.Spec.Type.ToName() + provider.Spec.Name,
-		provider.Spec.Name, // ex. "fleet"
+	var matchingLabels []string
+	if provider.Spec.Name != "" {
+		matchingLabels = []string{
+			provider.Spec.Type.ToName() + provider.Spec.Name,
+			provider.Spec.Name, // ex. "fleet"
+		}
+	} else { // support for CAPIProvider's name used as CAPIProvider.spec.name
+		matchingLabels = []string{
+			provider.Spec.Type.ToName() + provider.GetName(),
+			provider.GetName(),
+		}
 	}
 
 	requirement, err := labels.NewRequirement(CAPIProviderLabel, selection.In, matchingLabels)

--- a/test/e2e/data/capi-operator/capi-providers.yaml
+++ b/test/e2e/data/capi-operator/capi-providers.yaml
@@ -10,6 +10,7 @@ metadata:
   name: docker
   namespace: capd-system
 spec:
+  name: docker
   type: infrastructure
 ---
 apiVersion: v1


### PR DESCRIPTION
**What this PR does / why we need it**:

The `CAPIProvider.spec.name` API is used inconsistently all over the place.
In most scenarios it is defined, however there are cases (in tests and documentation), where it is not. 

Turtles also does not seem to set the `CAPIProvider.spec.name` once inferred from the `CAPIProvider.metadata.name`. It will just be empty.

This PR is not a fix to the behavior, but just a workaround to be able to select provider's resources. A workaround will be needed in any case even after a fix to support migration from older Turtles versions.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
