### PR TITLE
Increase turtles pod memory limits

### DIFF
--- a/charts/rancher-turtles/templates/deployment.yaml
+++ b/charts/rancher-turtles/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 300Mi
+            memory: 600Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,7 +52,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 300Mi
+            memory: 600Mi
           requests:
             cpu: 10m
             memory: 128Mi


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR increases Turtles pod memory limits, we've seen an issue in the past when processing big yaml templates for providers could cause a memory spike. The spike happens only one time when the provider of certain version is processed then it gets cached.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher/turtles/issues/2072

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
