### PR TITLE
chore(ci): bump aquasecurity/trivy-action to v0.35.0

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           TAG=${{ github.sha }} make docker-build-prime
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db


### PR DESCRIPTION
Updates GitHub Actions workflows to pin aquasecurity/trivy-action to v0.35.0.

CC @macedogm