### PR TITLE
[GKE ClusterClass] Add ClusterName to GCPControlManagedControlPlane

### DIFF
--- a/test/e2e/data/cluster-templates/gcp-gke-topology.yaml
+++ b/test/e2e/data/cluster-templates/gcp-gke-topology.yaml
@@ -22,8 +22,6 @@ spec:
         value: ${GCP_REGION}
       - name: networkName
         value: ${GCP_NETWORK_NAME}
-      - name: clusterName
-        value: ${CLUSTER_NAME}
     workers:
       machinePools:
         - class: default-system


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->
kind/enhancement

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
This PR adds `clusterName` variable to `GCPManagedControlPlane` spec, this ensures that GKE cluster created on Cloud Console does not have a random auto-generated name, [ref](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/58abcdcc039b8c7922057e95df5299ac779d040a/exp/webhooks/gcpmanagedcontrolplane_webhook.go#L78).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
