### PR TITLE
e2e: verify etcd size and collect data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,10 @@ CLUSTER_NAME ?= capi-test
 CACHE_DIR ?= .buildx-cache/
 CACHE_COMMANDS = "--cache-from type=local,src=$(CACHE_DIR) --cache-to type=local,dest=$(CACHE_DIR),mode=max"
 
+# ETCD Verification
+ETCD_VERIFY_SCRIPT_PATH := $(ROOT_DIR)/scripts/collect-etcd-data.sh
+ETCD_VERSION := v3.6.9
+
 .PHONY: all
 all: build
 
@@ -552,6 +556,15 @@ $(CLUSTERCTL): $(TOOLS_BIN_DIR) ## Download and install clusterctl
 	curl --retry $(CURL_RETRIES) -fsSL -o $(CLUSTERCTL) $(CAPI_UPSTREAM_RELEASES)/download/$(CLUSTERCTL_VER)/clusterctl-linux-amd64
 	chmod +x $(CLUSTERCTL) 
 
+install-etcd-tools: $(TOOLS_BIN_DIR) ## Download and install etcdctl
+	mkdir -p /tmp/etcd-tools-unpack
+	curl -L https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz -o /tmp/etcd-tools-unpack/etcd-${ETCD_VERSION}-linux-amd64.tar.gz
+	tar xzf /tmp/etcd-tools-unpack/etcd-${ETCD_VERSION}-linux-amd64.tar.gz -C /tmp/etcd-tools-unpack --strip-components=1 --no-same-owner
+	mv /tmp/etcd-tools-unpack/etcdctl $(TOOLS_BIN_DIR)/etcdctl
+	mv /tmp/etcd-tools-unpack/etcdutl $(TOOLS_BIN_DIR)/etcdutl
+	mv /tmp/etcd-tools-unpack/etcd $(TOOLS_BIN_DIR)/etcd
+	rm -rf /tmp/etcd-tools-unpack
+
 ## --------------------------------------
 ## Release
 ## --------------------------------------
@@ -639,7 +652,8 @@ SKIP_RESOURCE_CLEANUP=$(SKIP_RESOURCE_CLEANUP) \
 USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) \
 TURTLES_PROVIDERS=$(TURTLES_PROVIDERS) \
 TURTLES_PROVIDERS_PATH=$(ROOT_DIR)/$(CHART_PACKAGE_DIR)/rancher-turtles-providers-$(RANCHER_CHART_DEV_VERSION).tgz \
-CREATE_RANCHER_CERTS_SCRIPT_PATH=$(CREATE_RANCHER_CERTS_SCRIPT_PATH)
+CREATE_RANCHER_CERTS_SCRIPT_PATH=$(CREATE_RANCHER_CERTS_SCRIPT_PATH) \
+ETCD_VERIFY_SCRIPT_PATH=$(ETCD_VERIFY_SCRIPT_PATH)
 
 E2E_RUN_COMMAND=$(E2ECONFIG_VARS) $(GINKGO) -v --trace -p -procs=10 -poll-progress-after=$(GINKGO_POLL_PROGRESS_AFTER) \
 		-poll-progress-interval=$(GINKGO_POLL_PROGRESS_INTERVAL) --tags=e2e --focus="$(GINKGO_FOCUS)" --label-filter="$(GINKGO_LABEL_FILTER)" \
@@ -658,7 +672,7 @@ test-e2e: ## If MANAGEMENT_CLUSTER_ENVIRONMENT is 'eks', run remote e2e tests, o
 	fi
 
 .PHONY: test-e2e-local
-test-e2e-local: $(GINKGO) $(HELM) $(CLUSTERCTL) $(ENVSUBST) kubectl e2e-image build-local-rancher-charts ## Run the end-to-end tests
+test-e2e-local: $(GINKGO) $(HELM) $(CLUSTERCTL) $(ENVSUBST) kubectl e2e-image build-local-rancher-charts install-etcd-tools ## Run the end-to-end tests
 	$(E2E_RUN_COMMAND)
 
 .PHONY: test-e2e-remote
@@ -742,3 +756,10 @@ update-core-capi-manifest: kubectl
 	mkdir -p $(ARTIFACTS_FOLDER)
 	ARTIFACTS_FOLDER=$(ARTIFACTS_FOLDER) CAPI_VERSION=$(CAPI_MANIFEST_UPDATE_VERSION) OUTPUT_FILE=$(CAPI_MANIFEST_OUTPUT_FILE) hack/fetch-core-capi.sh
 
+## --------------------------------------
+## Verify ETCD size and collect data
+## --------------------------------------
+
+.PHONY: collect-etcd-data
+collect-etcd-data: install-etcd-tools
+	$(ETCD_VERIFY_SCRIPT_PATH)

--- a/scripts/collect-etcd-data.sh
+++ b/scripts/collect-etcd-data.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# Copyright © 2026 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script dumps some etcd info.
+# Mainly this is used to detect and debug conflicts managing resources.
+ 
+set -e
+
+# OUTPUT_DIR is the directory where to store results.
+OUTPUT_DIR=${OUTPUT_DIR:-./_artifacts/etcd}
+# CLUSTER_NAME is a name prefix added to all collected artifacts.
+CLUSTER_NAME=${CLUSTER_NAME:-capi-test}
+# CONTROL_PLANE_CONTAINER_NAME is the docker container name used to lookup ETCD certificates.
+CONTROL_PLANE_CONTAINER_NAME=${CONTROL_PLANE_CONTAINER_NAME:-capi-test-control-plane}
+# ETCD_ENDPOINT_ADDRESS is the ETCD listener address
+ETCD_ENDPOINT_ADDRESS=${ETCD_ENDPOINT_ADDRESS:-127.0.0.1}
+# ETCD_ENDPOINT_PORT is the ETCD listener port
+ETCD_ENDPOINT_PORT=${ETCD_ENDPOINT_PORT:-30002}
+
+etcd_endpoint=https://$ETCD_ENDPOINT_ADDRESS:$ETCD_ENDPOINT_PORT
+intermediate_dir=/tmp/etcd-collection/$CLUSTER_NAME
+
+mkdir -p $OUTPUT_DIR
+
+# Initialize intermediate directory
+rm -rf $intermediate_dir
+mkdir -p $intermediate_dir
+
+# Fetch etcd credentials
+echo "Fetching etcd credentials from container $CONTROL_PLANE_CONTAINER_NAME"
+docker cp $CONTROL_PLANE_CONTAINER_NAME:/etc/kubernetes/pki/etcd/ca.crt $intermediate_dir/ca.crt
+docker cp $CONTROL_PLANE_CONTAINER_NAME:/etc/kubernetes/pki/etcd/peer.crt $intermediate_dir/peer.crt
+docker cp $CONTROL_PLANE_CONTAINER_NAME:/etc/kubernetes/pki/etcd/peer.key $intermediate_dir/peer.key
+
+# Dump human readable status
+echo "Dumping endpoint status: $OUTPUT_DIR/$CLUSTER_NAME-status.txt"
+etcdctl --endpoints=$etcd_endpoint --cacert=$intermediate_dir/ca.crt --insecure-skip-tls-verify --cert=$intermediate_dir/peer.crt --key=$intermediate_dir/peer.key endpoint status --write-out=table > $OUTPUT_DIR/$CLUSTER_NAME-status.txt
+
+# Dump keys collection, sorted by versions
+echo "Collecting keys... this will take a while"
+
+# For each key, dump some info
+for key in `etcdctl --endpoints=$etcd_endpoint --cacert=$intermediate_dir/ca.crt --cert=$intermediate_dir/peer.crt --key=$intermediate_dir/peer.key get --prefix --keys-only /`
+do
+  size=`etcdctl --endpoints=$etcd_endpoint --cacert=$intermediate_dir/ca.crt --cert=$intermediate_dir/peer.crt --key=$intermediate_dir/peer.key get $key --print-value-only | wc -c`
+  count=`etcdctl --endpoints=$etcd_endpoint --cacert=$intermediate_dir/ca.crt --cert=$intermediate_dir/peer.crt --key=$intermediate_dir/peer.key get $key --write-out=fields | grep \"Count\" | cut -f2 -d':'`
+  if [ $count -ne 0 ]; then
+    versions=`etcdctl --endpoints=$etcd_endpoint --cacert=$intermediate_dir/ca.crt --cert=$intermediate_dir/peer.crt --key=$intermediate_dir/peer.key get $key --write-out=fields | grep \"Version\" | cut -f2 -d':'`
+  else
+    versions=0
+  fi
+  total=$(($size * $versions))
+  printf "$total\t$size\t$versions\t$count\t$key\n" >> $intermediate_dir/keys.txt
+done
+
+# Sort keys by versions count
+echo "Dumping sorted keys: $OUTPUT_DIR/$CLUSTER_NAME-keys-sorted.txt"
+printf "TOTAL\tSIZE\tVERSIONS\tCOUNT\tKEY\n" > $OUTPUT_DIR/$CLUSTER_NAME-keys-sorted.txt
+sort -nrk 3 $intermediate_dir/keys.txt >> $OUTPUT_DIR/$CLUSTER_NAME-keys-sorted.txt
+
+# Exit with error if size exceeded
+echo "Taking snapshot to calculate database size"
+etcdctl --endpoints=$etcd_endpoint --cacert=$intermediate_dir/ca.crt --cert=$intermediate_dir/peer.crt --key=$intermediate_dir/peer.key snapshot save $intermediate_dir/snapshot.db
+size=$(($(stat -c%s $intermediate_dir/snapshot.db) / 1000000))
+echo "Calculated size from snapshot is $size MB"
+
+rm -rf $intermediate_dir # Ensure cleanup to immediately remove large snapshots.
+
+size_limit=500
+if (( size > size_limit )); then
+  printf "Error: ETCD database size exceeding limit of $size_limit MB. Found: $size MB\n" >&2
+  exit 1
+fi
+
+exit 0

--- a/scripts/kind-cluster-with-extramounts.yaml
+++ b/scripts/kind-cluster-with-extramounts.yaml
@@ -5,6 +5,8 @@ nodes:
 - role: control-plane
   image: kindest/node:v1.34.0
   extraMounts:
+    - hostPath: /tmp/capi-test/etcd
+      containerPath: /tmp/capi-test/etcd
     - hostPath: /var/run/docker.sock
       containerPath: /var/run/docker.sock
   extraPortMappings:
@@ -12,6 +14,10 @@ nodes:
   - containerPort: 30001
     hostPort: 30001
     protocol: TCP
+  # ETCD listener Nodeport
+  - containerPort: 30002
+    hostPort: 30002
+    protocol: TCP  
   # Rancher test Nodeports (HTTP and HTTPs)
   - containerPort: 30080
     hostPort: 30080

--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -244,6 +244,10 @@ install_local_providers_chart() {
 echo "Installing local Rancher Turtles Providers..."
 install_local_providers_chart
 
+echo "Exposing ETCD..."
+kubectl apply -f test/e2e/data/etcd/test-nodeport.yaml
+echo "To verify and collect ETCD data, run: make collect-etcd-data"
+
 if [ "$USE_TILT_DEV" == "true" ]; then
     kubectl wait --for=create deployments/rancher-turtles-controller-manager --namespace cattle-turtles-system --timeout=300s
     echo "Using Tilt for development..."

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -147,6 +147,9 @@ var (
 
 	//go:embed data/gitea/values.yaml
 	GiteaValues []byte
+
+	//go:embed data/etcd/test-nodeport.yaml
+	ETCDTestNodeport []byte
 )
 
 const (

--- a/test/e2e/data/etcd/test-nodeport.yaml
+++ b/test/e2e/data/etcd/test-nodeport.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-nodeport
+  namespace: kube-system
+spec:
+  type: NodePort
+  selector:
+    component: etcd
+  ports:
+  - nodePort: 30002
+    port: 2379
+    protocol: TCP
+    targetPort: 2379

--- a/test/e2e/specs/import_gitops.go
+++ b/test/e2e/specs/import_gitops.go
@@ -96,6 +96,10 @@ type CreateUsingGitOpsSpecInput struct {
 	// enum (rapid|regular|stable|extended) does not support disabling auto-upgrades, this skip
 	// is necessary for GKE clusters.
 	SkipClusterAvailableWait bool
+
+	// VerifyETCDSize can be used to verify ETCD database size and for the supported environments,
+	// collect debug data.
+	VerifyETCDSize bool
 }
 
 // CreateUsingGitOpsSpec implements a spec that will create a cluster via Fleet and test that it
@@ -340,6 +344,15 @@ func CreateUsingGitOpsSpec(ctx context.Context, inputGetter func() CreateUsingGi
 				RancherServerURL:        input.RancherServerURL,
 				WaitRancherIntervals:    input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher"),
 				SkipLatestFeatureChecks: input.SkipLatestFeatureChecks,
+			})
+		}
+
+		if input.VerifyETCDSize {
+			By("Verifying ETCD size")
+			testenv.VerifyETCDSize(ctx, testenv.VerifyETCDSizeInput{
+				ClusterName:         input.ClusterName + "-bootstrap-" + specName,
+				ContainerName:       input.BootstrapClusterProxy.GetName() + "-control-plane",
+				ETCDEndpointAddress: testenv.GetInternalAddress(ctx, input.BootstrapClusterProxy),
 			})
 		}
 	})

--- a/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
+++ b/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
@@ -188,6 +188,13 @@ var _ = Describe("Chart upgrade functionality should work", Ordered, Label(e2e.S
 	})
 
 	It("Should migrate to Rancher 2.14.x with zero-downtime", func() {
+		By("Verifying ETCD size before upgrade")
+		testenv.VerifyETCDSize(ctx, testenv.VerifyETCDSizeInput{
+			ClusterName:         bootstrapClusterProxy.GetName() + "-before",
+			ContainerName:       bootstrapClusterProxy.GetName() + "-control-plane",
+			ETCDEndpointAddress: testenv.GetInternalAddress(ctx, bootstrapClusterProxy),
+		})
+
 		By("Upgrading Rancher to 2.14.x with Gitea chart repository")
 		testenv.UpgradeInstallRancherWithGitea(ctx, testenv.UpgradeInstallRancherWithGiteaInput{
 			BootstrapClusterProxy: bootstrapClusterProxy,
@@ -278,6 +285,13 @@ var _ = Describe("Chart upgrade functionality should work", Ordered, Label(e2e.S
 			BootstrapClusterProxy:   bootstrapClusterProxy,
 			Name:                    clusterName,
 			DeleteAfterVerification: true,
+		})
+
+		By("Verifying ETCD size after upgrade")
+		testenv.VerifyETCDSize(ctx, testenv.VerifyETCDSizeInput{
+			ClusterName:         bootstrapClusterProxy.GetName() + "-after",
+			ContainerName:       bootstrapClusterProxy.GetName() + "-control-plane",
+			ETCDEndpointAddress: testenv.GetInternalAddress(ctx, bootstrapClusterProxy),
 		})
 	})
 })

--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -54,6 +54,7 @@ var _ = Describe("[Docker] [Kubeadm]  Create and delete CAPI cluster functionali
 			CAPIClusterCreateWaitName: "wait-rancher",
 			DeleteClusterWaitName:     "wait-controllers",
 			TopologyNamespace:         topologyNamespace,
+			VerifyETCDSize:            true,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "docker-cluster-classes-regular",
@@ -96,6 +97,7 @@ var _ = Describe("[Docker] [RKE2] Create and delete CAPI cluster functionality s
 			CAPIClusterCreateWaitName: "wait-rancher",
 			DeleteClusterWaitName:     "wait-controllers",
 			TopologyNamespace:         topologyNamespace,
+			VerifyETCDSize:            true,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "docker-cluster-classes-regular",
@@ -143,6 +145,7 @@ var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster clas
 			CAPIClusterCreateWaitName: "wait-capz-create-cluster",
 			DeleteClusterWaitName:     "wait-aks-delete",
 			TopologyNamespace:         topologyNamespace,
+			VerifyETCDSize:            true,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "azure-cluster-classes-aks",
@@ -179,6 +182,7 @@ var _ = Describe("[Azure] [Kubeadm] Create and delete CAPI cluster from cluster 
 			CAPIClusterCreateWaitName: "wait-capz-create-cluster",
 			DeleteClusterWaitName:     "wait-aks-delete",
 			TopologyNamespace:         topologyNamespace,
+			VerifyETCDSize:            true,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "azure-cluster-class-kubeadm",
@@ -227,6 +231,7 @@ var _ = Describe("[Azure] [RKE2] Create and delete CAPI cluster from cluster cla
 			CAPIClusterCreateWaitName: "wait-capz-create-cluster",
 			DeleteClusterWaitName:     "wait-aks-delete",
 			TopologyNamespace:         topologyNamespace,
+			VerifyETCDSize:            true,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "azure-cluster-class-rke2",
@@ -274,6 +279,7 @@ var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster from cluster class"
 			CAPIClusterCreateWaitName: "wait-capa-create-cluster",
 			DeleteClusterWaitName:     "wait-eks-delete",
 			TopologyNamespace:         topologyNamespace,
+			VerifyETCDSize:            true,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "aws-cluster-classes-eks",
@@ -310,6 +316,7 @@ var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionali
 			CAPIClusterCreateWaitName: "wait-capa-create-cluster",
 			DeleteClusterWaitName:     "wait-eks-delete",
 			TopologyNamespace:         topologyNamespace,
+			VerifyETCDSize:            true,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "aws-cluster-classes-regular",
@@ -363,6 +370,7 @@ var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality 
 			CAPIClusterCreateWaitName: "wait-capa-create-cluster",
 			DeleteClusterWaitName:     "wait-eks-delete",
 			TopologyNamespace:         topologyNamespace,
+			VerifyETCDSize:            true,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "aws-cluster-class-rke2",
@@ -418,6 +426,7 @@ var _ = Describe("[GCP] [Kubeadm] Create and delete CAPI cluster functionality s
 			CAPIClusterCreateWaitName: "wait-capg-create-cluster",
 			DeleteClusterWaitName:     "wait-gke-delete",
 			TopologyNamespace:         topologyNamespace,
+			VerifyETCDSize:            true,
 			AdditionalTemplateVariables: map[string]string{
 				e2e.GCPImageIDFormattedVar: gcpImageFormatted,
 			},
@@ -469,6 +478,7 @@ var _ = Describe("[GCP] [GKE] Create and delete CAPI cluster functionality shoul
 			DeleteClusterWaitName:     "wait-gke-delete",
 			TopologyNamespace:         topologyNamespace,
 			SkipClusterAvailableWait:  true, // GKE auto-upgrades cause non-empty Available condition message
+			VerifyETCDSize:            true,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "gcp-cluster-classes-gke",
@@ -506,6 +516,7 @@ var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster from cluste
 			RancherServerURL:          hostName,
 			CAPIClusterCreateWaitName: "wait-capv-create-cluster",
 			DeleteClusterWaitName:     "wait-vsphere-delete",
+			VerifyETCDSize:            true,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "vsphere-cluster-classes-kubeadm",
@@ -561,6 +572,7 @@ var _ = Describe("[vSphere] [RKE2] Create and delete CAPI cluster functionality 
 			RancherServerURL:          hostName,
 			CAPIClusterCreateWaitName: "wait-capv-create-cluster",
 			DeleteClusterWaitName:     "wait-vsphere-delete",
+			VerifyETCDSize:            true,
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "vsphere-cluster-classes-rke2",

--- a/test/testenv/bootstrapclusterproviders.go
+++ b/test/testenv/bootstrapclusterproviders.go
@@ -63,6 +63,7 @@ func KindWithExtraPortMappingsBootstrapCluster(ctx context.Context, config *clus
 		ExtraPortMappings: []v1alpha4.PortMapping{
 			{ContainerPort: 80, HostPort: 80, Protocol: v1alpha4.PortMappingProtocolTCP},
 			{ContainerPort: 443, HostPort: 443, Protocol: v1alpha4.PortMappingProtocolTCP},
+			{ContainerPort: 30002, HostPort: 30002, Protocol: v1alpha4.PortMappingProtocolTCP}, // etcd nodeport
 		},
 	})
 }

--- a/test/testenv/etcd.go
+++ b/test/testenv/etcd.go
@@ -1,0 +1,86 @@
+/*
+Copyright © 2026 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testenv
+
+import (
+	"context"
+	"os"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/turtles/test/e2e"
+	turtlesframework "github.com/rancher/turtles/test/framework"
+)
+
+// VerifyETCDSizeInput is the input for VerifyETCDSize
+type VerifyETCDSizeInput struct {
+	// ClusterName is the cluster for which the data is collected.
+	// Beware that launching the script multiple times for the same cluster will override the data.
+	ClusterName string
+
+	// ContainerName is the container to use to fetch etcd credentials.
+	ContainerName string
+
+	// ETCDEndpointAddress is the address used by the etcd client
+	ETCDEndpointAddress string
+
+	// VerifyETCDDataScriptPath is the file path to the certs creation script.
+	VerifyETCDDataScriptPath string `env:"ETCD_VERIFY_SCRIPT_PATH"`
+
+	// ArtifactsFolder is the root path for the artifacts folder.
+	ArtifactsFolder string `env:"ARTIFACTS_FOLDER"`
+
+	// ManagementClusterEnvironment is the management cluster environment type.
+	ManagementClusterEnvironment e2e.ManagementClusterEnvironmentType `env:"MANAGEMENT_CLUSTER_ENVIRONMENT"`
+}
+
+// VerifyETCDSize runs etcd data collection and size verification for a given cluster.
+func VerifyETCDSize(ctx context.Context, input VerifyETCDSizeInput) {
+	Expect(turtlesframework.Parse(&input)).To(Succeed(), "Failed to parse environment variables")
+
+	Expect(ctx).ShouldNot(BeNil(), "ctx is required for VerifyETCDSize")
+	Expect(input.ClusterName).ShouldNot(BeEmpty(), "ClusterName is required for VerifyETCDSize")
+	Expect(input.ArtifactsFolder).ShouldNot(BeEmpty(), "ArtifactsFolder is required for VerifyETCDSize")
+	Expect(input.ManagementClusterEnvironment).ShouldNot(BeEmpty(), "ManagementClusterEnvironment is required for VerifyETCDSize")
+
+	switch input.ManagementClusterEnvironment {
+	case e2e.ManagementClusterEnvironmentEKS:
+	default:
+		Expect(input.ContainerName).ShouldNot(BeEmpty(), "ContainerName is required for VerifyETCDSize")
+		Expect(input.ETCDEndpointAddress).ShouldNot(BeEmpty(), "ETCDEndpointAddress is required for VerifyETCDSize")
+		Expect(input.VerifyETCDDataScriptPath).ShouldNot(BeEmpty(), "VerifyETCDDataScriptPath is required for VerifyETCDSize")
+	}
+
+	switch input.ManagementClusterEnvironment {
+	case e2e.ManagementClusterEnvironmentEKS:
+		GinkgoWriter.Println("ETCD size verification not yet supported for EKS")
+		return
+	default:
+		verityETCDCmd := exec.Command(input.VerifyETCDDataScriptPath)
+		verityETCDCmd.Env = append(os.Environ(),
+			"OUTPUT_DIR="+input.ArtifactsFolder+"/etcd",
+			"CLUSTER_NAME="+input.ClusterName,
+			"CONTROL_PLANE_CONTAINER_NAME="+input.ContainerName,
+			"ETCD_ENDPOINT_ADDRESS="+input.ETCDEndpointAddress,
+		)
+		out, err := verityETCDCmd.CombinedOutput()
+		GinkgoWriter.Printf("%s\n", out)
+		Expect(err).ShouldNot(HaveOccurred(), "ETCD verification failed")
+	}
+}

--- a/test/testenv/setupcluster.go
+++ b/test/testenv/setupcluster.go
@@ -119,6 +119,9 @@ func SetupTestCluster(ctx context.Context, input SetupTestClusterInput) *SetupTe
 	result.BootstrapClusterLogFolder = filepath.Join(input.ArtifactFolder, "clusters", result.BootstrapClusterProxy.GetName())
 	Expect(os.MkdirAll(result.BootstrapClusterLogFolder, 0o750)).To(Succeed(), "Invalid argument. Log folder can't be created %s", result.BootstrapClusterLogFolder)
 
+	By("Exposing ETCD Pod with Nodeport")
+	Expect(turtlesframework.Apply(ctx, result.BootstrapClusterProxy, e2e.ETCDTestNodeport)).Should(Succeed())
+
 	return result
 }
 
@@ -157,6 +160,15 @@ func (r *SetupTestClusterResult) setupCluster(ctx context.Context, config *clust
 // "ingress-ready" so that the nginx ingress controller can pick it up, required by kind. See: https://kind.sigs.k8s.io/docs/user/ingress/#create-cluster
 // This hostname can be used in an environment where the cluster is isolated from the outside world and a Rancher hostname is required.
 func getInternalClusterHostname(ctx context.Context, clusterProxy framework.ClusterProxy) string {
+	if address := GetInternalAddress(ctx, clusterProxy); address == "" {
+		return ""
+	} else {
+		return address + "." + turtlesframework.MagicDNS
+	}
+}
+
+// GetInternalAddress gets the internal address by setting it to the IP of the first and only node in the boostrap cluster.
+func GetInternalAddress(ctx context.Context, clusterProxy framework.ClusterProxy) string {
 	cpNodeList := corev1.NodeList{}
 	Expect(clusterProxy.GetClient().List(ctx, &cpNodeList)).To(Succeed())
 	Expect(cpNodeList.Items).To(HaveLen(1))
@@ -167,7 +179,7 @@ func getInternalClusterHostname(ctx context.Context, clusterProxy framework.Clus
 
 	for _, address := range cpNode.Status.Addresses {
 		if address.Type == corev1.NodeInternalIP {
-			return address.Address + "." + turtlesframework.MagicDNS
+			return address.Address
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Part of https://github.com/rancher/turtles/issues/2106

This PR introduces verification of etcd database size.
For the moment this is only implemented for Clusters provisioned using kind.

An arbitrary 500MB limit has been defined, which should be plenty and can probably be lowered in the future.
Artifacts have also been added in the `etcd` folder, containing:
- The human readable endpoint status: `my-cluster-status.txt`
- The list of keys sorted by versions: `my-cluster-sorted-keys.txt`

For reference, when the size limit is exceeded, the CI output should look like this:

```txt
  STEP: Verifying ETCD size @ 03/25/26 16:05:40.963
  Fetching etcd credentials from container rancher-turtles-e2e-import-gitops-rjbe0d-control-plane
  Dumping endpoint status: /home/andrea/repos/rancher-turtles/_artifacts/etcd/cluster-docker-rke2-6xu6fs-bootstrap-creategitops-status.txt
  Collecting keys... this will take a while
  Dumping sorted keys: /home/andrea/repos/rancher-turtles/_artifacts/etcd/cluster-docker-rke2-6xu6fs-bootstrap-creategitops-keys-sorted.txt
  Taking snapshot to calculate database size
  {"level":"info","ts":"2026-03-25T16:07:27.015379+0100","caller":"snapshot/v3_snapshot.go:83","msg":"created temporary db file","path":"/tmp/etcd-collection/cluster-docker-rke2-6xu6fs-bootstrap-creategitops/snapshot.db.part"}
  {"level":"info","ts":"2026-03-25T16:07:27.020234+0100","logger":"client","caller":"v3@v3.6.9/maintenance.go:236","msg":"opened snapshot stream; downloading"}
  {"level":"info","ts":"2026-03-25T16:07:27.028628+0100","caller":"snapshot/v3_snapshot.go:96","msg":"fetching snapshot","endpoint":"https://172.18.0.2:30002"}
  {"level":"info","ts":"2026-03-25T16:07:27.450116+0100","logger":"client","caller":"v3@v3.6.9/maintenance.go:302","msg":"completed snapshot read; closing"}
  {"level":"info","ts":"2026-03-25T16:07:27.450218+0100","caller":"snapshot/v3_snapshot.go:111","msg":"fetched snapshot","endpoint":"https://172.18.0.2:30002","size":"78 MB","took":"434.742135ms","etcd-version":"3.6.0"}
  {"level":"info","ts":"2026-03-25T16:07:27.450279+0100","caller":"snapshot/v3_snapshot.go:121","msg":"saved","path":"/tmp/etcd-collection/cluster-docker-rke2-6xu6fs-bootstrap-creategitops/snapshot.db"}
  Snapshot saved at /tmp/etcd-collection/cluster-docker-rke2-6xu6fs-bootstrap-creategitops/snapshot.db
  Server version 3.6.0
  Calculated size from snapshot is 77 MB
  Error: ETCD database size exceeding limit of 1 MB. Found: 77 MB

  [FAILED] in [It] - /home/andrea/repos/rancher-turtles/test/testenv/etcd.go:84 @ 03/25/26 16:07:27.477
```

e2e long run (etcd collection is skipped on eks, test failure not related to this PR): https://github.com/rancher/turtles/actions/runs/23550142878
vSphere run: https://github.com/rancher/turtles/actions/runs/23585552421

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
