### PR TITLE
chore: bump caprke2 to v0.23.1

### DIFF
--- a/charts/rancher-turtles-providers/values.yaml
+++ b/charts/rancher-turtles-providers/values.yaml
@@ -332,13 +332,13 @@ images:
     tag: v1.12.2
   bootstrapRKE2:
     repository: rancher/cluster-api-provider-rke2-bootstrap
-    tag: v0.23.0
+    tag: v0.23.1
   controlplaneKubeadm:
     repository: rancher/kubeadm-control-plane-controller
     tag: v1.12.2
   controlplaneRKE2:
     repository: rancher/cluster-api-provider-rke2-controlplane
-    tag: v0.23.0
+    tag: v0.23.1
   infrastructureAWS:
     repository: rancher/cluster-api-aws-controller
     tag: v2.10.0

--- a/internal/controllers/clusterctl/config-prime.yaml
+++ b/internal/controllers/clusterctl/config-prime.yaml
@@ -36,7 +36,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.12.2/bootstrap-components.yaml"
       type:         "BootstrapProvider"
     - name:         "rke2"
-      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.23.0/bootstrap-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.23.1/bootstrap-components.yaml"
       type:         "BootstrapProvider"
 
     # ControlPlane providers
@@ -44,7 +44,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.12.2/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
     - name:         "rke2"
-      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.23.0/control-plane-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.23.1/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
 
     # Addon providers

--- a/internal/controllers/clusterctl/config_test.go
+++ b/internal/controllers/clusterctl/config_test.go
@@ -69,7 +69,7 @@ data:
         url: https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/v1.11.0/infrastructure-components.yaml
       - name: rke2
         type: ControlPlaneProvider
-        url: https://github.com/rancher/cluster-api-provider-rke2/releases/v0.23.0/control-plane-components.yaml
+        url: https://github.com/rancher/cluster-api-provider-rke2/releases/v0.23.1/control-plane-components.yaml
     images:
       image1:
         repository: repo1
@@ -98,7 +98,7 @@ data:
 							{
 								Name: "rke2",
 								Type: "BootstrapProvider",
-								URL:  "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.23.0/bootstrap-components.yaml",
+								URL:  "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.23.1/bootstrap-components.yaml",
 							},
 							{
 								Name: "fleet",
@@ -149,14 +149,14 @@ data:
 		Expect(configRepo.Providers).To(ContainElement(v1alpha1.Provider{
 			Name: "rke2",
 			Type: "ControlPlaneProvider",
-			URL:  "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.23.0/control-plane-components.yaml",
+			URL:  "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.23.1/control-plane-components.yaml",
 		}))
 
 		// Ensure a new rke2 bootstrap provider is added
 		Expect(configRepo.Providers).To(ContainElement(v1alpha1.Provider{
 			Name: "rke2",
 			Type: "BootstrapProvider",
-			URL:  "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.23.0/bootstrap-components.yaml",
+			URL:  "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.23.1/bootstrap-components.yaml",
 		}))
 
 		// Ensure a new fleet addon provider is added


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump CAPRKE2 to `v0.23.1` which includes a fix for a sporadic cluster deletion issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This is part of the preparation for the next release candidate. It should be backported to `release/v0.26`.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
