### PR TITLE
fix: bump capg to v1.11.1

### DIFF
--- a/charts/rancher-turtles-providers/values.yaml
+++ b/charts/rancher-turtles-providers/values.yaml
@@ -363,7 +363,7 @@ images:
       tag: v2.13.0
   infrastructureGCP:
     repository: rancher/cluster-api-gcp-controller
-    tag: v1.11.0  
+    tag: v1.11.1
   infrastructureVSphere:
     repository: rancher/cluster-api-vsphere-controller
     tag: v1.15.2

--- a/internal/controllers/clusterctl/config-prime.yaml
+++ b/internal/controllers/clusterctl/config-prime.yaml
@@ -22,7 +22,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api-provider-azure/releases/v1.22.0/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "gcp"
-      url:          "https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/v1.11.0/infrastructure-components.yaml"
+      url:          "https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/v1.11.1/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "vsphere"
       url:          "https://github.com/rancher-sandbox/cluster-api-provider-vsphere/releases/v1.15.2/infrastructure-components.yaml"

--- a/internal/controllers/clusterctl/config_test.go
+++ b/internal/controllers/clusterctl/config_test.go
@@ -66,7 +66,7 @@ data:
         url: https://github.com/rancher-sandbox/cluster-api/releases/v1.12.2/core-components.yaml
       - name: gcp
         type: InfrastructureProvider
-        url: https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/v1.11.0/infrastructure-components.yaml
+        url: https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/v1.11.1/infrastructure-components.yaml
       - name: rke2
         type: ControlPlaneProvider
         url: https://github.com/rancher/cluster-api-provider-rke2/releases/v0.23.2/control-plane-components.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the latest patch release that fixes a conflict in managed template resources using the same short name as CAPZ's.

- [x] Full e2e run: https://github.com/rancher/turtles/actions/runs/22911623940: all tests passed successfully.

**Which issue(s) this PR fixes**:
Fixes #2199

**Special notes for your reviewer**:

This needs back-port to `release/v0.26` when merged.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
