### PR TITLE
fix: Add kubeadm providers to image overrides list

### DIFF
--- a/internal/controllers/clusterctl/config-prime.yaml
+++ b/internal/controllers/clusterctl/config-prime.yaml
@@ -55,18 +55,22 @@ data:
     # Image overrides
     images:
       cluster-api:
-        repository: "registry.suse.com/rancher"
+        repository: "registry.rancher.com/rancher"
+      control-plane-kubeadm:
+        repository: "registry.rancher.com/rancher"
+      bootstrap-kubeadm:
+        repository: "registry.rancher.com/rancher"
       control-plane-rke2:
-        repository: "registry.suse.com/rancher"
+        repository: "registry.rancher.com/rancher"
       bootstrap-rke2:
-        repository: "registry.suse.com/rancher"
+        repository: "registry.rancher.com/rancher"
       infrastructure-aws:
-        repository: "registry.suse.com/rancher"
+        repository: "registry.rancher.com/rancher"
       infrastructure-azure:
-        repository: "registry.suse.com/rancher"
+        repository: "registry.rancher.com/rancher"
       infrastructure-gcp:
-        repository: "registry.suse.com/rancher"
+        repository: "registry.rancher.com/rancher"
       infrastructure-vsphere:
-        repository: "registry.suse.com/rancher"
+        repository: "registry.rancher.com/rancher"
       addon-rancher-fleet:
-        repository: "registry.suse.com/rancher"
+        repository: "registry.rancher.com/rancher"


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR adds the kubeadm bootstrap/control-plane providers to the prime config. This is needed so that any custom registries are applied correctly for these providers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1945 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
