### PR TITLE
ci: ignore artifact collection errors

### DIFF
--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -110,6 +110,7 @@ jobs:
 
       - name: Run crust-gather
         if: always()
+        continue-on-error: true
         run: make collect-artifacts
 
       - name: Collect run artifacts
@@ -190,6 +191,7 @@ jobs:
 
       - name: Run crust-gather
         if: always()
+        continue-on-error: true
         run: make collect-artifacts
 
       - name: Collect run artifacts


### PR DESCRIPTION
**What this PR does / why we need it**:

Occasionally this fails. See: https://github.com/rancher/turtles/actions/runs/22452236476/job/65023668818
To prevent flakiness, especially when the test succeeds, an error exit code on this step can be ignored to make the test pass.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
