### PR TITLE
[feat] Disable Rancher k8s version management for CAPI imported Clusters

### DIFF
--- a/internal/controllers/import_controller.go
+++ b/internal/controllers/import_controller.go
@@ -272,6 +272,7 @@ func (r *CAPIImportReconciler) reconcileNormal(ctx context.Context, capiCluster 
 			},
 			Annotations: map[string]string{
 				fleetNamespaceMigrated: "cattle-fleet-system",
+				turtlesannotations.ImportedClusterVersionManagementAnnotation: "false",
 			},
 			Finalizers: []string{
 				managementv3.CapiClusterFinalizer,

--- a/internal/controllers/import_controller_test.go
+++ b/internal/controllers/import_controller_test.go
@@ -100,6 +100,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 				},
 				Annotations: map[string]string{
 					fleetNamespaceMigrated: "cattle-fleet-system",
+					turtlesannotations.ImportedClusterVersionManagementAnnotation: "false",
 				},
 			},
 		}
@@ -210,6 +211,9 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 			g.Expect(rancherClusters.Items).To(HaveLen(1))
 			g.Expect(rancherClusters.Items[0].Name).To(ContainSubstring("c-"))
 			g.Expect(rancherClusters.Items[0].Annotations).To(HaveKey(turtlesannotations.NoCreatorRBACAnnotation))
+			g.Expect(rancherClusters.Items[0].Annotations).To(HaveKey(turtlesannotations.ImportedClusterVersionManagementAnnotation))
+			value := rancherClusters.Items[0].Annotations[turtlesannotations.ImportedClusterVersionManagementAnnotation]
+			g.Expect(value).To(Equal("false"), "imported-cluster-version-management must be disabled")
 			g.Expect(rancherClusters.Items[0].Finalizers).To(ContainElement(managementv3.CapiClusterFinalizer))
 		}).Should(Succeed())
 

--- a/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
+++ b/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
@@ -150,6 +150,7 @@ var _ = Describe("Chart upgrade functionality should work", Ordered, Label(e2e.S
 			TopologyNamespace:              topologyNamespace,
 			SkipCleanup:                    true, // Keep cluster running during upgrade
 			SkipDeletionTest:               true,
+			SkipLatestFeatureChecks:        true,
 			AdditionalFleetGitRepos: []framework.FleetCreateGitRepoInput{
 				{
 					Name:            "docker-cluster-classes-regular",

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -39,6 +39,8 @@ const (
 	LocalSystemAgentAnnotation = "cluster-api.cattle.io/local-system-agent"
 	// ClusterDescriptionAnnotation is a cluster annotation, allowing user to provide a custom cluster description.
 	ClusterDescriptionAnnotation = "cluster-api.cattle.io/cluster-description"
+	// ImportedClusterVersionManagementAnnotation is a Rancher management Cluster annotation that enables or disables version management for the Cluster.
+	ImportedClusterVersionManagementAnnotation = "rancher.io/imported-cluster-version-management"
 )
 
 // HasClusterImportAnnotation returns true if the object has the `imported` annotation.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR disables the Rancher driven k8s version management for CAPI imported Clusters.
This is needed to not confuse users with an upgrade process that's not relevant and does not apply to their CAPI Clusters.

As for other Cluster import features, this requires a re-import of the Cluster. It will only apply to newly imported Clusters.
There's no reconcile logic for updates.

There is also no official documentation for this annotation. 
For reference just read through the source code following the same named global Setting: https://github.com/rancher/rancher/blob/v2.13.1/pkg/settings/setting.go#L404

Fixes https://github.com/rancher/rancher/issues/50776

For the end user, the UI should now look like this:

<img width="1003" height="392" alt="Screenshot From 2026-01-19 16-44-50" src="https://github.com/user-attachments/assets/7a20a30f-b49e-49af-8a4a-0b7bce1cb0d3" />


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
