### PR TITLE
[release/v0.25] fix: permissions to create release from workflow

### DIFF
--- a/.github/workflows/release-v2.yaml
+++ b/.github/workflows/release-v2.yaml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read # to checkout code
+  contents: write # to create new releases
   id-token: write # to read vault secrets
 
 jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:

`chart-releaser` was moved to a separate composite action as it was originally only executed inside the legacy release action, which is no longer triggered when `>=v0.25.x`. After this change, there seems to be a lack of permissions for creating a new release https://github.com/rancher/turtles/actions/runs/20136566070/job/57794232816.

`contents: write` should help with fixing this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
