### PR TITLE
feat: add no-cert-manager e2e coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ CHART_RELEASE_DIR ?= $(RELEASE_DIR)/$(CHART_DIR)
 PROVIDERS_CHART_RELEASE_DIR ?= $(RELEASE_DIR)/$(PROVIDERS_CHART_DIR)
 
 # Rancher charts testing
-export RANCHER_CHARTS_REPO_DIR ?= $(RELEASE_DIR)/rancher-charts
+export RANCHER_CHARTS_REPO_DIR ?=  $(abspath $(RELEASE_DIR)/rancher-charts)
 export RANCHER_CHART_DEV_VERSION ?= 108.0.0+up99.99.99
 export RANCHER_CHARTS_BASE_BRANCH ?= dev-v2.13
 
@@ -632,7 +632,7 @@ E2E_RUN_COMMAND=$(E2ECONFIG_VARS) $(GINKGO) -v --trace -p -procs=10 -poll-progre
 		--output-dir="$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" $(GINKGO_ARGS) $(GINKGO_TESTS)
 
 .PHONY: test-e2e
-test-e2e: $(GINKGO) $(HELM) $(CLUSTERCTL) kubectl e2e-image ## Run the end-to-end tests
+test-e2e: $(GINKGO) $(HELM) $(CLUSTERCTL) kubectl e2e-image build-local-rancher-charts ## Run the end-to-end tests
 	$(E2E_RUN_COMMAND)
 
 .PHONY: test-e2e-push-image

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -35,10 +35,10 @@ features:
   agent-tls-mode:
     # enabled: Turn on or off.
     enabled: true
-  # no-cert-manager: Alpha feature for cert-manager removal.
+  # no-cert-manager: Beta feature for cert-manager removal.
   no-cert-manager:
     # enabled: Turn on or off.
-    enabled: false
+    enabled: true
   # use-rancher-default-registry: Alpha feature to use Rancher's default registry for provider images.
   use-rancher-default-registry:
     # enabled: Turn on or off.

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -122,9 +122,6 @@ var (
 
 	// CAPIProvider test data
 
-	//go:embed data/test-providers/namespace.yaml
-	CAPVProviderNamespace []byte
-
 	//go:embed data/test-providers/capv-provider-no-ver.yaml
 	CAPVProviderNoVersion []byte
 
@@ -136,6 +133,11 @@ var (
 
 	//go:embed data/test-providers/clusterctlconfig-updated.yaml
 	ClusterctlConfigUpdated []byte
+
+	//go:embed data/test-providers/dummy-vsphere-template.yaml
+	CAPVDummyMachineTemplate []byte
+
+	// Extra Environment
 
 	//go:embed data/gitea/ingress.yaml
 	GiteaIngress []byte

--- a/test/e2e/data/test-providers/capv-provider-no-ver.yaml
+++ b/test/e2e/data/test-providers/capv-provider-no-ver.yaml
@@ -1,9 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capv-system
+---
 apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: CAPIProvider
 metadata:
   name: vsphere
   namespace: capv-system
 spec:
+  name: vsphere
   type: infrastructure
   variables:
     VSPHERE_USERNAME: ""

--- a/test/e2e/data/test-providers/clusterctlconfig-updated.yaml
+++ b/test/e2e/data/test-providers/clusterctlconfig-updated.yaml
@@ -2,7 +2,7 @@ apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: ClusterctlConfig
 metadata:
   name: clusterctl-config
-  namespace: rancher-turtles-system
+  namespace: cattle-turtles-system
 spec:
   providers:
   - name: vsphere

--- a/test/e2e/data/test-providers/clusterctlconfig.yaml
+++ b/test/e2e/data/test-providers/clusterctlconfig.yaml
@@ -2,7 +2,7 @@ apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: ClusterctlConfig
 metadata:
   name: clusterctl-config
-  namespace: rancher-turtles-system
+  namespace: cattle-turtles-system
 spec:
   providers:
   - name: vsphere

--- a/test/e2e/data/test-providers/dummy-vsphere-template.yaml
+++ b/test/e2e/data/test-providers/dummy-vsphere-template.yaml
@@ -1,0 +1,12 @@
+# This is a dummy template to test the provider webhook configuration
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: dummy-vsphere-test
+  namespace: default
+spec:
+  template:
+    spec:
+      template: 'foo'
+      network:
+       devices: []

--- a/test/e2e/data/test-providers/namespace.yaml
+++ b/test/e2e/data/test-providers/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: capv-system

--- a/test/e2e/data/test-providers/unknown-provider.yaml
+++ b/test/e2e/data/test-providers/unknown-provider.yaml
@@ -1,15 +1,16 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: unknown-provider
+  name: cluster-api-provider-vcluster-system
 spec: {}
 ---
 apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: CAPIProvider
 metadata:
   name: vcluster
-  namespace: unknown-provider
+  namespace: cluster-api-provider-vcluster-system
 spec:
   enableAutomaticUpdate: true # Since this provider is unknown, enabling automatic updates should have no effect.
   version: v0.2.1
   type: infrastructure
+  name: vcluster

--- a/test/e2e/suites/capiprovider/suite_test.go
+++ b/test/e2e/suites/capiprovider/suite_test.go
@@ -26,6 +26,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 	capiframework "sigs.k8s.io/cluster-api/test/framework"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -37,9 +39,6 @@ import (
 
 // Test suite global vars.
 var (
-	// hostName is the host name for the Rancher Manager server.
-	hostName string
-
 	ctx = context.Background()
 
 	setupClusterResult    *testenv.SetupTestClusterResult
@@ -51,7 +50,14 @@ func TestE2E(t *testing.T) {
 
 	ctrl.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	RunSpecs(t, "rancher-turtles-e2e-capiprovider")
+	// Ensure nodes are not ran in parallel.
+	// Tests in this suite mostly influence each other and are meant to run sequentially.
+	// Note that the order of the Ginkgo nodes (Describe) is not deterministic, so ensure cleanup is performed in each node.
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+	suiteConfig.ParallelProcess = 1
+	suiteConfig.ParallelTotal = 1
+
+	RunSpecs(t, "rancher-turtles-e2e-capiprovider", suiteConfig, reporterConfig)
 }
 
 var _ = SynchronizedBeforeSuite(
@@ -63,6 +69,10 @@ var _ = SynchronizedBeforeSuite(
 			Scheme:    e2e.InitScheme(),
 		})
 
+		testenv.DeployCertManager(ctx, testenv.DeployCertManagerInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+		})
+
 		testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 			BootstrapClusterProxy:     setupClusterResult.BootstrapClusterProxy,
 			CustomIngress:             e2e.NginxIngress,
@@ -70,20 +80,54 @@ var _ = SynchronizedBeforeSuite(
 			DefaultIngressClassPatch:  e2e.IngressClassPatch,
 		})
 
-		rancherHookResult := testenv.DeployRancher(ctx, testenv.DeployRancherInput{
+		By("Deploying Gitea for chart repository")
+		giteaResult := testenv.DeployGitea(ctx, testenv.DeployGiteaInput{
 			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+			ValuesFile:            e2e.GiteaValues,
+			CustomIngressConfig:   e2e.GiteaIngress,
+		})
+
+		By("Pushing Rancher charts to Gitea for Turtles installation")
+		chartsResult := testenv.PushRancherChartsToGitea(ctx, testenv.PushRancherChartsToGiteaInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+			GiteaServerAddress:    giteaResult.GitAddress,
+			GiteaRepoName:         "charts",
+			// ChartVersion will be auto-populated from RANCHER_CHART_DEV_VERSION env var or Makefile default
+		})
+
+		By("Installing Rancher to 2.13.x with Gitea chart repository (enables system chart controller)")
+		testenv.UpgradeInstallRancherWithGitea(ctx, testenv.UpgradeInstallRancherWithGiteaInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+			ChartRepoURL:          chartsResult.ChartRepoHTTPURL,
+			ChartRepoBranch:       chartsResult.Branch,
+			ChartVersion:          chartsResult.ChartVersion,
+			TurtlesImageRepo:      "ghcr.io/rancher/turtles-e2e",
+			TurtlesImageTag:       "v0.0.1",
+			RancherWaitInterval:   e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-rancher"),
 			RancherPatches:        [][]byte{e2e.RancherSettingPatch},
 		})
 
-		testenv.DeployRancherTurtles(ctx, testenv.DeployRancherTurtlesInput{
-			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
-			AdditionalValues:      map[string]string{},
-		})
+		By("Waiting for Rancher to be ready")
+		capiframework.WaitForDeploymentsAvailable(ctx, capiframework.WaitForDeploymentsAvailableInput{
+			Getter: setupClusterResult.BootstrapClusterProxy.GetClient(),
+			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+				Name:      "rancher",
+				Namespace: e2e.RancherNamespace,
+			}},
+		}, e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-rancher")...)
+
+		By("Waiting for Turtles controller to be installed by system chart controller")
+		capiframework.WaitForDeploymentsAvailable(ctx, capiframework.WaitForDeploymentsAvailableInput{
+			Getter: setupClusterResult.BootstrapClusterProxy.GetClient(),
+			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+				Name:      "rancher-turtles-controller-manager",
+				Namespace: e2e.NewRancherTurtlesNamespace,
+			}},
+		}, e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers")...)
 
 		data, err := json.Marshal(e2e.Setup{
-			ClusterName:     setupClusterResult.ClusterName,
-			KubeconfigPath:  setupClusterResult.KubeconfigPath,
-			RancherHostname: rancherHookResult.Hostname,
+			ClusterName:    setupClusterResult.ClusterName,
+			KubeconfigPath: setupClusterResult.KubeconfigPath,
 		})
 		Expect(err).ToNot(HaveOccurred())
 		return data
@@ -91,8 +135,6 @@ var _ = SynchronizedBeforeSuite(
 	func(sharedData []byte) {
 		setup := e2e.Setup{}
 		Expect(json.Unmarshal(sharedData, &setup)).To(Succeed())
-
-		hostName = setup.RancherHostname
 
 		bootstrapClusterProxy = capiframework.NewClusterProxy(setup.ClusterName, setup.KubeconfigPath, e2e.InitScheme(), capiframework.WithMachineLogCollector(capiframework.DockerLogCollector{}))
 		Expect(bootstrapClusterProxy).ToNot(BeNil(), "cluster proxy should not be nil")
@@ -113,10 +155,6 @@ var _ = SynchronizedAfterSuite(
 			// add a log line about skipping charts uninstallation and cluster cleanup
 			return
 		}
-
-		testenv.UninstallRancherTurtles(ctx, testenv.UninstallRancherTurtlesInput{
-			BootstrapClusterProxy: bootstrapClusterProxy,
-		})
 
 		testenv.CleanupTestCluster(ctx, testenv.CleanupTestClusterInput{
 			SetupTestClusterResult: *setupClusterResult,

--- a/test/e2e/suites/import-gitops/suite_test.go
+++ b/test/e2e/suites/import-gitops/suite_test.go
@@ -63,6 +63,10 @@ var _ = SynchronizedBeforeSuite(
 			Scheme:    e2e.InitScheme(),
 		})
 
+		testenv.DeployCertManager(ctx, testenv.DeployCertManagerInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+		})
+
 		testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 			BootstrapClusterProxy:     setupClusterResult.BootstrapClusterProxy,
 			CustomIngress:             e2e.NginxIngress,

--- a/test/e2e/suites/v2prov/suite_test.go
+++ b/test/e2e/suites/v2prov/suite_test.go
@@ -68,6 +68,10 @@ var _ = SynchronizedBeforeSuite(
 			Scheme:    e2e.InitScheme(),
 		})
 
+		testenv.DeployCertManager(ctx, testenv.DeployCertManagerInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+		})
+
 		testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 			BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 			CustomIngress:            e2e.NginxIngress,

--- a/test/framework/wrangler.go
+++ b/test/framework/wrangler.go
@@ -1,0 +1,114 @@
+/*
+Copyright © 2023 - 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func VerifyCertificatesInNamespace(ctx context.Context, cl client.Client, namespace string) {
+	Byf("Verifying no Certificates are used in namespace: %s", namespace)
+	certs := schema.GroupVersionKind{
+		Group:   "cert-manager.io",
+		Version: "v1",
+		Kind:    "Certificate",
+	}
+
+	certList := &unstructured.UnstructuredList{}
+	certList.SetGroupVersionKind(certs)
+
+	Expect(cl.List(ctx, certList, &client.ListOptions{Namespace: namespace})).Should(Succeed())
+	Expect(certList.Items).Should(BeEmpty(), "cert-manager Certificates should not have been deployed")
+}
+
+func VerifyIssuersInNamespace(ctx context.Context, cl client.Client, namespace string) {
+	Byf("Should verify no Issuers are used in namespace: %s", namespace)
+	issuers := schema.GroupVersionKind{
+		Group:   "cert-manager.io",
+		Version: "v1",
+		Kind:    "Issuer",
+	}
+
+	issuerList := &unstructured.UnstructuredList{}
+	issuerList.SetGroupVersionKind(issuers)
+
+	Expect(cl.List(ctx, issuerList, &client.ListOptions{Namespace: namespace})).Should(Succeed())
+	Expect(issuerList.Items).Should(BeEmpty(), "cert-manager Issuers should not have been deployed")
+}
+
+func VerifyCertManagerAnnotationsForProvider(ctx context.Context, cl client.Client, providerName string) {
+	Byf("Should verify cert-manager annotations have been removed for provider: %s", providerName)
+	requirement, err := labels.NewRequirement("cluster.x-k8s.io/provider", selection.In, []string{providerName})
+	Expect(err).ShouldNot(HaveOccurred())
+	selector := client.MatchingLabelsSelector{
+		Selector: labels.NewSelector().
+			Add(*requirement),
+	}
+
+	cleanupKinds := []schema.GroupVersionKind{
+		{
+			Group:   "apiextensions.k8s.io",
+			Version: "v1",
+			Kind:    "CustomResourceDefinition",
+		},
+		{
+			Group:   "admissionregistration.k8s.io",
+			Version: "v1",
+			Kind:    "MutatingWebhookConfiguration",
+		},
+		{
+			Group:   "admissionregistration.k8s.io",
+			Version: "v1",
+			Kind:    "ValidatingWebhookConfiguration",
+		},
+	}
+
+	for _, cleanupKind := range cleanupKinds {
+		resourcesList := &unstructured.UnstructuredList{}
+		resourcesList.SetGroupVersionKind(cleanupKind)
+
+		Byf("Verifying %s resources do not contain cert-manager annotations", cleanupKind.Kind)
+		Expect(cl.List(ctx, resourcesList, &client.ListOptions{LabelSelector: selector})).Should(Succeed())
+		Expect(resourcesList.Items).ShouldNot(BeEmpty(), "Could not find any "+cleanupKind.Kind+" for the provider")
+
+		for i := range resourcesList.Items {
+			_, found := resourcesList.Items[i].GetAnnotations()["cert-manager.io/inject-ca-from"]
+			Expect(found).Should(BeFalse(), "cert-manager annotation must be not found on: "+resourcesList.Items[i].GetName())
+		}
+	}
+}
+
+func VerifyWranglerAnnotationsInNamespace(ctx context.Context, cl client.Client, namespace string) {
+	Byf("Should verify wrangler annotations have been added to Services in namespace: %s", namespace)
+	servicesList := &corev1.ServiceList{}
+	Expect(cl.List(ctx, servicesList, &client.ListOptions{Namespace: namespace})).Should(Succeed())
+	Expect(servicesList.Items).ShouldNot(BeEmpty())
+
+	for _, service := range servicesList.Items {
+		Expect(service.GetAnnotations()).ShouldNot(BeEmpty())
+		_, found := service.GetAnnotations()["need-a-cert.cattle.io/secret-name"]
+		Expect(found).Should(BeTrue(), "need-a-cert.cattle.io/secret-name annotation must be found on Service: "+service.GetName())
+	}
+}

--- a/test/testenv/certmanager.go
+++ b/test/testenv/certmanager.go
@@ -1,0 +1,89 @@
+/*
+Copyright © 2023 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testenv
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	turtlesframework "github.com/rancher/turtles/test/framework"
+
+	opframework "sigs.k8s.io/cluster-api-operator/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework"
+)
+
+// DeployCertManagerInput represents the input parameters for deploying Cert Manager.
+type DeployCertManagerInput struct {
+	// BootstrapClusterProxy is the cluster proxy for bootstrapping.
+	BootstrapClusterProxy framework.ClusterProxy
+
+	// HelmBinaryPath is the path to the Helm binary.
+	HelmBinaryPath string `env:"HELM_BINARY_PATH"`
+
+	// CertManagerChartPath is the path to the Cert Manager chart.
+	CertManagerChartPath string `env:"CERT_MANAGER_PATH"`
+
+	// CertManagerUrl is the URL for Cert Manager.
+	CertManagerUrl string `env:"CERT_MANAGER_URL"`
+
+	// CertManagerRepoName is the repository name for Cert Manager.
+	CertManagerRepoName string `env:"CERT_MANAGER_REPO_NAME"`
+}
+
+// DeployCertManager deploys Cert Manager using the provided input parameters.
+func DeployCertManager(ctx context.Context, input DeployCertManagerInput) {
+	Expect(turtlesframework.Parse(&input)).To(Succeed(), "Failed to parse environment variables")
+
+	Expect(ctx).NotTo(BeNil(), "ctx is required for DeployRancher")
+	Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "BootstrapClusterProxy is required for DeployCertManager")
+
+	Expect(input.CertManagerRepoName).ToNot(BeEmpty(), "CertManagerRepoName is required for DeployRancher")
+	Expect(input.CertManagerUrl).ToNot(BeEmpty(), "CertManagerUrl is required for DeployRancher")
+	Expect(input.CertManagerChartPath).ToNot(BeEmpty(), "CertManagerChartPath is required for DeployRancher")
+
+	By("Adding cert-manager chart repo")
+	certChart := &opframework.HelmChart{
+		BinaryPath:      input.HelmBinaryPath,
+		Name:            input.CertManagerRepoName,
+		Path:            input.CertManagerUrl,
+		Commands:        opframework.Commands(opframework.Repo, opframework.Add),
+		AdditionalFlags: opframework.Flags("--force-update"),
+		Kubeconfig:      input.BootstrapClusterProxy.GetKubeconfigPath(),
+	}
+	_, certErr := certChart.Run(nil)
+	Expect(certErr).ToNot(HaveOccurred())
+
+	By("Installing cert-manager")
+	certManagerChart := &opframework.HelmChart{
+		BinaryPath: input.HelmBinaryPath,
+		Path:       input.CertManagerChartPath,
+		Name:       "cert-manager",
+		Kubeconfig: input.BootstrapClusterProxy.GetKubeconfigPath(),
+		AdditionalFlags: opframework.Flags(
+			"--namespace", "cert-manager",
+			"--version", "v1.16.3",
+			"--create-namespace",
+		),
+		Wait: true,
+	}
+	_, err := certManagerChart.Run(map[string]string{
+		"crds.enabled": "true",
+		"crds.keep":    "true",
+	})
+	Expect(err).ToNot(HaveOccurred())
+}

--- a/test/testenv/operator.go
+++ b/test/testenv/operator.go
@@ -30,6 +30,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,7 +61,7 @@ type CAPIOperatorDeployProviderInput struct {
 	WaitDeploymentsReadyInterval []interface{} `envDefault:"15m,10s"`
 
 	// WaitForDeployments is the list of deployments to wait for.
-	WaitForDeployments []NamespaceName
+	WaitForDeployments []types.NamespacedName
 
 	// CustomWaiter is a slice of functions for custom waiting logic.
 	CustomWaiter []func(ctx context.Context)
@@ -70,11 +71,6 @@ type CAPIOperatorDeployProviderInput struct {
 type ProviderTemplateData struct {
 	// ProviderVersion is the version of the provider
 	ProviderVersion string
-}
-
-type NamespaceName struct {
-	Name      string
-	Namespace string
 }
 
 type OCIProvider struct {

--- a/test/testenv/providers.go
+++ b/test/testenv/providers.go
@@ -34,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	opframework "sigs.k8s.io/cluster-api-operator/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -393,32 +394,32 @@ func getEnabledCAPIProviders(values map[string]string) []string {
 	return out
 }
 
-func getDeploymentsForEnabledProviders(enabled []string, useLegacyCAPINamespace bool) []NamespaceName {
+func getDeploymentsForEnabledProviders(enabled []string, useLegacyCAPINamespace bool) []types.NamespacedName {
 	capiNamespace := namespaceCAPISystem
 	if useLegacyCAPINamespace {
 		capiNamespace = legacyNamespaceCAPISystem
 	}
 
-	deployments := []NamespaceName{
+	deployments := []types.NamespacedName{
 		{Name: deployCAPIControllerManager, Namespace: capiNamespace},
 	}
 
 	for _, name := range enabled {
 		switch name {
 		case providerKubeadmBootstrap:
-			deployments = append(deployments, NamespaceName{Name: deployKubeadmBootstrapControllerManager, Namespace: namespaceKubeadmBootstrapSystem})
+			deployments = append(deployments, types.NamespacedName{Name: deployKubeadmBootstrapControllerManager, Namespace: namespaceKubeadmBootstrapSystem})
 		case providerKubeadmControlPlane:
-			deployments = append(deployments, NamespaceName{Name: deployKubeadmControlPlaneControllerManager, Namespace: namespaceKubeadmControlPlaneSystem})
+			deployments = append(deployments, types.NamespacedName{Name: deployKubeadmControlPlaneControllerManager, Namespace: namespaceKubeadmControlPlaneSystem})
 		case providerDocker:
-			deployments = append(deployments, NamespaceName{Name: deployCAPDControllerManager, Namespace: namespaceCAPDSystem})
+			deployments = append(deployments, types.NamespacedName{Name: deployCAPDControllerManager, Namespace: namespaceCAPDSystem})
 		case providerAWS:
-			deployments = append(deployments, NamespaceName{Name: deployCAPAControllerManager, Namespace: namespaceCAPASystem})
+			deployments = append(deployments, types.NamespacedName{Name: deployCAPAControllerManager, Namespace: namespaceCAPASystem})
 		case providerAzure:
-			deployments = append(deployments, NamespaceName{Name: deployCAPZControllerManager, Namespace: namespaceCAPZSystem})
+			deployments = append(deployments, types.NamespacedName{Name: deployCAPZControllerManager, Namespace: namespaceCAPZSystem})
 		case providerGCP:
-			deployments = append(deployments, NamespaceName{Name: deployCAPGControllerManager, Namespace: namespaceCAPGSystem})
+			deployments = append(deployments, types.NamespacedName{Name: deployCAPGControllerManager, Namespace: namespaceCAPGSystem})
 		case providerVSphere:
-			deployments = append(deployments, NamespaceName{Name: deployCAPVControllerManager, Namespace: namespaceCAPVSystem})
+			deployments = append(deployments, types.NamespacedName{Name: deployCAPVControllerManager, Namespace: namespaceCAPVSystem})
 		}
 	}
 

--- a/test/testenv/rancher.go
+++ b/test/testenv/rancher.go
@@ -18,13 +18,13 @@ package testenv
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	turtlesframework "github.com/rancher/turtles/test/framework"
 
-	"github.com/drone/envsubst/v2"
 	"github.com/rancher/turtles/test/e2e"
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
@@ -46,18 +46,6 @@ type DeployRancherInput struct {
 
 	// HelmExtraValuesPath is the path to the Helm extra values file.
 	HelmExtraValuesPath string `env:",expand" envDefault:"${HELM_EXTRA_VALUES_FOLDER}/deploy-rancher.yaml"`
-
-	// InstallCertManager is the flag indicating whether to install Cert Manager.
-	InstallCertManager bool `env:"INSTALL_CERT_MANAGER" envDefault:"true"`
-
-	// CertManagerChartPath is the path to the Cert Manager chart.
-	CertManagerChartPath string `env:"CERT_MANAGER_PATH"`
-
-	// CertManagerUrl is the URL for Cert Manager.
-	CertManagerUrl string `env:"CERT_MANAGER_URL"`
-
-	// CertManagerRepoName is the repository name for Cert Manager.
-	CertManagerRepoName string `env:"CERT_MANAGER_REPO_NAME"`
 
 	// RancherChartRepoName is the repository name for Rancher chart.
 	RancherChartRepoName string `env:"RANCHER_REPO_NAME"`
@@ -98,12 +86,7 @@ type DeployRancherInput struct {
 	// ControllerWaitInterval is the wait interval for the controller.
 	ControllerWaitInterval []interface{} `envDefault:"15m,10s"`
 
-	// RancherIngressConfig is the ingress configuration for Rancher.
-	RancherIngressConfig []byte
-
-	// RancherServicePatch is the service patch for Rancher.
-	RancherServicePatch []byte
-
+	// RancherIngressClassName is the class name of the Ingress used by Rancher.
 	RancherIngressClassName string
 
 	// Development is the flag indicating whether it is a development environment.
@@ -138,14 +121,10 @@ type deployRancherIngressValuesFile struct {
 // If RancherIngressConfig is provided, the function sets up the ingress for Rancher.
 // If RancherServicePatch is provided, the function updates the Rancher service.
 // The function waits for the Rancher webhook rollout and the fleet controller rollout.
+//
+// Deprecated: Use UpgradeInstallRancherWithGitea instead to bootstrap Rancher using a custom Turtles system chart.
 func DeployRancher(ctx context.Context, input DeployRancherInput) PreRancherInstallHookResult {
 	Expect(turtlesframework.Parse(&input)).To(Succeed(), "Failed to parse environment variables")
-
-	By("Running rancher pre-install hook")
-	rancherHookResult := PreRancherInstallHook(&PreRancherInstallHookInput{
-		Ctx:          ctx,
-		RancherInput: &input,
-	})
 
 	Expect(ctx).NotTo(BeNil(), "ctx is required for DeployRancher")
 	Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "BootstrapClusterProxy is required for DeployRancher")
@@ -160,29 +139,19 @@ func DeployRancher(ctx context.Context, input DeployRancherInput) PreRancherInst
 	Expect(input.RancherWaitInterval).ToNot(BeNil(), "RancherWaitInterval is required for DeployRancher")
 	Expect(input.ControllerWaitInterval).ToNot(BeNil(), "ControllerWaitInterval is required for DeployRancher")
 
+	By("Running rancher pre-install hook")
+	rancherHookResult := PreRancherInstallHook(PreRancherInstallHookInput{
+		Ctx:                     ctx,
+		BootstrapClusterProxy:   input.BootstrapClusterProxy,
+		RancherIngressClassName: input.RancherIngressClassName,
+		RancherHostname:         input.RancherHost,
+	})
+
 	if input.RancherVersion == "" && input.RancherImageTag == "" {
 		Fail("RancherVersion or RancherImageTag is required")
 	}
 	if input.RancherVersion != "" && input.RancherImageTag != "" {
 		Fail("Only one of RancherVersion or RancherImageTag cen be used")
-	}
-
-	if input.InstallCertManager {
-		Expect(input.CertManagerRepoName).ToNot(BeEmpty(), "CertManagerRepoName is required for DeployRancher")
-		Expect(input.CertManagerUrl).ToNot(BeEmpty(), "CertManagerUrl is required for DeployRancher")
-		Expect(input.CertManagerChartPath).ToNot(BeEmpty(), "CertManagerChartPath is required for DeployRancher")
-
-		By("Add cert manager chart repo")
-		certChart := &opframework.HelmChart{
-			BinaryPath:      input.HelmBinaryPath,
-			Name:            input.CertManagerRepoName,
-			Path:            input.CertManagerUrl,
-			Commands:        opframework.Commands(opframework.Repo, opframework.Add),
-			AdditionalFlags: opframework.Flags("--force-update"),
-			Kubeconfig:      input.BootstrapClusterProxy.GetKubeconfigPath(),
-		}
-		_, certErr := certChart.Run(nil)
-		Expect(certErr).ToNot(HaveOccurred())
 	}
 
 	By("Adding Rancher chart repo")
@@ -205,30 +174,9 @@ func DeployRancher(ctx context.Context, input DeployRancherInput) PreRancherInst
 	_, err = updateChart.Run(nil)
 	Expect(err).ToNot(HaveOccurred())
 
-	if input.InstallCertManager {
-		By("Installing cert-manager")
-		certManagerChart := &opframework.HelmChart{
-			BinaryPath: input.HelmBinaryPath,
-			Path:       input.CertManagerChartPath,
-			Name:       "cert-manager",
-			Kubeconfig: input.BootstrapClusterProxy.GetKubeconfigPath(),
-			AdditionalFlags: opframework.Flags(
-				"--namespace", "cert-manager",
-				"--version", "v1.16.3",
-				"--create-namespace",
-			),
-			Wait: true,
-		}
-		_, err = certManagerChart.Run(map[string]string{
-			"crds.enabled": "true",
-			"crds.keep":    "true",
-		})
-		Expect(err).ToNot(HaveOccurred())
-	}
-
 	yamlExtraValues, err := yaml.Marshal(deployRancherValuesFile{
 		BootstrapPassword: input.RancherPassword,
-		Hostname:          input.RancherHost,
+		Hostname:          rancherHookResult.Hostname,
 	})
 	Expect(err).ToNot(HaveOccurred())
 	err = os.WriteFile(input.HelmExtraValuesPath, yamlExtraValues, 0644)
@@ -273,8 +221,8 @@ func DeployRancher(ctx context.Context, input DeployRancherInput) PreRancherInst
 	if input.RancherImageTag != "" {
 		values["rancherImageTag"] = input.RancherImageTag
 	}
-	if input.RancherIngressClassName != "" {
-		values["ingress.ingressClassName"] = input.RancherIngressClassName
+	if rancherHookResult.IngressClassName != "" {
+		values["ingress.ingressClassName"] = rancherHookResult.IngressClassName
 	}
 	// Merge additional values
 	for k, v := range input.AdditionalValues {
@@ -284,16 +232,8 @@ func DeployRancher(ctx context.Context, input DeployRancherInput) PreRancherInst
 	_, err = chart.Run(values)
 	Expect(err).ToNot(HaveOccurred())
 
-	if len(input.RancherIngressConfig) > 0 { // only true when using kind + ngrok
-		By("Setting up ingress")
-		ingress, err := envsubst.Eval(string(input.RancherIngressConfig), os.Getenv)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(turtlesframework.Apply(ctx, input.BootstrapClusterProxy, []byte(ingress))).To(Succeed())
-		input.RancherPatches = append(input.RancherPatches, e2e.SystemStoreSettingPatch)
-	}
-	if len(input.RancherServicePatch) > 0 {
-		By("Updating rancher svc")
-		Expect(turtlesframework.Apply(ctx, input.BootstrapClusterProxy, input.RancherServicePatch)).To(Succeed())
+	if len(rancherHookResult.ConfigPatches) > 0 {
+		input.RancherPatches = append(input.RancherPatches, rancherHookResult.ConfigPatches...)
 	}
 
 	By("Updating rancher configuration")
@@ -302,7 +242,7 @@ func DeployRancher(ctx context.Context, input DeployRancherInput) PreRancherInst
 			Proxy:    input.BootstrapClusterProxy,
 			Template: patch,
 			AddtionalEnvironmentVariables: map[string]string{
-				e2e.RancherHostnameVar: input.RancherHost,
+				e2e.RancherHostnameVar: rancherHookResult.Hostname,
 			},
 		})).To(Succeed())
 	}
@@ -558,11 +498,14 @@ type PreRancherInstallHookInput struct {
 	// Ctx is the context for the hook execution.
 	Ctx context.Context
 
+	// BootstrapClusterProxy is the cluster proxy for bootstrapping.
+	BootstrapClusterProxy framework.ClusterProxy
+
 	// EnvironmentType is the environment type
 	EnvironmentType e2e.ManagementClusterEnvironmentType `env:"MANAGEMENT_CLUSTER_ENVIRONMENT"`
 
-	// RancherInput is the input parameters for deploying Rancher.
-	RancherInput *DeployRancherInput `env:",init"`
+	// RancherIngressClassName is the class name of the Ingress used by Rancher.
+	RancherIngressClassName string
 
 	// IngressWaitInterval is the interval to wait between ingress checks.
 	IngressWaitInterval []interface{} `envDefault:"15m,10s"`
@@ -575,6 +518,10 @@ type PreRancherInstallHookInput struct {
 type PreRancherInstallHookResult struct {
 	// Hostname is the hostname of the Rancher installation.
 	Hostname string
+	// IngressClassName is the class name of the Ingress used by Rancher.
+	IngressClassName string
+	// ConfigPatches is an optional list of additional patches that need to be applied to configure Rancher.
+	ConfigPatches [][]byte
 }
 
 // PreRancherInstallHook is a function that performs pre-installation tasks for Rancher.
@@ -583,43 +530,46 @@ type PreRancherInstallHookResult struct {
 // It also deploys ghcr details by creating a Docker registry secret.
 // If the infrastructure type is e2e.ManagementClusterEnvironmentIsolatedKind, it sets the isolated host name as the Rancher host.
 // If the infrastructure type is e2e.ManagementClusterEnvironmentKind, it sets the Rancher ingress config and service patch based on the provided values.
-// The function returns the host name as part of the PreRancherInstallHookResult.
-func PreRancherInstallHook(input *PreRancherInstallHookInput) PreRancherInstallHookResult {
-	Expect(turtlesframework.Parse(input)).To(Succeed(), "Failed to parse environment variables")
-
-	hostName := ""
+func PreRancherInstallHook(input PreRancherInstallHookInput) PreRancherInstallHookResult {
+	Expect(turtlesframework.Parse(&input)).To(Succeed(), "Failed to parse environment variables")
 
 	switch input.EnvironmentType {
 	case e2e.ManagementClusterEnvironmentEKS:
 		By("Getting ingress hostname")
 		svcRes := &WaitForServiceIngressHostnameResult{}
 		WaitForServiceIngressHostname(input.Ctx, WaitForServiceIngressHostnameInput{
-			BootstrapClusterProxy: input.RancherInput.BootstrapClusterProxy,
+			BootstrapClusterProxy: input.BootstrapClusterProxy,
 			ServiceName:           "ingress-nginx-controller",
 			ServiceNamespace:      "ingress-nginx",
 			IngressWaitInterval:   input.IngressWaitInterval,
 		}, svcRes)
 
-		hostName = svcRes.Hostname
-		input.RancherInput.RancherHost = hostName
-
 		By("Deploying ghcr details")
 		turtlesframework.CreateDockerRegistrySecret(input.Ctx, turtlesframework.CreateDockerRegistrySecretInput{
-			BootstrapClusterProxy: input.RancherInput.BootstrapClusterProxy,
+			BootstrapClusterProxy: input.BootstrapClusterProxy,
 		})
 
-		input.RancherInput.RancherIngressClassName = "nginx"
+		return PreRancherInstallHookResult{
+			Hostname:         svcRes.Hostname,
+			IngressClassName: "nginx",
+		}
 	case e2e.ManagementClusterEnvironmentIsolatedKind:
-		hostName = getInternalClusterHostname(input.Ctx, input.RancherInput.BootstrapClusterProxy)
-		input.RancherInput.RancherHost = hostName
+		By("Getting internal cluster hostname")
+		hostname := getInternalClusterHostname(input.Ctx, input.BootstrapClusterProxy)
+		return PreRancherInstallHookResult{
+			Hostname:         hostname,
+			IngressClassName: input.RancherIngressClassName,
+		}
 	case e2e.ManagementClusterEnvironmentKind:
+		By("Using RANCHER_HOSTNAME")
 		// i.e. we are using ngrok locally
-		input.RancherInput.RancherIngressConfig = e2e.IngressConfig
-		input.RancherInput.RancherServicePatch = e2e.RancherServicePatch
-		input.RancherInput.RancherHost = input.RancherHostname
-	}
-
-	return PreRancherInstallHookResult{
-		Hostname: input.RancherInput.RancherHost,
+		return PreRancherInstallHookResult{
+			Hostname:         input.RancherHostname,
+			IngressClassName: input.RancherIngressClassName,
+			ConfigPatches:    [][]byte{e2e.RancherServicePatch, e2e.IngressConfig, e2e.SystemStoreSettingPatch},
+		}
+	default:
+		Fail(fmt.Sprintf("Unknown MANAGEMENT_CLUSTER_ENVIRONMENT: %s", input.EnvironmentType))
+		return PreRancherInstallHookResult{}
 	}
 }

--- a/test/testenv/rancher_system_chart.go
+++ b/test/testenv/rancher_system_chart.go
@@ -31,7 +31,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	opframework "sigs.k8s.io/cluster-api-operator/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -108,8 +110,8 @@ func UpdateRancherDeploymentWithChartConfig(ctx context.Context, input UpdateRan
 	Expect(input.BootstrapClusterProxy.GetClient().Update(ctx, deployment)).To(Succeed())
 }
 
-// UpgradeRancherWithGiteaInput represents the input for UpgradeRancherWithGitea.
-type UpgradeRancherWithGiteaInput struct {
+// UpgradeInstallRancherWithGiteaInput represents the input for UpgradeInstallRancherWithGitea.
+type UpgradeInstallRancherWithGiteaInput struct {
 	// BootstrapClusterProxy is the cluster proxy for the bootstrap cluster.
 	BootstrapClusterProxy framework.ClusterProxy
 
@@ -122,8 +124,17 @@ type UpgradeRancherWithGiteaInput struct {
 	// RancherChartURL is the URL for Rancher chart.
 	RancherChartURL string `env:"RANCHER_URL"`
 
+	// RancherHostname is the hostname to be used by Rancher. This depends on the result of PreRancherInstallHook and it's based on MANAGEMENT_CLUSTER_ENVIRONMENT.
+	RancherHostname string `env:"RANCHER_HOSTNAME"`
+
+	// RancherIngressClassName is the class name of the Ingress used by Rancher.
+	RancherIngressClassName string
+
 	// RancherNamespace is the namespace for Rancher.
 	RancherNamespace string `env:"RANCHER_NAMESPACE" envDefault:"cattle-system"`
+
+	// RancherPatches are the patches for Rancher.
+	RancherPatches [][]byte
 
 	// RancherVersion is the version to upgrade to.
 	RancherVersion string `env:"RANCHER_VERSION"`
@@ -147,16 +158,17 @@ type UpgradeRancherWithGiteaInput struct {
 	RancherWaitInterval []interface{} `envDefault:"15m,30s"`
 }
 
-// UpgradeRancherWithGitea upgrades Rancher to a new version and configures it with Gitea chart repository
+// UpgradeInstallRancherWithGitea upgrades Rancher to a new version and configures it with Gitea chart repository
 // environment variables to enable the system chart controller.
-func UpgradeRancherWithGitea(ctx context.Context, input UpgradeRancherWithGiteaInput) {
+func UpgradeInstallRancherWithGitea(ctx context.Context, input UpgradeInstallRancherWithGiteaInput) {
 	Expect(turtlesframework.Parse(&input)).To(Succeed(), "Failed to parse environment variables")
 
-	Expect(ctx).NotTo(BeNil(), "ctx is required for UpgradeRancherWithGitea")
+	Expect(ctx).NotTo(BeNil(), "ctx is required for UpgradeInstallRancherWithGitea")
 	Expect(input.BootstrapClusterProxy).NotTo(BeNil(), "BootstrapClusterProxy is required")
 	Expect(input.HelmBinaryPath).NotTo(BeEmpty(), "HelmBinaryPath is required")
 	Expect(input.RancherChartRepoName).NotTo(BeEmpty(), "RancherChartRepoName is required")
 	Expect(input.RancherChartURL).NotTo(BeEmpty(), "RancherChartURL is required")
+	Expect(input.RancherHostname).NotTo(BeEmpty(), "RancherHostname is required")
 	Expect(input.RancherNamespace).NotTo(BeEmpty(), "RancherNamespace is required")
 	Expect(input.RancherVersion).NotTo(BeEmpty(), "RancherVersion is required")
 	Expect(input.ChartRepoURL).NotTo(BeEmpty(), "ChartRepoURL is required")
@@ -164,16 +176,48 @@ func UpgradeRancherWithGitea(ctx context.Context, input UpgradeRancherWithGiteaI
 	Expect(input.ChartVersion).NotTo(BeEmpty(), "ChartVersion is required")
 	Expect(input.RancherWaitInterval).NotTo(BeNil(), "RancherWaitInterval is required")
 
-	By(fmt.Sprintf("Upgrading Rancher to version %s with Gitea chart repository", input.RancherVersion))
+	By("Adding Rancher chart repo")
+	addChart := &opframework.HelmChart{
+		BinaryPath:      input.HelmBinaryPath,
+		Name:            input.RancherChartRepoName,
+		Path:            input.RancherChartURL,
+		Commands:        opframework.Commands(opframework.Repo, opframework.Add),
+		AdditionalFlags: opframework.Flags("--force-update"),
+		Kubeconfig:      input.BootstrapClusterProxy.GetKubeconfigPath(),
+	}
+	_, err := addChart.Run(nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	updateChart := &opframework.HelmChart{
+		BinaryPath: input.HelmBinaryPath,
+		Commands:   opframework.Commands(opframework.Repo, opframework.Update),
+		Kubeconfig: input.BootstrapClusterProxy.GetKubeconfigPath(),
+	}
+	_, err = updateChart.Run(nil)
+	Expect(err).ToNot(HaveOccurred())
+
+	By(fmt.Sprintf("Upgrading/Installing Rancher to version %s with Gitea chart repository", input.RancherVersion))
+
+	By("Running rancher pre-install hook")
+	rancherHookResult := PreRancherInstallHook(PreRancherInstallHookInput{
+		Ctx:                     ctx,
+		BootstrapClusterProxy:   input.BootstrapClusterProxy,
+		RancherIngressClassName: input.RancherIngressClassName,
+		RancherHostname:         input.RancherHostname,
+	})
+	input.RancherPatches = append(input.RancherPatches, rancherHookResult.ConfigPatches...)
 
 	// Run helm upgrade with environment variables for system chart controller
 	upgradeCmd := exec.Command(
 		input.HelmBinaryPath,
 		"upgrade", "rancher",
 		fmt.Sprintf("%s/rancher", input.RancherChartRepoName),
+		"--install",
+		"--create-namespace",
 		"--namespace", input.RancherNamespace,
 		"--version", input.RancherVersion,
 		"--reuse-values",
+		"--set", fmt.Sprintf("hostname=%s", rancherHookResult.Hostname),
 		"--set", "extraEnv[0].name=CATTLE_CHART_DEFAULT_URL",
 		"--set", fmt.Sprintf("extraEnv[0].value=%s", input.ChartRepoURL),
 		"--set", "extraEnv[1].name=CATTLE_CHART_DEFAULT_BRANCH",
@@ -187,7 +231,7 @@ func UpgradeRancherWithGitea(ctx context.Context, input UpgradeRancherWithGiteaI
 	output, err := upgradeCmd.CombinedOutput()
 	Expect(err).ToNot(HaveOccurred(), "Failed to upgrade Rancher: %s", string(output))
 
-	By("Waiting for Rancher deployment to be ready after upgrade")
+	By("Waiting for Rancher deployment to be ready")
 	framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
 		Getter: input.BootstrapClusterProxy.GetClient(),
 		Deployment: &appsv1.Deployment{
@@ -212,22 +256,30 @@ func UpgradeRancherWithGitea(ctx context.Context, input UpgradeRancherWithGiteaI
 		patchOutput, patchErr := patchCmd.CombinedOutput()
 		Expect(patchErr).ToNot(HaveOccurred(), "Failed to patch rancher-config ConfigMap: %s", string(patchOutput))
 	}
+
+	By("Applying additional patches")
+	for _, patch := range input.RancherPatches {
+		Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+			Proxy:    input.BootstrapClusterProxy,
+			Template: patch,
+			AddtionalEnvironmentVariables: map[string]string{
+				e2e.RancherHostnameVar: rancherHookResult.Hostname,
+			},
+		})).To(Succeed())
+	}
 }
 
-// BuildAndPushRancherChartsToGiteaInput represents the input parameters for building and pushing Rancher charts to Gitea.
-type BuildAndPushRancherChartsToGiteaInput struct {
+// PushRancherChartsToGiteaInput represents the input parameters for building and pushing Rancher charts to Gitea.
+type PushRancherChartsToGiteaInput struct {
 	// BootstrapClusterProxy is the cluster proxy for the bootstrap cluster.
 	BootstrapClusterProxy framework.ClusterProxy
 
-	// RootDir is the root directory of the turtles repository.
-	RootDir string
-
 	// RancherChartsRepoDir is the directory where the rancher/charts repo will be created by the Makefile.
-	RancherChartsRepoDir string
+	RancherChartsRepoDir string `env:"RANCHER_CHARTS_REPO_DIR"`
 
 	// RancherChartsBaseBranch is the branch name to use in the charts repo (e.g., dev-v2.13).
 	// Turtles integration with Rancher system chart controller starts from Rancher v2.13.0.
-	RancherChartsBaseBranch string `envDefault:"dev-v2.13"`
+	RancherChartsBaseBranch string `env:"RANCHER_CHARTS_BASE_BRANCH" envDefault:"dev-v2.13"`
 
 	// GiteaServerAddress is the address of the Gitea server.
 	GiteaServerAddress string
@@ -246,8 +298,8 @@ type BuildAndPushRancherChartsToGiteaInput struct {
 	ChartVersion string `env:"RANCHER_CHART_DEV_VERSION" envDefault:"108.0.0+up99.99.99"`
 }
 
-// BuildAndPushRancherChartsToGiteaResult represents the result of building and pushing charts.
-type BuildAndPushRancherChartsToGiteaResult struct {
+// PushRancherChartsToGiteaResult represents the result of building and pushing charts.
+type PushRancherChartsToGiteaResult struct {
 	// ChartRepoURL is the URL of the chart repository in Gitea (for git clone).
 	ChartRepoURL string
 
@@ -264,27 +316,25 @@ type BuildAndPushRancherChartsToGiteaResult struct {
 	ChartVersion string
 }
 
-// BuildAndPushRancherChartsToGitea builds the Turtles chart using the Makefile target and pushes it to a Gitea server.
+// PushRancherChartsToGitea pushes the Turtles chart to a Gitea server.
 // This is used for testing the system chart controller integration with Rancher.
-// It leverages the existing build-local-rancher-charts Makefile target and then pushes the result to Gitea.
+// The chart is expected to be prepared before the tests run, using `make build-local-rancher-charts`.`
 //
 // The result can be used to configure Rancher with environment variables:
 //   - CATTLE_CHART_DEFAULT_URL: result.ChartRepoHTTPURL
 //   - CATTLE_CHART_DEFAULT_BRANCH: result.Branch
 //   - CATTLE_RANCHER_TURTLES_VERSION: input.ChartVersion
-func BuildAndPushRancherChartsToGitea(ctx context.Context, input BuildAndPushRancherChartsToGiteaInput) *BuildAndPushRancherChartsToGiteaResult {
+func PushRancherChartsToGitea(ctx context.Context, input PushRancherChartsToGiteaInput) *PushRancherChartsToGiteaResult {
 	Expect(turtlesframework.Parse(&input)).To(Succeed(), "Failed to parse environment variables")
 
-	Expect(ctx).NotTo(BeNil(), "ctx is required for BuildAndPushRancherChartsToGitea")
-	Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "BootstrapClusterProxy is required for BuildAndPushRancherChartsToGitea")
-	Expect(input.RootDir).ToNot(BeEmpty(), "RootDir is required for BuildAndPushRancherChartsToGitea")
-	Expect(input.RancherChartsRepoDir).ToNot(BeEmpty(), "RancherChartsRepoDir is required for BuildAndPushRancherChartsToGitea")
-	Expect(input.RancherChartsBaseBranch).ToNot(BeEmpty(), "RancherChartsBaseBranch is required for BuildAndPushRancherChartsToGitea")
-	Expect(input.GiteaServerAddress).ToNot(BeEmpty(), "GiteaServerAddress is required for BuildAndPushRancherChartsToGitea")
-	Expect(input.GiteaRepoName).ToNot(BeEmpty(), "GiteaRepoName is required for BuildAndPushRancherChartsToGitea")
-	Expect(input.GiteaUsername).ToNot(BeEmpty(), "GiteaUsername is required for BuildAndPushRancherChartsToGitea")
-	Expect(input.GiteaPassword).ToNot(BeEmpty(), "GiteaPassword is required for BuildAndPushRancherChartsToGitea")
-	Expect(input.ChartVersion).ToNot(BeEmpty(), "ChartVersion is required for BuildAndPushRancherChartsToGitea")
+	Expect(ctx).NotTo(BeNil(), "ctx is required for PushRancherChartsToGitea")
+	Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "BootstrapClusterProxy is required for PushRancherChartsToGitea")
+	Expect(input.RancherChartsRepoDir).ToNot(BeEmpty(), "RancherChartsRepoDir is required for PushRancherChartsToGitea")
+	Expect(input.GiteaServerAddress).ToNot(BeEmpty(), "GiteaServerAddress is required for PushRancherChartsToGitea")
+	Expect(input.GiteaRepoName).ToNot(BeEmpty(), "GiteaRepoName is required for PushRancherChartsToGitea")
+	Expect(input.GiteaUsername).ToNot(BeEmpty(), "GiteaUsername is required for PushRancherChartsToGitea")
+	Expect(input.GiteaPassword).ToNot(BeEmpty(), "GiteaPassword is required for PushRancherChartsToGitea")
+	Expect(input.ChartVersion).ToNot(BeEmpty(), "ChartVersion is required for PushRancherChartsToGitea")
 
 	By("Creating Gitea repository for Rancher charts")
 	repoURL := turtlesframework.GiteaCreateRepo(ctx, turtlesframework.GiteaCreateRepoInput{
@@ -294,18 +344,9 @@ func BuildAndPushRancherChartsToGitea(ctx context.Context, input BuildAndPushRan
 		Password:   input.GiteaPassword,
 	})
 
-	By("Building local rancher charts using Makefile target")
-	// Run make build-local-rancher-charts which already handles all the chart building logic
-	makeCmd := exec.Command("make", "build-local-rancher-charts")
-	makeCmd.Dir = input.RootDir
-	envVars := []string{
-		fmt.Sprintf("RANCHER_CHARTS_REPO_DIR=%s", input.RancherChartsRepoDir),
-		fmt.Sprintf("RANCHER_CHARTS_BASE_BRANCH=%s", input.RancherChartsBaseBranch),
-		fmt.Sprintf("RANCHER_CHART_DEV_VERSION=%s", input.ChartVersion),
-	}
-	makeCmd.Env = append(os.Environ(), envVars...)
-	output, err := makeCmd.CombinedOutput()
-	Expect(err).ToNot(HaveOccurred(), "Failed to run make build-local-rancher-charts: %s", string(output))
+	// Use random remote name.
+	// This is needed since different suites may be adding remotes to different gitea instances concurrently.
+	remoteName := util.RandomString(6)
 
 	By("Configuring git remote to point to Gitea")
 	// Strip protocol prefix from server address
@@ -320,7 +361,7 @@ func BuildAndPushRancherChartsToGitea(ctx context.Context, input BuildAndPushRan
 
 	turtlesframework.GitSetRemote(ctx, turtlesframework.GitSetRemoteInput{
 		RepoLocation: input.RancherChartsRepoDir,
-		RemoteName:   "origin",
+		RemoteName:   remoteName,
 		RemoteURL:    giteaRemoteURL,
 		Username:     input.GiteaUsername,
 		Password:     input.GiteaPassword,
@@ -331,7 +372,7 @@ func BuildAndPushRancherChartsToGitea(ctx context.Context, input BuildAndPushRan
 	// Force push is needed because Gitea creates an initial commit with README
 	turtlesframework.GitPush(ctx, turtlesframework.GitPushInput{
 		RepoLocation: input.RancherChartsRepoDir,
-		RemoteName:   "origin",
+		RemoteName:   remoteName,
 		Username:     input.GiteaUsername,
 		Password:     input.GiteaPassword,
 		Force:        true,
@@ -341,7 +382,7 @@ func BuildAndPushRancherChartsToGitea(ctx context.Context, input BuildAndPushRan
 	// Format: http://gitea-address/username/repo.git (matches Gitea's repository URL structure)
 	httpURL := fmt.Sprintf("http://%s/%s/%s.git", serverAddr, input.GiteaUsername, input.GiteaRepoName)
 
-	return &BuildAndPushRancherChartsToGiteaResult{
+	return &PushRancherChartsToGiteaResult{
 		ChartRepoURL:     repoURL,
 		ChartRepoHTTPURL: httpURL,
 		LocalRepoDir:     input.RancherChartsRepoDir,

--- a/test/testenv/turtles.go
+++ b/test/testenv/turtles.go
@@ -30,12 +30,13 @@ import (
 	turtlesframework "github.com/rancher/turtles/test/framework"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	opframework "sigs.k8s.io/cluster-api-operator/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var DefaultDeployments = []NamespaceName{
+var DefaultDeployments = []types.NamespacedName{
 	{
 		Name:      "capi-controller-manager",
 		Namespace: "cattle-capi-system",
@@ -99,7 +100,7 @@ type DeployRancherTurtlesInput struct {
 	WaitDeploymentsReadyInterval []interface{} `envDefault:"15m,10s"`
 
 	// WaitForDeployments is the list of deployments to wait for.
-	WaitForDeployments []NamespaceName
+	WaitForDeployments []types.NamespacedName
 
 	// AdditionalValues are the additional values for Rancher Turtles.
 	AdditionalValues map[string]string


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR:
- Promotes no-cert-manager feature to Beta (doc: https://github.com/rancher/turtles-docs/pull/395)
- Add test coverage for the no-cert-manager feature

Additionally:
- The DeployRancher method as been deprecated in favor of the new way of installing Turtles using Rancher's system charts
- cert-manager e2e deployment has been decoupled so that's reusable and easier to remove eventually
- UpgradeInstallRancherWithGitea has been improved so that it can also install Rancher from scratch
- UpgradeInstallRancherWithGitea no longer prepares the chart fork repository, this is done only once now, before the tests are executed
- various cleanups

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1677 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
