### PR TITLE
fix: automatically update kuberlr-kubectl version

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,10 +1,10 @@
 ---
-name: "Updatecli: CAPI provider version management"
+name: "Updatecli"
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: "0 1 * * *"
 
 permissions:
   contents: "write"

--- a/updatecli/updatecli.d/capiproviders.yaml
+++ b/updatecli/updatecli.d/capiproviders.yaml
@@ -94,7 +94,7 @@ targets:
     kind: file
     spec:
       file: ./internal/controllers/clusterctl/config-prime.yaml
-      matchpattern: 'https://github.com/rancher-sandbox/cluster-api/releases/(.*)/'
+      matchpattern: "https://github.com/rancher-sandbox/cluster-api/releases/(.*)/"
       replacepattern: 'https://github.com/rancher-sandbox/cluster-api/releases/{{ source "capirelease" }}/'
     scmid: turtles
     sourceid: capirelease # Will be ignored as `replacepattern` is specified
@@ -103,8 +103,8 @@ targets:
     kind: file
     spec:
       file: ./internal/controllers/clusterctl/config-community.yaml
-      matchpattern: 'https://github.com/rancher-sandbox/cluster-api/releases/(.*)/'
-      replacepattern: 'https://github.com/rancher-sandbox/cluster-api/releases/{{ source "capirelease" }}/'
+      matchpattern: "https://github.com/kubernetes-sigs/cluster-api/releases/(.*)/"
+      replacepattern: 'https://github.com/kubernetes-sigs/cluster-api/releases/{{ source "capirelease" }}/'
     scmid: turtles
     sourceid: capirelease # Will be ignored as `replacepattern` is specified
   bumpcapd:
@@ -112,7 +112,7 @@ targets:
     kind: file
     spec:
       file: ./internal/controllers/clusterctl/config-prime.yaml
-      matchpattern: 'https://github.com/kubernetes-sigs/cluster-api/releases/(.*)/'
+      matchpattern: "https://github.com/kubernetes-sigs/cluster-api/releases/(.*)/"
       replacepattern: 'https://github.com/kubernetes-sigs/cluster-api/releases/{{ source "capirelease" }}/'
     scmid: turtles
     sourceid: capirelease # Will be ignored as `replacepattern` is specified
@@ -121,7 +121,7 @@ targets:
     kind: file
     spec:
       file: ./internal/controllers/operator_reconciler_test.go
-      matchpattern: 'CAPIVersion = .*'
+      matchpattern: "CAPIVersion = .*"
       replacepattern: CAPIVersion = "{{ source "capirelease" }}"
     scmid: turtles
     sourceid: capirelease # Will be ignored as `replacepattern` is specified
@@ -130,7 +130,7 @@ targets:
     kind: file
     spec:
       file: ./test/e2e/const.go
-      matchpattern: 'CAPIVersion = .*'
+      matchpattern: "CAPIVersion = .*"
       replacepattern: CAPIVersion = "{{ source "capirelease" }}"
     scmid: turtles
     sourceid: capirelease # Will be ignored as `replacepattern` is specified
@@ -139,7 +139,7 @@ targets:
     kind: file
     spec:
       file: ./internal/controllers/clusterctl/config-prime.yaml
-      matchpattern: 'https://github.com/rancher/cluster-api-provider-rke2/releases/(.*)/'
+      matchpattern: "https://github.com/rancher/cluster-api-provider-rke2/releases/(.*)/"
       replacepattern: 'https://github.com/rancher/cluster-api-provider-rke2/releases/{{ source "caprke2release" }}/'
     scmid: turtles
     sourceid: caprke2release # Will be ignored as `replacepattern` is specified
@@ -148,7 +148,7 @@ targets:
     kind: file
     spec:
       file: ./internal/controllers/clusterctl/config-prime.yaml
-      matchpattern: 'https://github.com/rancher-sandbox/cluster-api-provider-azure/releases/(.*)/'
+      matchpattern: "https://github.com/rancher-sandbox/cluster-api-provider-azure/releases/(.*)/"
       replacepattern: 'https://github.com/rancher-sandbox/cluster-api-provider-azure/releases/{{ source "capzrelease" }}/'
     scmid: turtles
     sourceid: capzrelease # Will be ignored as `replacepattern` is specified
@@ -157,7 +157,7 @@ targets:
     kind: file
     spec:
       file: ./internal/controllers/clusterctl/config-prime.yaml
-      matchpattern: 'https://github.com/rancher-sandbox/cluster-api-provider-aws/releases/(.*)/'
+      matchpattern: "https://github.com/rancher-sandbox/cluster-api-provider-aws/releases/(.*)/"
       replacepattern: 'https://github.com/rancher-sandbox/cluster-api-provider-aws/releases/{{ source "caparelease" }}/'
     scmid: turtles
     sourceid: caparelease # Will be ignored as `replacepattern` is specified
@@ -166,7 +166,7 @@ targets:
     kind: file
     spec:
       file: ./internal/controllers/clusterctl/config-prime.yaml
-      matchpattern: 'https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/(.*)/'
+      matchpattern: "https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/(.*)/"
       replacepattern: 'https://github.com/rancher-sandbox/cluster-api-provider-gcp/releases/{{ source "capgrelease" }}/'
     scmid: turtles
     sourceid: capgrelease # Will be ignored as `replacepattern` is specified
@@ -175,7 +175,7 @@ targets:
     kind: file
     spec:
       file: ./internal/controllers/clusterctl/config-prime.yaml
-      matchpattern: 'https://github.com/rancher-sandbox/cluster-api-provider-vsphere/releases/(.*)/'
+      matchpattern: "https://github.com/rancher-sandbox/cluster-api-provider-vsphere/releases/(.*)/"
       replacepattern: 'https://github.com/rancher-sandbox/cluster-api-provider-vsphere/releases/{{ source "capvrelease" }}/'
     scmid: turtles
     sourceid: capvrelease # Will be ignored as `replacepattern` is specified
@@ -184,7 +184,7 @@ targets:
     kind: file
     spec:
       file: ./internal/controllers/clusterctl/config-prime.yaml
-      matchpattern: 'https://github.com/rancher/cluster-api-addon-provider-fleet/releases/(.*)/'
+      matchpattern: "https://github.com/rancher/cluster-api-addon-provider-fleet/releases/(.*)/"
       replacepattern: 'https://github.com/rancher/cluster-api-addon-provider-fleet/releases/{{ source "capifleetrelease" }}/'
     scmid: turtles
     sourceid: capifleetrelease # Will be ignored as `replacepattern` is specified
@@ -192,12 +192,12 @@ targets:
 # create a pr with the changes
 actions:
   default:
-    title: '[updatecli] Bump CAPI Providers versions'
+    title: "[updatecli] Bump CAPI Providers versions"
     kind: github/pullrequest
     scmid: turtles
     spec:
       automerge: true
       mergemethod: squash
       labels:
-        - area/update
-        - kind/chore
+        - area/providers
+        - kind/cleanup

--- a/updatecli/updatecli.d/chart.yaml
+++ b/updatecli/updatecli.d/chart.yaml
@@ -1,0 +1,54 @@
+name: Bump chart versions
+
+# define scm for turtles
+scms:
+  turtles:
+    kind: github
+    spec:
+      user: turtles-bot
+      email: turtles@suse.de
+      owner: rancher
+      repository: turtles
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      branch: main
+      commitusingapi: true
+
+# retrieve latest release
+sources:
+  kuberlrkubectlrelease:
+    kind: githubrelease
+    name: Get the latest kuberlr-kubectl
+    spec:
+      owner: "rancher"
+      repository: "kuberlr-kubectl"
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      typeFilter:
+        latest: true
+
+# update targets
+targets:
+  helmchartshellimage:
+    name: bump kuberlr-kubectl
+    kind: yaml
+    spec:
+      file: "./charts/rancher-turtles/values.yaml"
+      key: "shellImage.image.tag"
+      value: '{{ source "kuberlrkubectlrelease" }}'
+    scmid: turtles
+    sourceid: kuberlrkubectlrelease
+
+# create a pr with the changes
+actions:
+  default:
+    title: "[updatecli] Bump chart versions"
+    kind: github/pullrequest
+    scmid: turtles
+    spec:
+      automerge: true
+      mergemethod: squash
+      labels:
+        - area/update
+        - area/chart
+        - kind/cleanup


### PR DESCRIPTION
**What this PR does / why we need it**:

Add new `updatecli` configuration to fetch and update the version of `rancher/kuberlr-kubectl` referenced in Turtles Helm chart.

**Which issue(s) this PR fixes**:
Fixes #2240

**Special notes for your reviewer**:

The PR that actually updates the version was created by `updatecli` from this source branch: https://github.com/rancher/turtles/pull/2252.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
