### PR TITLE
CI fixes for vsphere

### DIFF
--- a/test/e2e/data/gitea/ingress.yaml
+++ b/test/e2e/data/gitea/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: gitea-http
   namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "1000m"
 spec:
   ingressClassName: ${GITEA_INGRESS_CLASS_NAME}
   rules:

--- a/test/testenv/rancher.go
+++ b/test/testenv/rancher.go
@@ -568,6 +568,13 @@ func PreRancherInstallHook(input PreRancherInstallHookInput) PreRancherInstallHo
 			IngressClassName: input.RancherIngressClassName,
 			ConfigPatches:    [][]byte{e2e.RancherServicePatch, e2e.IngressConfig, e2e.SystemStoreSettingPatch},
 		}
+
+	case e2e.ManagementClusterEnvironmentInternalKind:
+		By("Using RANCHER_HOSTNAME for internal kind")
+		return PreRancherInstallHookResult{
+			Hostname: input.RancherHostname,
+		}
+
 	default:
 		Fail(fmt.Sprintf("Unknown MANAGEMENT_CLUSTER_ENVIRONMENT: %s", input.EnvironmentType))
 		return PreRancherInstallHookResult{}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This should address issue with pushing code to gitea via setting annotation at gitea ingress level, ref. failed [run](https://github.com/rancher/turtles/actions/runs/20355252820/job/58489201080#step:6:705)
* also contains a fix for unavailable cluster type for vsphere
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1955 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

:green_circle: Testrun https://github.com/rancher/turtles/actions/runs/20437869775