### PR TITLE
CI: get IP for vsphere runner dynamically

### DIFF
--- a/.github/workflows/run-vsphere-tests.yaml
+++ b/.github/workflows/run-vsphere-tests.yaml
@@ -18,7 +18,6 @@ env:
   VSPHERE_PASSWORD: ${{ secrets.VSPHERE_PASSWORD }}
   VSPHERE_KUBE_VIP_IP_KUBEADM: ${{ secrets.VSPHERE_KUBE_VIP_IP_KUBEADM }}
   VSPHERE_KUBE_VIP_IP_RKE2: ${{ secrets.VSPHERE_KUBE_VIP_IP_RKE2 }}
-  RANCHER_HOSTNAME: ${{ secrets.INTERNAL_DOMAIN }}
   MANAGEMENT_CLUSTER_ENVIRONMENT: "internal-kind"
   GINKGO_LABEL_FILTER: "vsphere"
   TAG: v0.0.1
@@ -45,7 +44,10 @@ jobs:
       - name: Display docker version
         run: docker version
       - name: Run e2e tests
-        run: make test-e2e
+        run: |
+          export RANCHER_HOSTNAME="$(ip route get 8.8.8.8 | awk '{print $7}').sslip.io"
+          echo "RANCHER_HOSTNAME is set to $RANCHER_HOSTNAME"
+          make test-e2e
       - name: Collect run artifacts
         if: always()
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:


kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This is preparation for a new vsphere runner which can work in parallel with the existing one. Having secret with single domain is not usable for multiple runners.

Existing vsphere runner is about to be terminated due to PRG office reconstruction in few days.

In addition we won't depend on static IP for the vsphere runner anymore.

It will also output RANCHER_HOSTNAME value in the e2e step https://github.com/rancher/turtles/actions/runs/20925389350/job/60121763748#step:6:29

Secret INTERNAL_DOMAIN is used only for vsphere and after merging we can delete it.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
