### PR TITLE
[release/v0.26] chore: bump go to v1.24.13 (#2057)

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/examples
 
-go 1.24.12
+go 1.24.13
 
 require (
 	github.com/agnivade/levenshtein v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles
 
-go 1.24.12
+go 1.24.13
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/test
 
-go 1.24.12
+go 1.24.13
 
 replace github.com/rancher/turtles => ../
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This bump fixes CVE-2025-68121, a vulnerability on `crypto/tls`.

Backport to `release/v0.26`. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
