### PR TITLE
examples: remove hostNetwork usage from AWS CSI chart

### DIFF
--- a/examples/applications/csi/aws/helm-chart.yaml
+++ b/examples/applications/csi/aws/helm-chart.yaml
@@ -7,9 +7,6 @@ spec:
     releaseName: aws-ebs-csi-driver
     repo: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
     chart: aws-ebs-csi-driver
-    templateValues:
-      node: |-
-        hostNetwork: true
   insecureSkipTLSVerify: true
   targets:
   - clusterSelector:

--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -296,7 +296,7 @@ var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionali
 			BootstrapClusterProxy:     bootstrapClusterProxy,
 			ClusterTemplate:           e2e.CAPIAwsKubeadmTopology,
 			ClusterName:               "cluster-aws-kubeadm",
-			ControlPlaneMachineCount:  ptr.To(1),
+			ControlPlaneMachineCount:  ptr.To(3), //minimum 3 replicas for CSI controller
 			WorkerMachineCount:        ptr.To(1),
 			SkipDeletionTest:          false,
 			LabelNamespace:            true,
@@ -350,7 +350,7 @@ var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality 
 			BootstrapClusterProxy:     bootstrapClusterProxy,
 			ClusterTemplate:           e2e.CAPIAwsEC2RKE2Topology,
 			ClusterName:               "cluster-aws-rke2",
-			ControlPlaneMachineCount:  ptr.To(1),
+			ControlPlaneMachineCount:  ptr.To(3), //minimum 3 replicas for CSI controller
 			WorkerMachineCount:        ptr.To(1),
 			LabelNamespace:            true,
 			RancherServerURL:          hostName,
@@ -480,7 +480,7 @@ var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster from cluste
 			ClusterTemplate:           e2e.CAPIvSphereKubeadmTopology,
 			TopologyNamespace:         topologyNamespace,
 			ClusterName:               "cluster-vsphere-kubeadm",
-			ControlPlaneMachineCount:  ptr.To(3),
+			ControlPlaneMachineCount:  ptr.To(3), //minimum 3 replicas for CSI controller
 			WorkerMachineCount:        ptr.To(1),
 			LabelNamespace:            true,
 			RancherServerURL:          hostName,
@@ -535,7 +535,7 @@ var _ = Describe("[vSphere] [RKE2] Create and delete CAPI cluster functionality 
 			ClusterTemplate:           e2e.CAPIvSphereRKE2Topology,
 			TopologyNamespace:         topologyNamespace,
 			ClusterName:               "cluster-vsphere-rke2",
-			ControlPlaneMachineCount:  ptr.To(3),
+			ControlPlaneMachineCount:  ptr.To(3), //minimum 3 replicas for CSI controller
 			WorkerMachineCount:        ptr.To(1),
 			LabelNamespace:            true,
 			RancherServerURL:          hostName,


### PR DESCRIPTION
**What this PR does / why we need it**:

The `hostNetwork` usage seems to have been added accidentally.
The original manifest used with ClusterResourceSet did not use `hostNetwork: true`. 
Upstream CAPA templates also do not use this setting.

This PR is also bumping the number of control plane replicas for AWS tests to 3. 
The reason is that the CSI driver chart uses 2 replicas by default, so to better align with a production environment it's best to test with 3 control planes.

Test run: https://github.com/rancher/turtles/actions/runs/22675546959/job/65731389088

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
