### PR TITLE
chore: bump capv to v1.15.2

### DIFF
--- a/charts/rancher-turtles-providers/values.yaml
+++ b/charts/rancher-turtles-providers/values.yaml
@@ -353,4 +353,4 @@ images:
     tag: v1.11.0  
   infrastructureVSphere:
     repository: rancher/cluster-api-vsphere-controller
-    tag: v1.14.0
+    tag: v1.15.2

--- a/internal/controllers/clusterctl/config-prime.yaml
+++ b/internal/controllers/clusterctl/config-prime.yaml
@@ -25,7 +25,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/v1.11.0/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "vsphere"
-      url:          "https://github.com/rancher-sandbox/cluster-api-provider-vsphere/releases/v1.14.0/infrastructure-components.yaml"
+      url:          "https://github.com/rancher-sandbox/cluster-api-provider-vsphere/releases/v1.15.2/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "docker"
       url:          "https://github.com/kubernetes-sigs/cluster-api/releases/v1.12.2/infrastructure-components-development.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:

We missed vSphere `v1.15.2` that already supports CAPI v1.12.

This should not yet be backported to `release/v0.26` until we're confident that we're releasing Turtles with v1.12 support.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Successful test run: https://github.com/rancher/turtles/actions/runs/21916678283

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
