### PR TITLE
[backport-release/v0.25] fix: ignore cert-manager CRDs not found

### DIFF
--- a/internal/provider/wrangler.go
+++ b/internal/provider/wrangler.go
@@ -26,6 +26,7 @@ import (
 	admissionv1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -266,7 +267,7 @@ func CleanupCertManagerResources(ctx context.Context, cl client.Client, provider
 	certList := &unstructured.UnstructuredList{}
 	certList.SetGroupVersionKind(certs)
 
-	if err := cl.List(ctx, certList, listOpts...); err != nil {
+	if err := cl.List(ctx, certList, listOpts...); err != nil && !apimeta.IsNoMatchError(err) {
 		return &controller.Result{}, fmt.Errorf("listing Certificates: %w", err)
 	}
 
@@ -289,7 +290,7 @@ func CleanupCertManagerResources(ctx context.Context, cl client.Client, provider
 	issuerList := &unstructured.UnstructuredList{}
 	issuerList.SetGroupVersionKind(issuers)
 
-	if err := cl.List(ctx, issuerList, listOpts...); err != nil {
+	if err := cl.List(ctx, issuerList, listOpts...); err != nil && !apimeta.IsNoMatchError(err) {
 		return &controller.Result{}, fmt.Errorf("listing Issuers: %w", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a backport PR https://github.com/rancher/turtles/pull/2128

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
