### PR TITLE
fix: Make turtles a Rancher managed chart (i.e. not user upgradeable)

### DIFF
--- a/charts/rancher-turtles/Chart.yaml
+++ b/charts/rancher-turtles/Chart.yaml
@@ -13,6 +13,7 @@ keywords:
 - provisioning
 annotations:
   catalog.cattle.io/certified: rancher
+  catalog.cattle.io/managed: "true"
   catalog.cattle.io/display-name: Rancher Turtles
   catalog.cattle.io/kube-version: ">= 1.31.4-0 < 1.35.0-0"
   catalog.cattle.io/namespace: cattle-turtles-system


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

With the addition of this annotation, the Rancher UI treats the Turtles chart as Rancher managed instead of user managed.

**Which issue(s) this PR fixes**:
Fixes #2092 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
