### PR TITLE
chore: un-rc providers chart version

### DIFF
--- a/charts/rancher-turtles-providers/Chart.yaml
+++ b/charts/rancher-turtles-providers/Chart.yaml
@@ -3,8 +3,8 @@ name: rancher-turtles-providers
 description: This chart installs the Rancher Turtles certified providers.
 home: https://turtles.docs.rancher.com/turtles/stable/en/overview/certified.html
 icon: https://raw.githubusercontent.com/rancher/turtles/main/logos/capi.svg
-version: 0.26.0-rc.10
-appVersion: "0.26.0-rc.10"
+version: 0.26.0
+appVersion: "0.26.0"
 keywords:
   - rancher
   - cluster-api


### PR DESCRIPTION
**What this PR does / why we need it**:

Un-rc providers chart in preparation for `v0.26.0`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Note that this process should be improved in the future. With this (required) change, we're un-rc'ing a different revision of the code validated in `v0.26.0-rc.10`.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
