### PR TITLE
fix: use systemDefaultRegistry for chart shell image

### DIFF
--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -108,6 +108,17 @@ jobs:
       - name: Run chart re-install
         run: helm install rancher-turtles out/charts/rancher-turtles/ -n rancher-turtles-system --set namespace=rancher-turtles-system --create-namespace --wait --debug
 
+      - name: Run crust-gather
+        if: always()
+        run: make collect-artifacts
+
+      - name: Collect run artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: artifacts-prime
+          path: _artifacts
+
   community-test:
     runs-on: ubuntu-latest
     steps:
@@ -176,3 +187,14 @@ jobs:
             echo "capi-controller-manager does not use rancher/cluster-api-controller based image"
             exit 1
           fi
+
+      - name: Run crust-gather
+        if: always()
+        run: make collect-artifacts
+
+      - name: Collect run artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: artifacts-community
+          path: _artifacts

--- a/charts/rancher-turtles/templates/clusterctl-cm-cleanup-job.yaml
+++ b/charts/rancher-turtles/templates/clusterctl-cm-cleanup-job.yaml
@@ -54,7 +54,7 @@ spec:
       serviceAccountName: pre-upgrade-job
       containers:
       - name: rancher-clusterctl-configmap-cleanup
-        image: {{ .Values.shellImage }}
+        image: '{{ template "system_default_registry" . }}{{ .Values.shellImage.image.repository }}:{{ .Values.shellImage.image.tag }}'
         command: ["kubectl"]
         args:
         - delete

--- a/charts/rancher-turtles/templates/post-delete-job.yaml
+++ b/charts/rancher-turtles/templates/post-delete-job.yaml
@@ -69,7 +69,7 @@ spec:
       serviceAccountName: post-delete-job
       containers:
       - name: cluster-api-operator-mutatingwebhook-cleanup
-        image: {{ .Values.shellImage }}
+        image: '{{ template "system_default_registry" . }}{{ .Values.shellImage.image.repository }}:{{ .Values.shellImage.image.tag }}'
         command: ["kubectl"]
         args:
         - delete
@@ -102,7 +102,7 @@ spec:
       serviceAccountName: post-delete-job
       containers:
       - name: cluster-api-operator-validatingwebhook-cleanup
-        image: {{ .Values.shellImage }}
+        image: '{{ template "system_default_registry" . }}{{ .Values.shellImage.image.repository }}:{{ .Values.shellImage.image.tag }}'
         command: ["kubectl"]
         args:
         - delete
@@ -136,7 +136,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: delete-capi-controller-manager
-        image: {{ .Values.shellImage }}
+        image: '{{ template "system_default_registry" . }}{{ .Values.shellImage.image.repository }}:{{ .Values.shellImage.image.tag }}'
         command: ["kubectl"]
         args:
         - delete
@@ -170,7 +170,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: delete-capi-configmaps
-        image: {{ .Values.shellImage }}
+        image: '{{ template "system_default_registry" . }}{{ .Values.shellImage.image.repository }}:{{ .Values.shellImage.image.tag }}'
         command: ["kubectl"]
         args:
         - delete

--- a/charts/rancher-turtles/templates/post-upgrade-job.yaml
+++ b/charts/rancher-turtles/templates/post-upgrade-job.yaml
@@ -107,7 +107,7 @@ spec:
       serviceAccountName: post-upgrade-job
       containers:
         - name: cluster-api-operator-resources-cleanup
-          image: {{ index .Values "shellImage" }}
+          image: '{{ template "system_default_registry" . }}{{ .Values.shellImage.image.repository }}:{{ .Values.shellImage.image.tag }}'
           command: ["/bin/bash"]
           args:
           - "-c"

--- a/charts/rancher-turtles/templates/pre-delete-job.yaml
+++ b/charts/rancher-turtles/templates/pre-delete-job.yaml
@@ -58,7 +58,7 @@ spec:
       serviceAccountName: pre-delete-job
       containers:
       - name: rancher-capiprovider-cleanup
-        image: {{ .Values.shellImage }}
+        image: '{{ template "system_default_registry" . }}{{ .Values.shellImage.image.repository }}:{{ .Values.shellImage.image.tag }}'
         command: ["kubectl"]
         args:
         - delete
@@ -94,7 +94,7 @@ spec:
       serviceAccountName: pre-delete-job
       containers:
       - name: rancher-clusterctlconfig-cleanup
-        image: {{ .Values.shellImage }}
+        image: '{{ template "system_default_registry" . }}{{ .Values.shellImage.image.repository }}:{{ .Values.shellImage.image.tag }}'
         command: ["kubectl"]
         args:
         - delete

--- a/charts/rancher-turtles/values.schema.json
+++ b/charts/rancher-turtles/values.schema.json
@@ -29,7 +29,20 @@
       "items": { "type": "string" }
     },
     "shellImage": {
-      "type": "string"
+      "type": "object",
+      "properties": {
+        "image": { 
+        "type": "object",
+        "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
+        }
+      }
     },
     "features": {
       "type": "object",

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -19,7 +19,10 @@ managerArguments: []
 # imagePullSecrets: Secrets for private registries.
 imagePullSecrets: []
 # shellImage: Image for shell tasks.
-shellImage: rancher/kuberlr-kubectl:v5.0.0
+shellImage:
+  image:
+    repository: rancher/kuberlr-kubectl
+    tag: v5.0.0
 # features: Optional and experimental features.
 features:
   # agent-tls-mode: Beta feature for agent TLS.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR should fix usage of systemDefaultRegistry setting when performing chart jobs.
I followed the [rancher-monitoring](https://github.com/rancher/charts/blob/dev-v2.14/charts/rancher-monitoring/108.0.0%2Bup77.9.1-rancher.6/values.yaml#L558) similar implementation.

Refers to #2035 

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # SURE-11227

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
