### PR TITLE
Switch from Turtles to embedded CAPI

### DIFF
--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -144,6 +144,9 @@ var (
 
 	//go:embed data/gitea/values.yaml
 	GiteaValues []byte
+
+	//go:embed data/test-switch/turtles-embedded-cluster-api-feature.yaml
+	TurtlesEmbeddedCAPIFeature []byte
 )
 
 const (

--- a/test/e2e/data/test-switch/turtles-embedded-cluster-api-feature.yaml
+++ b/test/e2e/data/test-switch/turtles-embedded-cluster-api-feature.yaml
@@ -1,0 +1,13 @@
+apiVersion: management.cattle.io/v3
+kind: Feature
+metadata:
+  name: turtles
+spec:
+  value: ${ENABLE_TURTLES_FEATURE}
+---
+apiVersion: management.cattle.io/v3
+kind: Feature
+metadata:
+  name: embedded-cluster-api
+spec:
+  value: ${ENABLE_EMBEDDED_CAPI_FEATURE}

--- a/test/e2e/suites/turtles-switch/suite_test.go
+++ b/test/e2e/suites/turtles-switch/suite_test.go
@@ -1,0 +1,177 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright © 2023 - 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package turtles_switch
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/turtles/test/framework"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/json"
+	capiframework "sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/rancher/turtles/test/e2e"
+	"github.com/rancher/turtles/test/testenv"
+)
+
+// Test suite global vars.
+var (
+	// hostName is the host name for the Rancher Manager server.
+	hostName string
+
+	// e2eConfig to be used for this test, read from configPath.
+	e2eConfig *clusterctl.E2EConfig
+
+	ctx = context.Background()
+
+	setupClusterResult    *testenv.SetupTestClusterResult
+	bootstrapClusterProxy capiframework.ClusterProxy
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	ctrl.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	RunSpecs(t, "rancher-turtles-e2e-switch")
+}
+
+var _ = SynchronizedBeforeSuite(
+	func() []byte {
+		e2eConfig := e2e.LoadE2EConfig()
+		e2eConfig.ManagementClusterName = e2eConfig.ManagementClusterName + "-switch"
+		setupClusterResult = testenv.SetupTestCluster(ctx, testenv.SetupTestClusterInput{
+			E2EConfig: e2eConfig,
+			Scheme:    e2e.InitScheme(),
+		})
+
+		testenv.DeployCertManager(ctx, testenv.DeployCertManagerInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+		})
+
+		testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
+			BootstrapClusterProxy:     setupClusterResult.BootstrapClusterProxy,
+			CustomIngress:             e2e.NginxIngress,
+			CustomIngressLoadBalancer: e2e.NginxIngressLoadBalancer,
+			DefaultIngressClassPatch:  e2e.IngressClassPatch,
+		})
+
+		By("Deploying Gitea for chart repository")
+		giteaResult := testenv.DeployGitea(ctx, testenv.DeployGiteaInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+			ValuesFile:            e2e.GiteaValues,
+			CustomIngressConfig:   e2e.GiteaIngress,
+		})
+
+		By("Pushing Rancher charts to Gitea for Turtles installation")
+		chartsResult := testenv.PushRancherChartsToGitea(ctx, testenv.PushRancherChartsToGiteaInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+			GiteaServerAddress:    giteaResult.GitAddress,
+			GiteaRepoName:         "charts",
+			// ChartVersion will be auto-populated from RANCHER_CHART_DEV_VERSION env var or Makefile default
+		})
+
+		By("Installing Rancher to 2.13.x with Gitea chart repository (enables system chart controller)")
+		rancherHookResult := testenv.UpgradeInstallRancherWithGitea(ctx, testenv.UpgradeInstallRancherWithGiteaInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+			ChartRepoURL:          chartsResult.ChartRepoHTTPURL,
+			ChartRepoBranch:       chartsResult.Branch,
+			ChartVersion:          chartsResult.ChartVersion,
+			TurtlesImageRepo:      "ghcr.io/rancher/turtles-e2e",
+			TurtlesImageTag:       "v0.0.1",
+			RancherWaitInterval:   e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-rancher"),
+			RancherPatches:        [][]byte{e2e.RancherSettingPatch},
+		})
+
+		By("Waiting for Rancher to be ready")
+		capiframework.WaitForDeploymentsAvailable(ctx, capiframework.WaitForDeploymentsAvailableInput{
+			Getter: setupClusterResult.BootstrapClusterProxy.GetClient(),
+			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+				Name:      "rancher",
+				Namespace: e2e.RancherNamespace,
+			}},
+		}, e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-rancher")...)
+
+		By("Waiting for Turtles controller to be installed by system chart controller")
+		capiframework.WaitForDeploymentsAvailable(ctx, capiframework.WaitForDeploymentsAvailableInput{
+			Getter: setupClusterResult.BootstrapClusterProxy.GetClient(),
+			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+				Name:      "rancher-turtles-controller-manager",
+				Namespace: e2e.NewRancherTurtlesNamespace,
+			}},
+		}, e2eConfig.GetIntervals(setupClusterResult.BootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+		By("Applying test ClusterctlConfig")
+		Expect(framework.Apply(ctx, setupClusterResult.BootstrapClusterProxy, e2e.ClusterctlConfig)).To(Succeed())
+
+		testenv.DeployRancherTurtlesProviders(ctx, testenv.DeployRancherTurtlesProvidersInput{
+			BootstrapClusterProxy:   setupClusterResult.BootstrapClusterProxy,
+			UseLegacyCAPINamespace:  false,
+			RancherTurtlesNamespace: e2e.NewRancherTurtlesNamespace,
+			ProviderList:            "docker,rke2",
+		})
+
+		data, err := json.Marshal(e2e.Setup{
+			ClusterName:     setupClusterResult.ClusterName,
+			KubeconfigPath:  setupClusterResult.KubeconfigPath,
+			RancherHostname: rancherHookResult.Hostname,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		return data
+	},
+	func(sharedData []byte) {
+		setup := e2e.Setup{}
+		Expect(json.Unmarshal(sharedData, &setup)).To(Succeed())
+
+		hostName = setup.RancherHostname
+
+		bootstrapClusterProxy = capiframework.NewClusterProxy(setup.ClusterName, setup.KubeconfigPath, e2e.InitScheme(), capiframework.WithMachineLogCollector(capiframework.DockerLogCollector{}))
+		Expect(bootstrapClusterProxy).ToNot(BeNil(), "cluster proxy should not be nil")
+	},
+)
+
+var _ = SynchronizedAfterSuite(
+	func() {
+	},
+	func() {
+		By("Dumping artifacts from the bootstrap cluster")
+		testenv.DumpBootstrapCluster(ctx, bootstrapClusterProxy.GetKubeconfigPath())
+
+		config := e2e.LoadE2EConfig()
+		// skipping error check since it is already done at the beginning of the test in e2e.ValidateE2EConfig()
+		skipCleanup, _ := strconv.ParseBool(config.GetVariableOrEmpty(e2e.SkipResourceCleanupVar))
+		if skipCleanup {
+			// add a log line about skipping charts uninstallation and cluster cleanup
+			return
+		}
+
+		testenv.CleanupTestCluster(ctx, testenv.CleanupTestClusterInput{
+			SetupTestClusterResult: *setupClusterResult,
+		})
+	},
+)

--- a/test/e2e/suites/turtles-switch/turtles_switch_test.go
+++ b/test/e2e/suites/turtles-switch/turtles_switch_test.go
@@ -1,0 +1,255 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright © 2023 - 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package turtles_switch
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/drone/envsubst/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/turtles/test/e2e"
+	"github.com/rancher/turtles/test/e2e/specs"
+	turtlesframework "github.com/rancher/turtles/test/framework"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	capiframework "sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+)
+
+var _ = Describe("Switch from Turtles to embedded CAPI", Ordered, Label(e2e.ShortTestLabel), func() {
+	var turtlesHelmApp, capiHelmApp turtlesframework.GetHelmAppInput
+	const (
+		oldCAPINamespace = "cattle-provisioning-capi-system"
+		turtlesNamespace = e2e.NewRancherTurtlesNamespace
+
+		clusterName = "cluster-docker-rke2-switch"
+	)
+	BeforeAll(func() {
+		komega.SetClient(bootstrapClusterProxy.GetClient())
+		komega.SetContext(ctx)
+		e2eConfig = e2e.LoadE2EConfig()
+		turtlesHelmApp = turtlesframework.GetHelmAppInput{
+			GetLister:        bootstrapClusterProxy.GetClient(),
+			HelmAppName:      "rancher-turtles",
+			HelmAppNamespace: turtlesNamespace,
+		}
+
+		capiHelmApp = turtlesframework.GetHelmAppInput{
+			GetLister:        bootstrapClusterProxy.GetClient(),
+			HelmAppName:      "rancher-provisioning-capi",
+			HelmAppNamespace: oldCAPINamespace,
+		}
+	})
+
+	It("Should use Turtles as the source of truth", func() {
+		By("Verifying turtles helm app is installed", func() {
+			app, err := turtlesframework.GetHelmApp(ctx, turtlesHelmApp)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(app).ToNot(BeNil())
+		})
+
+		By("Verifying cluster-api helm app is not installed", func() {
+			_, err := turtlesframework.GetHelmApp(ctx, capiHelmApp)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+
+		By("Verifying capi-controller-manager is managed by turtles", func() {
+			capiframework.WaitForDeploymentsAvailable(ctx, capiframework.WaitForDeploymentsAvailableInput{
+				Getter: bootstrapClusterProxy.GetClient(),
+				Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+					Name:      "capi-controller-manager",
+					Namespace: "cattle-capi-system",
+				}},
+			}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+		})
+
+	})
+
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
+		By("Provisioning workload cluster")
+
+		const topologyNamespace = "switch-docker-rke2"
+
+		return specs.CreateUsingGitOpsSpecInput{
+			E2EConfig:                      e2e.LoadE2EConfig(),
+			BootstrapClusterProxy:          bootstrapClusterProxy,
+			ClusterTemplate:                e2e.CAPIDockerRKE2Topology,
+			ClusterName:                    clusterName,
+			ControlPlaneMachineCount:       ptr.To(1),
+			WorkerMachineCount:             ptr.To(1),
+			LabelNamespace:                 true,
+			TestClusterReimport:            false,
+			SkipDeletionTest:               true, // Delete the cluster later
+			SkipCleanup:                    true, // Delete the cluster later
+			RancherServerURL:               hostName,
+			CAPIClusterCreateWaitName:      "wait-rancher",
+			DeleteClusterWaitName:          "wait-controllers",
+			CapiClusterOwnerLabel:          e2e.CapiClusterOwnerLabel,
+			CapiClusterOwnerNamespaceLabel: e2e.CapiClusterOwnerNamespaceLabel,
+			OwnedLabelName:                 e2e.OwnedLabelName,
+			TopologyNamespace:              topologyNamespace,
+			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
+				{
+					Name:            "docker-cluster-classes-regular",
+					Paths:           []string{"examples/clusterclasses/docker/rke2"},
+					ClusterProxy:    bootstrapClusterProxy,
+					TargetNamespace: topologyNamespace,
+				},
+				{
+					Name:            "docker-cni",
+					Paths:           []string{"examples/applications/cni/calico"},
+					ClusterProxy:    bootstrapClusterProxy,
+					TargetNamespace: topologyNamespace,
+				},
+			},
+		}
+	})
+
+	It("Should disable turtles feature with zero-downtime", func() {
+		By("Enabling embedded-cluster-api and disabling turtles feature", func() {
+			enableEmbeddedCAPIFeature, err := envsubst.Eval(string(e2e.TurtlesEmbeddedCAPIFeature), func(s string) string {
+				switch s {
+				case "ENABLE_TURTLES_FEATURE":
+					return "false"
+				case "ENABLE_EMBEDDED_CAPI_FEATURE":
+					return "true"
+				default:
+					return os.Getenv(s)
+				}
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(turtlesframework.Apply(ctx, bootstrapClusterProxy, []byte(enableEmbeddedCAPIFeature))).To(Succeed(), "Failed to enable embedded-cluster-api feature")
+		})
+
+		By("Verifying cluster-api helm app is installed", func() {
+			capiframework.WaitForDeploymentsAvailable(ctx, capiframework.WaitForDeploymentsAvailableInput{
+				Getter: bootstrapClusterProxy.GetClient(),
+				Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+					Name:      "capi-controller-manager",
+					Namespace: oldCAPINamespace,
+				}},
+			}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+			host, err := turtlesframework.GetHelmApp(ctx, capiHelmApp)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(host).ToNot(BeNil())
+		})
+
+		By("Verifying rancher-turtles is disabled", func() {
+			_, err := turtlesframework.GetHelmApp(ctx, turtlesHelmApp)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+
+		By("Verifying turtlesNamespace is deleted", func() {
+			turtlesframework.WaitForNamespaceToBeDeleted(ctx, turtlesframework.WaitNamespaceInput{
+				Name:      turtlesNamespace,
+				GetLister: bootstrapClusterProxy.GetClient(),
+			})
+		})
+
+		By("Verifying the cluster still exists", func() {
+			turtlesframework.VerifyCluster(ctx, turtlesframework.VerifyClusterInput{
+				BootstrapClusterProxy:   bootstrapClusterProxy,
+				Name:                    clusterName,
+				DeleteAfterVerification: false,
+			})
+		})
+
+	})
+
+	It("Should re-enable turtles feature with zero-downtime", func() {
+		By("Disabling embedded-cluster-api and enabling turtles feature", func() {
+			enableTurtlesFeature, err := envsubst.Eval(string(e2e.TurtlesEmbeddedCAPIFeature), func(s string) string {
+				switch s {
+				case "ENABLE_TURTLES_FEATURE":
+					return "true"
+				case "ENABLE_EMBEDDED_CAPI_FEATURE":
+					return "false"
+				default:
+					return os.Getenv(s)
+				}
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(turtlesframework.Apply(ctx, bootstrapClusterProxy, []byte(enableTurtlesFeature))).To(Succeed(), "Failed to enable turtles feature")
+		})
+
+		By("Verifying rancher-turtles is installed", func() {
+			capiframework.WaitForDeploymentsAvailable(ctx, capiframework.WaitForDeploymentsAvailableInput{
+				Getter: bootstrapClusterProxy.GetClient(),
+				Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+					Name:      "rancher-turtles-controller-manager",
+					Namespace: turtlesNamespace,
+				}},
+			}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+			host, err := turtlesframework.GetHelmApp(ctx, turtlesHelmApp)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(host).ToNot(BeNil())
+		})
+
+		By("Verifying cluster-api helm app is uninstalled", func() {
+			_, err := turtlesframework.GetHelmApp(ctx, capiHelmApp)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+
+		By("Verifying capiNamespace is deleted", func() {
+			turtlesframework.WaitForNamespaceToBeDeleted(ctx, turtlesframework.WaitNamespaceInput{
+				Name:      oldCAPINamespace,
+				GetLister: bootstrapClusterProxy.GetClient(),
+			})
+		})
+
+		By("Re-applying Clusterctl Config", func() {
+			// This configmap is deployed in ns cattle-turtles-system which is deleted when turtles is disabled;
+			// hence the need to re-apply it
+			Expect(turtlesframework.Apply(ctx, setupClusterResult.BootstrapClusterProxy, e2e.ClusterctlConfig)).To(Succeed())
+		})
+
+		By("Verifying providers deployments are active", func() {
+			for _, provider := range []string{"capd", "rke2-bootstrap", "rke2-control-plane"} {
+				capiframework.WaitForDeploymentsAvailable(ctx, capiframework.WaitForDeploymentsAvailableInput{
+					Getter: bootstrapClusterProxy.GetClient(),
+					Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s-controller-manager", provider),
+						Namespace: fmt.Sprintf("%s-system", provider),
+					}},
+				}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+			}
+		})
+
+		By("Verifying workload cluster survived the switch(zero-downtime validated)", func() {
+			// This is the critical validation: the workload cluster provisioned before the turtles feature disabling
+			// should still be healthy and operational, proving zero-downtime migration
+			turtlesframework.VerifyCluster(ctx, turtlesframework.VerifyClusterInput{
+				BootstrapClusterProxy:   bootstrapClusterProxy,
+				Name:                    clusterName,
+				DeleteAfterVerification: true,
+			})
+		})
+
+	})
+})

--- a/test/framework/const.go
+++ b/test/framework/const.go
@@ -25,6 +25,4 @@ const (
 	FleetLocalNamespace = "fleet-local"
 	// MagicDNS is the dns name to use in isolated mode
 	MagicDNS = "sslip.io"
-	// DefaulRancherTurtlesNamespace is the name of the default namespace for Rancher Turtles.
-	DefaultRancherTurtlesNamespace = "rancher-turtles-system"
 )

--- a/test/framework/kube_helper.go
+++ b/test/framework/kube_helper.go
@@ -18,9 +18,12 @@ package framework
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -343,4 +346,51 @@ func GetClusterctl(ctx context.Context, input GetClusterctlInput) string {
 	Expect(config.Data["clusterctl.yaml"]).NotTo(BeEmpty(), "Expected ConfigMap to have clusterctl.yaml data")
 
 	return config.Data["clusterctl.yaml"]
+}
+
+type GetHelmAppInput struct {
+	GetLister        framework.GetLister
+	HelmAppName      string
+	HelmAppNamespace string
+}
+
+// GetHelmApp fetches `catalog.cattle.io/v1 app`
+func GetHelmApp(ctx context.Context, input GetHelmAppInput) (*metav1.PartialObjectMetadata, error) {
+	Expect(ctx).NotTo(BeNil(), "ctx is required for GetHelmApp")
+	Expect(input.GetLister).ToNot(BeNil(), "Invalid argument. input.GetLister can't be nil when calling GetHelmApp")
+
+	app := &metav1.PartialObjectMetadata{}
+	app.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "catalog.cattle.io",
+		Version: "v1",
+		Kind:    "App",
+	})
+
+	return app, input.GetLister.Get(ctx, client.ObjectKey{Namespace: input.HelmAppNamespace, Name: input.HelmAppName}, app)
+
+}
+
+type WaitNamespaceInput struct {
+	Name      string
+	GetLister framework.GetLister
+}
+
+func WaitForNamespaceToBeDeleted(ctx context.Context, input WaitNamespaceInput) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: input.Name,
+		},
+	}
+	Eventually(func() error {
+
+		err := input.GetLister.Get(ctx, client.ObjectKeyFromObject(ns), ns)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("getting Namespace: %w", err)
+		}
+
+		return fmt.Errorf("namespace %s is still present", ns.Name)
+	}).Should(Succeed(), "Namespace deletion should complete")
 }


### PR DESCRIPTION
kind/enhancement
area/testing

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
This PR adds a new suite to test Turtles to embedded CAPI switch and back.

>A new test validates that, after installing rancher:v2.13.x, Turtles becomes the only source of truth for CAPI CRDs and controllers. Eventually, this configuration is changed and embedded-cluster-api feature is enabled. Existing clusters and provisioning should be unaffected.
>
>Ideally we should also check that users can go back Turtles once again.

1. We begin with Rancher 2.13 and check if turtles is in charge, checking turtles helm app and `cluster-api-controller-manager` deployment, and provisioning a cluster.

2. Then turtles is disabled and embedded-cluster-api is enabled. We now check if turtles helm app and `cattle-turtles-system` namespace is deleted, ensuring no resources related to it are present. We also check if embedded-capi has been installed in `cattle-provisioning-capi-system` namespace. We also ensure the cluster is unaffected.

3. Then turtles is enabled again, disabling embedded-cluster-api. We now check everything we did in step 1, including the deletion of `cattle-provisioing-capi-system` namespace and ensure the cluster is unaffected.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1827

**Special notes for your reviewer**:

_Please suggest if any additional checks can be added. The issue description mentions checking CAPI CRDs, but I am not sure how to do that._

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests - https://github.com/rancher/turtles/actions/runs/20366987143
