### PR TITLE
chore: Bump providers chart to 0.25.2

### DIFF
--- a/charts/rancher-turtles-providers/Chart.yaml
+++ b/charts/rancher-turtles-providers/Chart.yaml
@@ -3,8 +3,8 @@ name: rancher-turtles-providers
 description: This chart installs the Rancher Turtles certified providers.
 home: https://turtles.docs.rancher.com/turtles/stable/en/overview/certified.html
 icon: https://raw.githubusercontent.com/rancher/turtles/main/logos/capi.svg
-version: 0.25.1
-appVersion: "0.25.1"
+version: 0.25.2
+appVersion: "0.25.2"
 keywords:
 - rancher
 - cluster-api


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump the version of providers chart ahead of the 0.25.2 Turtles release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
