### PR TITLE
Make delete hooks do a full cleanup

### DIFF
--- a/charts/rancher-turtles/templates/post-delete-job.yaml
+++ b/charts/rancher-turtles/templates/post-delete-job.yaml
@@ -30,6 +30,13 @@ rules:
   - deployments
   verbs:
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -136,6 +143,42 @@ spec:
         - deployments.apps/capi-controller-manager
         - -n
         - {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
+        - --ignore-not-found=true
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cluster-api-operator-configmap-cleanup
+  namespace: '{{ .Values.namespace }}'
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "2"
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: post-delete-job
+      restartPolicy: Never
+      containers:
+      - name: delete-capi-configmaps
+        image: {{ .Values.shellImage }}
+        command: ["kubectl"]
+        args:
+        - delete
+        - configmaps
+        - -n
+        - {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
+        - -l
+        - managed-by.turtles.cattle.io=true
         - --ignore-not-found=true
         securityContext:
           seccompProfile:

--- a/charts/rancher-turtles/templates/pre-delete-job.yaml
+++ b/charts/rancher-turtles/templates/pre-delete-job.yaml
@@ -20,8 +20,11 @@ rules:
   - turtles-capi.cattle.io
   resources:
   - capiproviders
+  - clusterctlconfigs
   verbs:
+  - get
   - list
+  - patch
   - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -65,6 +68,40 @@ spec:
         - {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
         - --ignore-not-found=true
         - --cascade=foreground
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rancher-clusterctlconfig-cleanup
+  namespace: '{{ .Values.namespace }}'
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-1"
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: pre-delete-job
+      containers:
+      - name: rancher-clusterctlconfig-cleanup
+        image: {{ .Values.shellImage }}
+        command: ["kubectl"]
+        args:
+        - delete
+        - clusterctlconfigs.turtles-capi.cattle.io
+        - --all
+        - --all-namespaces
+        - --ignore-not-found=true
         securityContext:
           seccompProfile:
             type: RuntimeDefault

--- a/charts/rancher-turtles/templates/rancher-turtles-components.yaml
+++ b/charts/rancher-turtles/templates/rancher-turtles-components.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.1
-    helm.sh/resource-policy: keep
   name: capiproviders.turtles-capi.cattle.io
 spec:
   group: turtles-capi.cattle.io
@@ -3227,7 +3226,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.1
-    helm.sh/resource-policy: keep
   name: clusterctlconfigs.turtles-capi.cattle.io
 spec:
   group: turtles-capi.cattle.io

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -15,9 +15,6 @@ patches:
     kind: CustomResourceDefinition
     name: capiproviders.turtles-capi.cattle.io
   path: patches/turtles-capi.cattle.io_capiproviders.yaml
-- path: patches/keep-crds.yaml
-  target:
-    kind: CustomResourceDefinition
 
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 

--- a/config/crd/patches/keep-crds.yaml
+++ b/config/crd/patches/keep-crds.yaml
@@ -1,6 +1,0 @@
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    "helm.sh/resource-policy": keep
-  name: any

--- a/test/testenv/providers.go
+++ b/test/testenv/providers.go
@@ -297,6 +297,20 @@ func DeployRancherTurtlesProviders(ctx context.Context, input DeployRancherTurtl
 	}
 }
 
+// UninstallRancherTurtlesProviders uninstalls the rancher-turtles-providers chart.
+func UninstallRancherTurtlesProviders(ctx context.Context, namespace string, clusterProxy framework.ClusterProxy) {
+	var cmd turtlesframework.RunCommandResult
+	turtlesframework.RunCommand(ctx, turtlesframework.RunCommandInput{
+		Command: "helm",
+		Args: []string{
+			"uninstall", e2e.ProvidersChartName,
+			"-n", namespace,
+			"--kubeconfig", clusterProxy.GetKubeconfigPath(),
+			"--wait",
+		},
+	}, &cmd)
+}
+
 func runProviderMigration(ctx context.Context, scriptPath, kubeconfigPath, turtlesNamespace string, extraArgs ...string) {
 	if _, err := os.Stat(scriptPath); err != nil {
 		Expect(fmt.Errorf("migration script not found: %s", scriptPath)).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR fixes an issue where the config map with CAPI resources was not removed after chart deletion and allows deletion of the CAPI Provider and ClusterctlConfig CRDs. Having these resources present causes issues when re-installing the chart. Neither of these resources contains any data that needs to be backed up if accidentally deleted, all provider CRDs will remain untouched, as they are today.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher/turtles/issues/2016

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
