### PR TITLE
test: Conditionally install providers

### DIFF
--- a/.github/workflows/e2e-short.yaml
+++ b/.github/workflows/e2e-short.yaml
@@ -13,7 +13,6 @@ env:
   GINKGO_LABEL_FILTER: "short"
   TAG: v0.0.1
   SOURCE_REPO: https://github.com/${{ github.event.pull_request.head.repo.full_name }}
-  TURTLES_PROVIDERS: "docker,kubeadm"
 
 jobs:
   e2e:

--- a/.github/workflows/run-vsphere-tests.yaml
+++ b/.github/workflows/run-vsphere-tests.yaml
@@ -25,7 +25,6 @@ env:
   DOCKER_REGISTRY_USERNAME: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
   DOCKER_REGISTRY_CONFIG: ${{ secrets.DOCKER_REGISTRY_CONFIG }}
   GINKGO_NODES: 2
-  TURTLES_PROVIDERS: "vsphere,kubeadm"
 
 jobs:
   run_vsphere_e2e:

--- a/test/e2e/suites/import-gitops/suite_test.go
+++ b/test/e2e/suites/import-gitops/suite_test.go
@@ -125,10 +125,21 @@ var _ = SynchronizedBeforeSuite(
 		By("Applying test ClusterctlConfig")
 		Expect(framework.Apply(ctx, setupClusterResult.BootstrapClusterProxy, e2e.ClusterctlConfig)).To(Succeed())
 
+		var providerList string
+		cfg, _ := GinkgoConfiguration()
+		if cfg.LabelFilter == e2e.ShortTestLabel {
+			providerList = "docker,rke2,kubeadm"
+		} else if cfg.LabelFilter == e2e.FullTestLabel {
+			providerList = "azure,aws,gcp,rke2,kubeadm"
+		} else if cfg.LabelFilter == e2e.VsphereTestLabel {
+			providerList = "vsphere,rke2,kubeadm"
+		}
+
 		testenv.DeployRancherTurtlesProviders(ctx, testenv.DeployRancherTurtlesProvidersInput{
 			BootstrapClusterProxy:   setupClusterResult.BootstrapClusterProxy,
 			UseLegacyCAPINamespace:  false,
 			RancherTurtlesNamespace: e2e.NewRancherTurtlesNamespace,
+			ProviderList:            providerList,
 		})
 
 		data, err := json.Marshal(e2e.Setup{

--- a/test/testenv/providers.go
+++ b/test/testenv/providers.go
@@ -223,6 +223,7 @@ func DeployRancherTurtlesProviders(ctx context.Context, input DeployRancherTurtl
 	maps.Copy(values, input.AdditionalValues) // Merge additional values into the values map
 
 	enabledProviders := getEnabledCAPIProviders(values)
+	By(fmt.Sprintf("Enabled CAPI providers: %s", enabledProviders))
 
 	providerWaiters := []func(ctx context.Context){}
 	configureProviderDefaults(ctx, input, values, enabledProviders)


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Conditionally install Turtles providers chart based on the test label ("short", "full", or "vsphere"). Just to be clear, there's already a TURTLES_PROVIDERS env var that achieves the same thing but it can be missed when running tests locally (as in not in CI).

**Which issue(s) this PR fixes**:
Fixes #2029

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
