### PR TITLE
fix: override default fleet-agent metrics and health bind addresses

### DIFF
--- a/charts/rancher-turtles-providers/templates/addon-fleet.yaml
+++ b/charts/rancher-turtles-providers/templates/addon-fleet.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ index .Values "providers" "addonFleet" "namespace" }}
+{{- if index .Values "extras" "addonFleet" "config" "enabled" }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -31,6 +32,11 @@ data:
         patchResource: true
         setOwnerReferences: true
       cluster:
+        agentEnvVars:
+          - name: FLEET_AGENT_METRICS_BIND_ADDRESS
+            value: "{{ index .Values "extras" "addonFleet" "config" "fleetAgentMetricsAddress" }}"
+          - name: FLEET_AGENT_PROBE_BIND_ADDRESS
+            value: "{{ index .Values "extras" "addonFleet" "config" "fleetAgentHealthProbeAddress" }}"
         agentNamespace: cattle-fleet-system
         applyClassGroup: true
         patchResource: true
@@ -61,6 +67,7 @@ data:
     - kind: ServiceAccount
       name: caapf-controller-manager
       namespace: {{ .Values.providers.addonFleet.namespace }}
+{{- end }}
 ---
 apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: CAPIProvider
@@ -106,7 +113,9 @@ spec:
     oci: {{ index .Values "providers" "addonFleet" "fetchConfig" "oci" }}
     {{- end }}
 {{- end }}
+{{- if index .Values "extras" "addonFleet" "config" "enabled" }}
   additionalManifests:
     name: fleet-addon-config
     namespace: {{ index .Values "providers" "addonFleet" "namespace" }}
+{{- end }}
 {{- end }}

--- a/charts/rancher-turtles-providers/values.schema.json
+++ b/charts/rancher-turtles-providers/values.schema.json
@@ -172,6 +172,36 @@
           "$ref": "#/$defs/providerSchema"
         }
       }
+    },
+    "extras": {
+      "type": "object",
+      "description": "Extra configuration for providers.",
+      "properties": {
+        "addonFleet": {
+          "type": "object",
+          "description": "Extra configuration for CAAPF",
+          "properties": {
+            "config": {
+              "type": "object",
+              "descrpiton": "Configure the embedded FleetAddonConfig.",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable the embedded FleetAddonConfig."
+                },
+                "fleetAgentMetricsAddress": {
+                  "type": "string",
+                  "description": "Sets the default fleet-agent metrics bind address."
+                },
+                "fleetAgentHealthProbeAddress": {
+                  "type": "string",
+                  "description": "Sets the default fleet-agent health probe bind address."
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/charts/rancher-turtles-providers/values.yaml
+++ b/charts/rancher-turtles-providers/values.yaml
@@ -322,6 +322,19 @@ providers:
   #   syncPeriod: "5m"
   #   verbosity: 5
 
+# extras: extra providers configuration
+extras:
+  # addonFleet: extra configuration for CAAPF 
+  addonFleet:
+    # config: configure the embedded FleetAddonConfig
+    config:
+      # enabled: enable the embedded FleetAddonConfig
+      enabled: true
+      # fleetAgentMetricsAddress: sets the default fleet-agent metrics bind address
+      fleetAgentMetricsAddress: ":18080"
+      # fleetAgentHealthProbeAddress: sets the default fleet-agent health probe bind address
+      fleetAgentHealthProbeAddress: ":18081"
+
 # These images are for documentation purposes only and are *not* used directly in the chart. They are used as input during a release for the purpose of creating a list of images necessary for airgapped installations.
 images:
   addonFleet:


### PR DESCRIPTION
**What this PR does / why we need it**:

Original finding: https://github.com/rancher/turtles/pull/2154#issuecomment-3971572852


I found out that on GKE the `fleet-agent` fails to initialize correctly since the metrics port `8080` is already bound (also see the [reserved port list](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/reserved-hostports)). 

```json
{"level":"error","ts":"2026-02-26T15:32:50Z","logger":"setup","msg":"problem running manager","error":"failed to start metrics server: failed to create listener: listen tcp :8080: bind: address already in use","stacktrace":"github.com/rancher/fleet/internal/cmd/agent.start\n\t/home/runner/_work/fleet/fleet/internal/cmd/agent/operator.go:181\ngithub.com/rancher/fleet/internal/cmd/agent.(*FleetAgent).Run.func1\n\t/home/runner/_work/fleet/fleet/internal/cmd/agent/root.go:143"}
{"level":"error","ts":"2026-02-26T15:32:50Z","logger":"setup","msg":"failed to start agent","error":"failed to start metrics server: failed to create listener: listen tcp :8080: bind: address already in use","stacktrace":"github.com/rancher/fleet/internal/cmd/agent.(*FleetAgent).Run.func1\n\t/home/runner/_work/fleet/fleet/internal/cmd/agent/root.go:144"}
{"level":"error","ts":"2026-02-26T15:32:50Z","logger":"controller-runtime.source.Kind","msg":"failed to get informer from cache","error":"Timeout: failed waiting for *v1alpha1.BundleDeployment Informer to sync","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1.1\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/source/kind.go:80\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func1\n\t/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.35.0/pkg/util/wait/loop.go:53\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\t/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.35.0/pkg/util/wait/loop.go:54\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\t/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.35.0/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/source/kind.go:68"}
{"level":"error","ts":"2026-02-26T15:33:05Z","logger":"clusterstatus","msg":"failed to report initial cluster status","cluster":"cluster-gke-pq8v6b","interval":900,"error":"client rate limiter Wait returned an error: context canceled","stacktrace":"github.com/rancher/fleet/internal/cmd/agent/clusterstatus.Ticker.func1\n\t/home/runner/_work/fleet/fleet/internal/cmd/agent/clusterstatus/ticker.go:42"}
```

This can be configured using fleet-agent environment variables, however there are two issues:
1. The FleetAddonConfig is embedded in the rancher-turtles-providers chart (and previously it was embedded in the turtles one)
2. CAAPF does not allow changing the configuration per Cluster (see https://github.com/rancher/cluster-api-addon-provider-fleet/issues/428)

So I see no other way than changing this for all Clusters and for all rancher-turtles-providers chart users. 
This is an opinionated choice, however since we also use the `hostNetwork` setting, trying to bind to `18080` and `18081` is probably safer in most cases.

This however has the consequence of rolling out the `fleet-agent` on already provisioned Clusters to bind to the newly set ports, which is surely going to be an unexpected change for current users.
Chart configuration values have been added so that users can default back to `8080` and `8081` if they wish to.

Test run that includes this change: https://github.com/rancher/turtles/actions/runs/22565380279/job/65360516383

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
