### PR TITLE
fix: permissions to create release from workflow

### DIFF
--- a/.github/workflows/release-v2.yaml
+++ b/.github/workflows/release-v2.yaml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read # to checkout code
+  contents: write # to create new releases
   id-token: write # to read vault secrets
 
 jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:

Release workflow is missing permissions for creating a release, which come from `contents: write`. This has already been tested when releasing `v0.25.1-rc.0`, as this change is cherry-picked from an existing commit in `release/v0.25`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
