### PR TITLE
chore: use Nodeports for dev-env ngrok tunnels

### DIFF
--- a/scripts/build-local-rancher-charts.sh
+++ b/scripts/build-local-rancher-charts.sh
@@ -30,7 +30,9 @@ if [ "$CLEANUP" = "true" ]; then
     rm -rf $RANCHER_CHARTS_REPO_DIR
     mkdir -p $RANCHER_CHARTS_REPO_DIR
     # Build and copy Turtles chart into Rancher Charts local repo
-    git clone -b $RANCHER_CHARTS_BASE_BRANCH https://github.com/rancher/charts.git $RANCHER_CHARTS_REPO_DIR
+    git clone --depth 1 -b $RANCHER_CHARTS_BASE_BRANCH https://github.com/rancher/charts.git $RANCHER_CHARTS_REPO_DIR
+    rm -rf $RANCHER_CHARTS_REPO_DIR/.git
+    git -C $RANCHER_CHARTS_REPO_DIR init --initial-branch=$RANCHER_CHARTS_BASE_BRANCH
 fi
 
 mkdir -p $RANCHER_CHARTS_REPO_DIR/charts/rancher-turtles/$RANCHER_CHART_DEV_VERSION

--- a/scripts/kind-cluster-with-extramounts.yaml
+++ b/scripts/kind-cluster-with-extramounts.yaml
@@ -7,3 +7,12 @@ nodes:
   extraMounts:
     - hostPath: /var/run/docker.sock
       containerPath: /var/run/docker.sock
+  extraPortMappings:
+  # Gitea test Nodeport
+  - containerPort: 30001
+    hostPort: 30001
+    protocol: TCP
+  # Rancher test Nodeport
+  - containerPort: 30002
+    hostPort: 30002
+    protocol: TCP

--- a/test/e2e/data/gitea/ingress.yaml
+++ b/test/e2e/data/gitea/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: gitea-http
-  namespace: default
+  namespace: gitea
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "1000m"
 spec:

--- a/test/e2e/data/gitea/test-nodeport.yaml
+++ b/test/e2e/data/gitea/test-nodeport.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gitea-nodeport
+  namespace: gitea
+spec:
+  type: NodePort
+  selector:
+    app: gitea
+  ports:
+  - nodePort: 30001
+    port: 3000
+    protocol: TCP
+    targetPort: 3000

--- a/test/e2e/data/rancher/test-nodeport.yaml
+++ b/test/e2e/data/rancher/test-nodeport.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rancher-nodeport
+  namespace: cattle-system
+spec:
+  type: NodePort
+  selector:
+    app: rancher
+  ports:
+  - nodePort: 30002
+    port: 80
+    protocol: TCP
+    targetPort: 80


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a few improvements to the dev-env setup:
1. Nodeports are used instead of flaky port-forwards for Gitea and Rancher Ngrok tunnels
2. Now makes a shallow clone of the Rancher Charts repo to minimize pull data
3. The charts repo push to Gitea is done via the Nodeport and no longer through Ngrok
4. Gitea is now deployed to the `gitea` namespace instead of `default`

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
