### PR TITLE
Remove verbose file listing from git commit

### DIFF
--- a/scripts/build-local-rancher-charts.sh
+++ b/scripts/build-local-rancher-charts.sh
@@ -51,4 +51,4 @@ $HELM package $RANCHER_CHARTS_REPO_DIR/charts/rancher-turtles/$RANCHER_CHART_DEV
 git -C $RANCHER_CHARTS_REPO_DIR config user.email "ci@rancher-turtles.local"
 git -C $RANCHER_CHARTS_REPO_DIR config user.name "Rancher Turtles CI"
 git -C $RANCHER_CHARTS_REPO_DIR add .
-git -C $RANCHER_CHARTS_REPO_DIR commit -m "Added test chart $RANCHER_CHART_DEV_VERSION"
+git -C $RANCHER_CHARTS_REPO_DIR commit --quiet -m "Added test chart $RANCHER_CHART_DEV_VERSION"


### PR DESCRIPTION
**What this PR does / why we need it**:
It is impossible to see GH run logs from CI due to verbose file listing in git commit command that is run and creates 50K files and GH UI has to render it and obviously having hard time to do so and not so good expereince for the PR author to wait for it. So this PR adds `--quiet` option to silence it. 

Example run without this change: https://github.com/rancher/turtles/actions/runs/21665721945/job/62460557789?pr=2047

Example run with this change: 


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
