### PR TITLE
Bump Go to 1.24.11 to fix CVEs

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/examples
 
-go 1.24.9
+go 1.24.11
 
 require (
 	github.com/agnivade/levenshtein v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles
 
-go 1.24.9
+go 1.24.11
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/test
 
-go 1.24.9
+go 1.24.11
 
 replace github.com/rancher/turtles => ../
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This bumps Go to v1.24.11 to fix two CVEs on `crypto/x509`:
- https://avd.aquasec.com/nvd/2025/cve-2025-61729/
- https://avd.aquasec.com/nvd/2025/cve-2025-61727/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Must be backported to Turtles `<=v0.24.x`.

Originally bumped to Go v1.25.5 but it requires additional changes to other tools. Since this has to be back-ported I think it's safer to just bump to the patch version of Go v1.24 that fixes the CVE and then we can follow-up with an update to Go v1.25 for a future version of Turtles.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
