### PR TITLE
bump capa to v2.10.1

### DIFF
--- a/charts/rancher-turtles-providers/values.yaml
+++ b/charts/rancher-turtles-providers/values.yaml
@@ -341,7 +341,7 @@ images:
     tag: v0.23.1
   infrastructureAWS:
     repository: rancher/cluster-api-aws-controller
-    tag: v2.10.0
+    tag: v2.10.1
   infrastructureAzure:
     repository: rancher/cluster-api-azure-controller
     tag: v1.22.0

--- a/internal/controllers/clusterctl/config-prime.yaml
+++ b/internal/controllers/clusterctl/config-prime.yaml
@@ -16,7 +16,7 @@ data:
 
     # Infrastructure providers
     - name:         "aws"
-      url:          "https://github.com/rancher-sandbox/cluster-api-provider-aws/releases/v2.10.0/infrastructure-components.yaml"
+      url:          "https://github.com/rancher-sandbox/cluster-api-provider-aws/releases/v2.10.1/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "azure"
       url:          "https://github.com/rancher-sandbox/cluster-api-provider-azure/releases/v1.22.0/infrastructure-components.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump CAPA to latest release v2.10.1.

- **Full E2E run**: https://github.com/rancher/turtles/actions/runs/22308014157 (looks like there was a flake in `v2prov` but the affected CAPI tests passed successfully).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This change will be back-ported to `release/v0.26`.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
