### PR TITLE
ci: remove v0.0.1-capi image load

### DIFF
--- a/test/e2e/suites/chart-upgrade/suite_test.go
+++ b/test/e2e/suites/chart-upgrade/suite_test.go
@@ -22,7 +22,6 @@ package chart_upgrade
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"testing"
 
@@ -79,12 +78,6 @@ func TestE2E(t *testing.T) {
 var _ = SynchronizedBeforeSuite(
 	func() []byte {
 		e2eConfig := e2e.LoadE2EConfig()
-
-		// Must load a custom Turtles image with an updated version of CAPI for this test
-		e2eConfig.Images = append(e2eConfig.Images, clusterctl.ContainerImage{
-			Name:         fmt.Sprintf("%s:%s-capi", e2eConfig.Variables["TURTLES_IMAGE"], e2eConfig.Variables["TURTLES_VERSION"]),
-			LoadBehavior: clusterctl.LoadImageBehavior("tryLoad"),
-		})
 
 		e2eConfig.ManagementClusterName = e2eConfig.ManagementClusterName + "-chart-upgrade"
 		setupClusterResult = testenv.SetupTestCluster(ctx, testenv.SetupTestClusterInput{


### PR DESCRIPTION
This should be a leftover of #2083

Will prevent the following warning:

```
  INFO: Loading image: "ghcr.io/rancher/turtles-e2e:v0.0.1-capi"
  INFO: Image ghcr.io/rancher/turtles-e2e:v0.0.1-capi not present in local container image cache, will pull
Warning: WARNING] Unable to load image "ghcr.io/rancher/turtles-e2e:v0.0.1-capi" into the kind cluster "rancher-turtles-e2e-chart-upgrade-c1ilzf": error pulling image "ghcr.io/rancher/turtles-e2e:v0.0.1-capi": failure pulling container image: Error response from daemon: Head "https://ghcr.io/v2/rancher/turtles-e2e/manifests/v0.0.1-capi": unauthorized
```

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
