### PR TITLE
ci: Undeprecate DeployRancher method for stable Turtles deployments

### DIFF
--- a/test/testenv/rancher.go
+++ b/test/testenv/rancher.go
@@ -71,9 +71,6 @@ type DeployRancherInput struct {
 	// RancherPassword is the password for Rancher.
 	RancherPassword string `env:"RANCHER_PASSWORD"`
 
-	// RancherFeatures are the features for Rancher.
-	RancherFeatures string
-
 	// RancherPatches are the patches for Rancher.
 	RancherPatches [][]byte
 
@@ -122,7 +119,7 @@ type deployRancherIngressValuesFile struct {
 // If RancherServicePatch is provided, the function updates the Rancher service.
 // The function waits for the Rancher webhook rollout and the fleet controller rollout.
 //
-// Deprecated: Use UpgradeInstallRancherWithGitea instead to bootstrap Rancher using a custom Turtles system chart.
+// Note: Use UpgradeInstallRancherWithGitea instead to bootstrap Rancher using a custom Turtles system chart.
 func DeployRancher(ctx context.Context, input DeployRancherInput) PreRancherInstallHookResult {
 	Expect(turtlesframework.Parse(&input)).To(Succeed(), "Failed to parse environment variables")
 
@@ -187,8 +184,6 @@ func DeployRancher(ctx context.Context, input DeployRancherInput) PreRancherInst
 		"--namespace", input.RancherNamespace,
 		"--create-namespace",
 		"--values", input.HelmExtraValuesPath,
-		"--set", "extraEnv[0].name=CATTLE_FEATURES",
-		"--set", "extraEnv[0].value=turtles=false",
 	)
 	if input.RancherDebug {
 		installFlags = append(installFlags, "--set", "debug=true")
@@ -215,9 +210,7 @@ func DeployRancher(ctx context.Context, input DeployRancherInput) PreRancherInst
 		"global.cattle.psp.enabled": "false",
 		"replicas":                  "1",
 	}
-	if input.RancherFeatures != "" {
-		values["features"] = input.RancherFeatures
-	}
+
 	if input.RancherImageTag != "" {
 		values["rancherImageTag"] = input.RancherImageTag
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR undeprecates the `DeployRancher` method as it's still useful to have for all stable Turtles deployments.
One use case is the [integration-suite-example](https://github.com/rancher-sandbox/turtles-integration-suite-example) project, where users are expected to just deploy Rancher and wait for Turtles to be installed as system chart, without need for for a custom system chart support (ex. Gitea).

Also cleaning up `RancherFeatures` that doesn't seem to be a valid value for the Rancher chart.
The `turtles=false` `CATTLE_FEATURE` has also been removed, as no longer necessary. In the Turtles e2e test this is only used to install Rancher 2.12 series that didn't have Turtles integrated. For all other cases the default features will be enough.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
