### PR TITLE
release: verify chart asset is always present after release upload step

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -61,5 +61,31 @@ jobs:
       - name: Run chart-releaser upload
         run: cr upload --skip-existing -c "$(git rev-parse HEAD)" --generate-release-notes --release-name-template "${{ inputs.tag }}" --make-release-latest=false
 
+      - name: Verify chart asset present (recover if missing)
+        run: |
+          CHART_FILE=$(ls ${{ inputs.release_dir }}/*.tgz 2>/dev/null | head -1)
+          if [ -z "${CHART_FILE}" ]; then
+            echo "ERROR: No .tgz chart package found in ${{ inputs.release_dir }}"
+            exit 1
+          fi
+          ASSET_NAME=$(basename "${CHART_FILE}")
+
+          if ! gh release view "${{ inputs.tag }}" > /dev/null 2>&1; then
+            echo "ERROR: Release '${{ inputs.tag }}' not found."
+            exit 1
+          fi
+
+          FOUND=$(gh release view "${{ inputs.tag }}" \
+            --json assets \
+            --jq ".assets[] | select(.name == \"${ASSET_NAME}\") | .name")
+
+          if [ -z "${FOUND}" ]; then
+            echo "Chart asset '${ASSET_NAME}' missing — uploading now..."
+            gh release upload "${{ inputs.tag }}" "${CHART_FILE}" --clobber
+            echo "Upload complete."
+          else
+            echo "Chart asset '${ASSET_NAME}' confirmed present."
+          fi
+
       - name: Run chart-releaser index
         run: cr index --push --release-name-template "${{ inputs.tag }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new step immediately after `cr upload`. On every run it checks that the `.tgz` asset is actually attached to the release. If it is missing - whether due to a transient failure on first run or because `cr upload` skipped on re-run, it uploads the asset directly via `gh release upload --clobber`.
This makes the chart release job fully idempotent: it can be safely re-run from the Actions UI without needing to delete the release or remove and reapply the tag.


### Testing
I was able to test it from my own fork by:

1. Adding a new workflow to just test chart verification logic: https://github.com/furkatgofurov7/rancher-turtles/actions/runs/22181658886/workflow
2. Adding a temporary step that deletes the chart asset immediately after `cr upload`, simulating the broken state.
3. Confirming the verify step detected the missing asset and re-uploaded it on first run.
4. Re-running the same job from the UI and confirming the verify step recovered again which exactly reproduces the scenario being protected against.

Run from the fork: https://github.com/furkatgofurov7/rancher-turtles/actions/runs/22181658886
Generated release artifact: https://github.com/furkatgofurov7/rancher-turtles/releases/tag/v0.25.101-test
(I was able to verify that it deleted the chart asset and re-uploaded it again in the second run since timestamps were different for other assets: 
<img width="2468" height="528" alt="image" src="https://github.com/user-attachments/assets/a4f988fb-33c3-4df4-a83d-a631c8d7b1fc" />


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2138 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
