### PR TITLE
test: Moving providers secrets creation to after installation of the providers chart

### DIFF
--- a/test/e2e/data/capi-operator/capa-identity-secret.yaml
+++ b/test/e2e/data/capi-operator/capa-identity-secret.yaml
@@ -1,9 +1,4 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: capa-system
----
-apiVersion: v1
 kind: Secret
 metadata:
   name: cluster-identity

--- a/test/e2e/data/capi-operator/capg-variables.yaml
+++ b/test/e2e/data/capi-operator/capg-variables.yaml
@@ -1,9 +1,3 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: capg-system
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/test/e2e/data/capi-operator/capv-identity-secret.yaml
+++ b/test/e2e/data/capi-operator/capv-identity-secret.yaml
@@ -1,9 +1,3 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: capv-system
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/test/e2e/data/capi-operator/capz-identity-secret.yaml
+++ b/test/e2e/data/capi-operator/capz-identity-secret.yaml
@@ -1,9 +1,3 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: capz-system
----
 apiVersion: v1
 stringData:
   clientSecret: "${AZURE_CLIENT_SECRET}"

--- a/test/testenv/providers.go
+++ b/test/testenv/providers.go
@@ -224,8 +224,6 @@ func DeployRancherTurtlesProviders(ctx context.Context, input DeployRancherTurtl
 
 	enabledProviders := getEnabledCAPIProviders(values)
 
-	applyProviderSecrets(ctx, input, enabledProviders)
-
 	providerWaiters := []func(ctx context.Context){}
 	configureProviderDefaults(ctx, input, values, enabledProviders)
 
@@ -263,6 +261,9 @@ func DeployRancherTurtlesProviders(ctx context.Context, input DeployRancherTurtl
 	if err != nil {
 		Expect(fmt.Errorf("Unable to install providers chart: %w\nOutput: %s, Command: %s", err, out, strings.Join(fullCommand, " "))).ToNot(HaveOccurred())
 	}
+
+	// Applying provider secrets assumes that the namespaces used for the secrets have been created beforehand by the providers chart.
+	applyProviderSecrets(ctx, input, enabledProviders)
 
 	deploymentsToWait := getDeploymentsForEnabledProviders(enabledProviders, input.UseLegacyCAPINamespace)
 	if len(deploymentsToWait) > 0 {


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

After removing the migration script (https://github.com/rancher/turtles/pull/2127), e2e tests need to be updated so that provider secrets are applied _after_ the providers chart gets installed. This is because the provider secrets are applied to specific namespaces that the providers chart creates.

**Which issue(s) this PR fixes**:
Fixes #2146 

**Special notes for your reviewer**:

https://github.com/rancher/turtles/actions/runs/22227489270 CAPV test run
https://github.com/rancher/turtles/actions/runs/22228058065 Long test run

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
