### PR TITLE
fix: Fix secret reference to Rancher cloud credential

### DIFF
--- a/charts/rancher-turtles-providers/templates/addon-fleet.yaml
+++ b/charts/rancher-turtles-providers/templates/addon-fleet.yaml
@@ -92,11 +92,6 @@ spec:
   manager:
 {{ toYaml (index .Values "providers" "addonFleet" "manager") | nindent 4 }}
 {{- end }}
-{{- if or (index .Values "providers" "addonFleet" "credentials") }}
-  credentials:
-    name: {{ index .Values "providers" "addonFleet" "credentials" "name" }}
-    namespace: {{ index .Values "providers" "addonFleet" "credentials" "namespace" }}
-{{- end }}
 {{- if or (index .Values "providers" "addonFleet" "configSecret") }}
   configSecret:
     name: {{ index .Values "providers" "addonFleet" "configSecret" "name" }}

--- a/charts/rancher-turtles-providers/templates/bootstrap-kubeadm.yaml
+++ b/charts/rancher-turtles-providers/templates/bootstrap-kubeadm.yaml
@@ -35,11 +35,6 @@ spec:
   manager:
 {{ toYaml (index .Values "providers" "bootstrapKubeadm" "manager") | nindent 4 }}
 {{- end }}
-{{- if or (index .Values "providers" "bootstrapKubeadm" "credentials") }}
-  credentials:
-    name: {{ index .Values "providers" "bootstrapKubeadm" "credentials" "name" }}
-    namespace: {{ index .Values "providers" "bootstrapKubeadm" "credentials" "namespace" }}
-{{- end }}
 {{- if or (index .Values "providers" "bootstrapKubeadm" "configSecret") }}
   configSecret:
     name: {{ index .Values "providers" "bootstrapKubeadm" "configSecret" "name" }}

--- a/charts/rancher-turtles-providers/templates/bootstrap-rke2.yaml
+++ b/charts/rancher-turtles-providers/templates/bootstrap-rke2.yaml
@@ -35,11 +35,6 @@ spec:
   manager:
 {{ toYaml (index .Values "providers" "bootstrapRKE2" "manager") | nindent 4 }}
 {{- end }}
-{{- if or (index .Values "providers" "bootstrapRKE2" "credentials") }}
-  credentials:
-    name: {{ index .Values "providers" "bootstrapRKE2" "credentials" "name" }}
-    namespace: {{ index .Values "providers" "bootstrapRKE2" "credentials" "namespace" }}
-{{- end }}
 {{- if or (index .Values "providers" "bootstrapRKE2" "configSecret") }}
   configSecret:
     name: {{ index .Values "providers" "bootstrapRKE2" "configSecret" "name" }}

--- a/charts/rancher-turtles-providers/templates/controlplane-kubeadm.yaml
+++ b/charts/rancher-turtles-providers/templates/controlplane-kubeadm.yaml
@@ -35,11 +35,6 @@ spec:
   manager:
 {{ toYaml (index .Values "providers" "controlplaneKubeadm" "manager") | nindent 4 }}
 {{- end }}
-{{- if or (index .Values "providers" "controlplaneKubeadm" "credentials") }}
-  credentials:
-    name: {{ index .Values "providers" "controlplaneKubeadm" "credentials" "name" }}
-    namespace: {{ index .Values "providers" "controlplaneKubeadm" "credentials" "namespace" }}
-{{- end }}
 {{- if or (index .Values "providers" "controlplaneKubeadm" "configSecret") }}
   configSecret:
     name: {{ index .Values "providers" "controlplaneKubeadm" "configSecret" "name" }}

--- a/charts/rancher-turtles-providers/templates/controlplane-rke2.yaml
+++ b/charts/rancher-turtles-providers/templates/controlplane-rke2.yaml
@@ -35,11 +35,6 @@ spec:
   manager:
 {{ toYaml (index .Values "providers" "controlplaneRKE2" "manager") | nindent 4 }}
 {{- end }}
-{{- if or (index .Values "providers" "controlplaneRKE2" "credentials") }}
-  credentials:
-    name: {{ index .Values "providers" "controlplaneRKE2" "credentials" "name" }}
-    namespace: {{ index .Values "providers" "controlplaneRKE2" "credentials" "namespace" }}
-{{- end }}
 {{- if or (index .Values "providers" "controlplaneRKE2" "configSecret") }}
   configSecret:
     name: {{ index .Values "providers" "controlplaneRKE2" "configSecret" "name" }}

--- a/charts/rancher-turtles-providers/templates/infrastructure-aws.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-aws.yaml
@@ -37,8 +37,11 @@ spec:
 {{- end }}
 {{- if or (index .Values "providers" "infrastructureAWS" "credentials") }}
   credentials:
-    name: {{ index .Values "providers" "infrastructureAWS" "credentials" "name" }}
-    namespace: {{ index .Values "providers" "infrastructureAWS" "credentials" "namespace" }}
+    {{- if and (index .Values "providers" "infrastructureAWS" "credentials" "name") (not (index .Values "providers" "infrastructureAWS" "credentials" "namespace")) }}
+    rancherCloudCredential: {{ index .Values "providers" "infrastructureAWS" "credentials" "name" }}
+    {{- else if and (index .Values "providers" "infrastructureAWS" "credentials" "namespace") (index .Values "providers" "infrastructureAWS" "credentials" "name")}}
+    rancherCloudCredentialNamespaceName: {{ index .Values "providers" "infrastructureAWS" "credentials" "namespace" }}:{{ index .Values "providers" "infrastructureAWS" "credentials" "name" }}
+    {{- end }}
 {{- end }}
 {{- if or (index .Values "providers" "infrastructureAWS" "configSecret") }}
   configSecret:

--- a/charts/rancher-turtles-providers/templates/infrastructure-azure.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-azure.yaml
@@ -37,8 +37,11 @@ spec:
 {{- end }}
 {{- if or (index .Values "providers" "infrastructureAzure" "credentials") }}
   credentials:
-    name: {{ index .Values "providers" "infrastructureAzure" "credentials" "name" }}
-    namespace: {{ index .Values "providers" "infrastructureAzure" "credentials" "namespace" }}
+    {{- if and (index .Values "providers" "infrastructureAzure" "credentials" "name") (not (index .Values "providers" "infrastructureAzure" "credentials" "namespace")) }}
+    rancherCloudCredential: {{ index .Values "providers" "infrastructureAzure" "credentials" "name" }}
+    {{- else if and (index .Values "providers" "infrastructureAzure" "credentials" "namespace") (index .Values "providers" "infrastructureAzure" "credentials" "name")}}
+    rancherCloudCredentialNamespaceName: {{ index .Values "providers" "infrastructureAzure" "credentials" "namespace" }}:{{ index .Values "providers" "infrastructureAzure" "credentials" "name" }}
+    {{- end }}
 {{- end }}
 {{- if or (index .Values "providers" "infrastructureAzure" "configSecret") }}
   configSecret:

--- a/charts/rancher-turtles-providers/templates/infrastructure-docker.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-docker.yaml
@@ -35,11 +35,6 @@ spec:
   manager:
 {{ toYaml (index .Values "providers" "infrastructureDocker" "manager") | nindent 4 }}
 {{- end }}
-{{- if or (index .Values "providers" "infrastructureDocker" "credentials") }}
-  credentials:
-    name: {{ index .Values "providers" "infrastructureDocker" "credentials" "name" }}
-    namespace: {{ index .Values "providers" "infrastructureDocker" "credentials" "namespace" }}
-{{- end }}
 {{- if or (index .Values "providers" "infrastructureDocker" "configSecret") }}
   configSecret:
     name: {{ index .Values "providers" "infrastructureDocker" "configSecret" "name" }}

--- a/charts/rancher-turtles-providers/templates/infrastructure-gcp.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-gcp.yaml
@@ -37,8 +37,11 @@ spec:
 {{- end }}
 {{- if or (index .Values "providers" "infrastructureGCP" "credentials") }}
   credentials:
-    name: {{ index .Values "providers" "infrastructureGCP" "credentials" "name" }}
-    namespace: {{ index .Values "providers" "infrastructureGCP" "credentials" "namespace" }}
+    {{- if and (index .Values "providers" "infrastructureGCP" "credentials" "name") (not (index .Values "providers" "infrastructureGCP" "credentials" "namespace")) }}
+    rancherCloudCredential: {{ index .Values "providers" "infrastructureGCP" "credentials" "name" }}
+    {{- else if and (index .Values "providers" "infrastructureGCP" "credentials" "namespace") (index .Values "providers" "infrastructureGCP" "credentials" "name")}}
+    rancherCloudCredentialNamespaceName: {{ index .Values "providers" "infrastructureGCP" "credentials" "namespace" }}:{{ index .Values "providers" "infrastructureGCP" "credentials" "name" }}
+    {{- end }}
 {{- end }}
 {{- if or (index .Values "providers" "infrastructureGCP" "configSecret") }}
   configSecret:

--- a/charts/rancher-turtles-providers/templates/infrastructure-vsphere.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-vsphere.yaml
@@ -37,8 +37,11 @@ spec:
 {{- end }}
 {{- if or (index .Values "providers" "infrastructureVSphere" "credentials") }}
   credentials:
-    name: {{ index .Values "providers" "infrastructureVSphere" "credentials" "name" }}
-    namespace: {{ index .Values "providers" "infrastructureVSphere" "credentials" "namespace" }}
+    {{- if and (index .Values "providers" "infrastructureVSphere" "credentials" "name") (not (index .Values "providers" "infrastructureVSphere" "credentials" "namespace")) }}
+    rancherCloudCredential: {{ index .Values "providers" "infrastructureVSphere" "credentials" "name" }}
+    {{- else if and (index .Values "providers" "infrastructureVSphere" "credentials" "namespace") (index .Values "providers" "infrastructureVSphere" "credentials" "name")}}
+    rancherCloudCredentialNamespaceName: {{ index .Values "providers" "infrastructureVSphere" "credentials" "namespace" }}:{{ index .Values "providers" "infrastructureVSphere" "credentials" "name" }}
+    {{- end }}
 {{- end }}
 {{- if or (index .Values "providers" "infrastructureVSphere" "configSecret") }}
   configSecret:

--- a/charts/rancher-turtles-providers/values.schema.json
+++ b/charts/rancher-turtles-providers/values.schema.json
@@ -30,8 +30,7 @@
           "type": "object",
           "description": "Optional Secret reference containing Rancher credentials",
           "required": [
-            "name",
-            "namespace"
+            "name"
           ],
           "properties": {
             "name": {

--- a/charts/rancher-turtles-providers/values.yaml
+++ b/charts/rancher-turtles-providers/values.yaml
@@ -22,10 +22,6 @@ providers:
   # variables: Optional environment variables exposed to the controller manager.
   # variables:
   #   ENV_VAR: "value"
-  # credentials: Optional Secret reference containing Rancher credentials
-  # credentials:
-  #   name: ""
-  #   namespace: ""
   # configSecret: ConfigSecret is the object with name and namespace of the Secret providing the configuration variables for the current provider instance, like e.g. credentials.
   # configSecret:
   #   name: ""
@@ -56,10 +52,6 @@ providers:
   # variables: Optional environment variables exposed to the controller manager.
   # variables:
   #   ENV_VAR: "value"
-  # credentials: Optional Secret reference containing Rancher credentials
-  # credentials:
-  #   name: ""
-  #   namespace: ""
   # configSecret: ConfigSecret is the object with name and namespace of the Secret providing the configuration variables for the current provider instance, like e.g. credentials.
   # configSecret:
   #   name: ""
@@ -90,10 +82,6 @@ providers:
   # variables: Optional environment variables exposed to the controller manager.
   # variables:
   #   ENV_VAR: "value"
-  # credentials: Optional Secret reference containing Rancher credentials
-  # credentials:
-  #   name: ""
-  #   namespace: ""
   # configSecret: ConfigSecret is the object with name and namespace of the Secret providing the configuration variables for the current provider instance, like e.g. credentials.
   # configSecret:
   #   name: ""
@@ -124,10 +112,6 @@ providers:
   # variables: Optional environment variables exposed to the controller manager.
   # variables:
   #   ENV_VAR: "value"
-  # credentials: Optional Secret reference containing Rancher credentials
-  # credentials:
-  #   name: ""
-  #   namespace: ""
   # configSecret: ConfigSecret is the object with name and namespace of the Secret providing the configuration variables for the current provider instance, like e.g. credentials.
   # configSecret:
   #   name: ""
@@ -158,10 +142,6 @@ providers:
   # variables: Optional environment variables exposed to the controller manager.
   # variables:
   #   ENV_VAR: "value"
-  # credentials: Optional Secret reference containing Rancher credentials
-  # credentials:
-  #   name: ""
-  #   namespace: ""
   # configSecret: ConfigSecret is the object with name and namespace of the Secret providing the configuration variables for the current provider instance, like e.g. credentials.
   # configSecret:
   #   name: ""
@@ -260,10 +240,6 @@ providers:
   # variables: Optional environment variables exposed to the controller manager.
   # variables:
   #   ENV_VAR: "value"
-  # credentials: Optional Secret reference containing Rancher credentials
-  # credentials:
-  #   name: ""
-  #   namespace: ""
   # configSecret: ConfigSecret is the object with name and namespace of the Secret providing the configuration variables for the current provider instance, like e.g. credentials.
   # configSecret:
   #   name: ""


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR fixes the secret reference to Rancher cloud credential.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1978 

**Special notes for your reviewer**:

Running
```
helm template rancher-turtles-providers ./charts/rancher-turtles-providers --set providers.infrastructureAWS.enabled=true,providers.infrastructureAWS.credentials.name=bar
```
results in
```
apiVersion: turtles-capi.cattle.io/v1alpha1
kind: CAPIProvider
metadata:
  name: aws
  namespace: capa-system
spec:
  name: aws
  type: infrastructure
  enableAutomaticUpdate: true
  variables:
    AWS_B64ENCODED_CREDENTIALS: ""
  credentials:
    rancherCloudCredential: bar
```
In this case the namespace that will be used to lookup the secret is `cattle-global-data`.

Running
```
helm template rancher-turtles-providers ./charts/rancher-turtles-providers --set providers.infrastructureAWS.enabled=true,providers.infrastructureAWS.credentials.name=bar,providers.infrastructureAWS.credentials.namespace=foo
```
results in 
```
apiVersion: turtles-capi.cattle.io/v1alpha1
kind: CAPIProvider
metadata:
  name: aws
  namespace: capa-system
spec:
  name: aws
  type: infrastructure
  enableAutomaticUpdate: true
  variables:
    AWS_B64ENCODED_CREDENTIALS: ""
  credentials:
    rancherCloudCredentialNamespaceName: foo:bar
```

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
