### PR TITLE
[release/v0.26] Providers chart fix version

### DIFF
--- a/charts/rancher-turtles-providers/Chart.yaml
+++ b/charts/rancher-turtles-providers/Chart.yaml
@@ -3,8 +3,8 @@ name: rancher-turtles-providers
 description: This chart installs the Rancher Turtles certified providers.
 home: https://turtles.docs.rancher.com/turtles/stable/en/overview/certified.html
 icon: https://raw.githubusercontent.com/rancher/turtles/main/logos/capi.svg
-version: v0.26.0-rc.3
-appVersion: "v0.26.0-rc.3"
+version: 0.26.0-rc.3
+appVersion: "0.26.0-rc.3"
 keywords:
   - rancher
   - cluster-api


### PR DESCRIPTION
**What this PR does / why we need it**:

My previous PR #2104  for setting the chart version had the wrong format as the `v` prefix is not needed (see [release/v0.25](https://github.com/rancher/turtles/blob/22069d811f9d78b949fcd88927e176c5852afecb/charts/rancher-turtles-providers/Chart.yaml#L6)). This should allow us to release the chart.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
