### PR TITLE
check immutable checksum after curl download

### DIFF
--- a/.github/workflows/e2e-cleanup.yaml
+++ b/.github/workflows/e2e-cleanup.yaml
@@ -25,9 +25,11 @@ jobs:
         run: |
           ARCH=amd64
           PLATFORM=$(uname -s)_$ARCH
+          EKSCTL_VERSION=0.225.0
+          EXPECTED_SHA256_AMD64=041ad321cafd82596b33562f1e95a8c1035a9e0b2e95e9f2bcd2ada7219def83 # immutable hash for v0.225.0 AMD64
 
-          curl -sLO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$PLATFORM.tar.gz"
-          curl -sL "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_checksums.txt" | grep $PLATFORM | sha256sum --check
+          curl -sLO "https://github.com/eksctl-io/eksctl/releases/download/v$EKSCTL_VERSION/eksctl_$PLATFORM.tar.gz"
+          echo "$EXPECTED_SHA256_AMD64  eksctl_Linux_amd64.tar.gz" | sha256sum --check
 
           tar -xzf eksctl_$PLATFORM.tar.gz -C /tmp && rm eksctl_$PLATFORM.tar.gz
 

--- a/.github/workflows/run-e2e-suite.yaml
+++ b/.github/workflows/run-e2e-suite.yaml
@@ -73,16 +73,23 @@ jobs:
         run: |
           ARCH=amd64
           PLATFORM=$(uname -s)_$ARCH
+          EKSCTL_VERSION=0.225.0
+          EXPECTED_SHA256_AMD64=041ad321cafd82596b33562f1e95a8c1035a9e0b2e95e9f2bcd2ada7219def83 # immutable hash for v0.225.0 AMD64
 
-          curl -sLO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$PLATFORM.tar.gz"
-          curl -sL "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_checksums.txt" | grep $PLATFORM | sha256sum --check
+          curl -sLO "https://github.com/eksctl-io/eksctl/releases/download/v$EKSCTL_VERSION/eksctl_$PLATFORM.tar.gz"
+          echo "$EXPECTED_SHA256_AMD64  eksctl_$PLATFORM.tar.gz" | sha256sum --check
 
           tar -xzf eksctl_$PLATFORM.tar.gz -C /tmp && rm eksctl_$PLATFORM.tar.gz
 
           sudo mv /tmp/eksctl /usr/local/bin
       - name: Install aws-iam-authenticator
         run: |
-          curl -L -o aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.14/aws-iam-authenticator_0.6.14_linux_amd64
+          AWS_IAM_AUTHENTICATOR_VERSION=0.7.12
+          EXPECTED_SHA256_AMD64=73cca6175225ac72f4e0b8b23ca214043a98097ce6047d159b1bb3abde1bfce5 # immutable hash for v0.7.12 AMD64
+
+          curl -L -o aws-iam-authenticator "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v$AWS_IAM_AUTHENTICATOR_VERSION/aws-iam-authenticator_${AWS_IAM_AUTHENTICATOR_VERSION}_linux_amd64"
+          echo "$EXPECTED_SHA256_AMD64  aws-iam-authenticator" | sha256sum --check
+
           chmod +x ./aws-iam-authenticator
           sudo mv ./aws-iam-authenticator /usr/local/bin
 

--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -47,7 +47,13 @@ jobs:
 
       - name: Install kind
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-$(uname)-amd64
+          KIND_VERSION=0.31.0
+          PLATFORM=$(uname)-amd64
+          EXPECTED_SHA256_AMD64=eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa # immutable hash for v0.31.0
+
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-${PLATFORM}
+          echo "$EXPECTED_SHA256_AMD64  kind" | sha256sum --check
+
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 
@@ -152,7 +158,13 @@ jobs:
 
       - name: Install kind
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-$(uname)-amd64
+          KIND_VERSION=0.31.0
+          PLATFORM=$(uname)-amd64
+          EXPECTED_SHA256_AMD64=eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa # immutable hash for v0.31.0
+
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-${PLATFORM}
+          echo "$EXPECTED_SHA256_AMD64  kind" | sha256sum --check
+
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,6 @@ else
 GO_ARCH = arm64
 endif
 
-ifeq ($(shell go env GOOS),linux)
-UPDATECLI_OS = Linux
-else
-UPDATECLI_OS = Darwin
-endif
-
 GO_VERSION ?= $(shell grep "go " go.mod | head -1 |awk '{print $$NF}')
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 REPO ?= rancher/turtles
@@ -150,10 +144,6 @@ GINKGO_BIN := ginkgo
 GINGKO_VER := $(call get_go_version,github.com/onsi/ginkgo/v2)
 GINKGO := $(abspath $(TOOLS_BIN_DIR)/$(GINKGO_BIN)-$(GINGKO_VER))
 GINKGO_PKG := github.com/onsi/ginkgo/v2/ginkgo
-
-UPDATECLI_BIN := updatecli
-UPDATECLI_VER := v0.94.0
-UPDATECLI := $(abspath $(TOOLS_BIN_DIR)/$(UPDATECLI_BIN)-$(UPDATECLI_VER))
 
 HELM_VER := v3.18.4
 HELM_BIN := helm
@@ -318,10 +308,6 @@ lint: $(GOLANGCI_LINT) ## Lint the codebase
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter
 	GOLANGCI_LINT_EXTRA_ARGS=--fix $(MAKE) lint
-
-.PHONY: updatecli
-updatecli-apply: $(UPDATECLI)
-	$(UPDATECLI) apply --config ./updatecli/updatecli.d
 
 ## --------------------------------------
 ## Testing
@@ -521,12 +507,6 @@ $(SETUP_ENVTEST): # Build setup-envtest from tools folder.
 
 $(GINKGO): # Build ginkgo from tools folder.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(GINKGO_PKG) $(GINKGO_BIN) $(GINGKO_VER)
-
-$(UPDATECLI): # Install updatecli
-	curl -sSL -o ${TOOLS_BIN_DIR}/updatecli_${GO_ARCH}.tar.gz https://github.com/updatecli/updatecli/releases/download/${UPDATECLI_VER}/updatecli_${UPDATECLI_OS}_${GO_ARCH}.tar.gz
-	cd ${TOOLS_BIN_DIR} && tar -xzf updatecli_${GO_ARCH}.tar.gz
-	cd ${TOOLS_BIN_DIR} && chmod +x updatecli
-	cd ${TOOLS_BIN_DIR} && mv updatecli $(UPDATECLI_BIN)-$(UPDATECLI_VER)
 
 $(GOLANGCI_LINT): # Build golangci-lint from tools folder.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(GOLANGCI_LINT_PKG) $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -26,7 +26,29 @@ fi
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
+
+# kubectl version and immutable checksum for validation
 MINIMUM_KUBECTL_VERSION=v1.34.1
+# renovate-local: kubectl-linux-amd64=v1.34.1
+KUBECTL_SUM_linux_amd64="7721f265e18709862655affba5343e85e1980639395d5754473dafaadcaa69e3" # immutable sha256 for v1.34.1 linux amd64
+# renovate-local: kubectl-linux-arm64=v1.34.1
+KUBECTL_SUM_linux_arm64="420e6110e3ba7ee5a3927b5af868d18df17aae36b720529ffa4e9e945aa95450" # immutable sha256 for v1.34.1 linux arm64
+# renovate-local: kubectl-darwin-amd64=v1.34.1
+KUBECTL_SUM_darwin_amd64="bb211f2b31f2b3bc60562b44cc1e3b712a16a98e9072968ba255beb04cefcfdf" # immutable sha256 for v1.34.1 darwin amd64
+# renovate-local: kubectl-darwin-arm64=v1.34.1
+KUBECTL_SUM_darwin_arm64="d80e5fa36f2b14005e5bb35d3a72818acb1aea9a081af05340a000e5fbdb2f76" # immutable sha256 for v1.34.1 darwin arm64
+
+# Krew version and immutable checksum for validation
+KREW_VERSION="v0.5.0"
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/krew digestVersion=v0.5.0
+KREW_SUM_linux_amd64="5d5a221fffdf331d1c5c68d9917530ecd102e0def5b5a6d62eeed1c404efb28a" # immutable sha256 for krew v0.5.0 linux amd64
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/krew digestVersion=v0.5.0
+KREW_SUM_linux_arm64="ab7a98b992424e76b6c162f8b67fb76c4b1e243598aa2807bdf226752f964548" # immutable sha256 for krew v0.5.0 linux arm64
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/krew digestVersion=v0.5.0
+KREW_SUM_darwin_amd64="2d60559126452b57e3df0612f0475a473363f064da35f817290dbbcd877d1ea8" # immutable sha256 for krew v0.5.0 darwin amd64
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/krew digestVersion=v0.5.0
+KREW_SUM_darwin_arm64="cd6e58b4e954e301abd19001d772846997216d696bcaa58f0bcf04708339ece3" # immutable sha256 for krew v0.5.0 darwin arm64
+
 goarch="$(go env GOARCH)"
 goos="$(go env GOOS)"
 
@@ -47,6 +69,9 @@ verify_kubectl_version() {
       echo "Updating to ${MINIMUM_KUBECTL_VERSION}."
 
       curl -sLo "${GOPATH_BIN}/kubectl" "https://dl.k8s.io/release/${MINIMUM_KUBECTL_VERSION}/bin/${goos}/${goarch}/kubectl"
+      KUBECTL_SUM_VAR="KUBECTL_SUM_${goos}_${goarch}"
+      echo "${!KUBECTL_SUM_VAR}  $GOPATH_BIN/kubectl" | sha256sum --check
+
       chmod +x "${GOPATH_BIN}/kubectl"
       verify_gopath_bin
     else
@@ -58,12 +83,16 @@ verify_kubectl_version() {
 
 install_plugins() {
   (
-    set -x; cd "$(mktemp -d)" &&
-    OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
-    ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
-    KREW="krew-${OS}_${ARCH}" &&
-    curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
-    tar zxvf "${KREW}.tar.gz" &&
+    set -x; cd "$(mktemp -d)"
+    OS="$(uname | tr '[:upper:]' '[:lower:]')"
+    ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
+    KREW="krew-${OS}_${ARCH}"
+
+    curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/${KREW_VERSION}/${KREW}.tar.gz"
+    KREW_SUM_VAR="KREW_SUM_${OS}_${ARCH}"
+    echo "${!KREW_SUM_VAR}  ${KREW}.tar.gz" | sha256sum --check
+
+    tar zxvf "${KREW}.tar.gz"
     ./"${KREW}" install krew
   )
   kubectl krew version


### PR DESCRIPTION
**What this PR does / why we need it**:

For every tool downloaded using curl, validate the downloaded artifact's sha256 against an immutable, pre-calculated version of the hash.

This also removes unused `updatecli` actions from the Makefile which were using `curl` but are not used as part of the actual `updatecli` workflow which relies on the project's GitHub action.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Original security issue: https://github.com/rancher/rancher-security/issues/2038

Files that are reported in the issue but are not shipped or not considered relevant:
- `ensure-pr-labels.yaml` and `ensure-issues-labels-desc.yaml`: these just curl the GitHub API to check for (lack of) labels. No file or executable involved.
- `fetch-core-capi-airgapped.yaml`: this is in fact aimed at pulling the latest version of Cluster API (from Rancher's forked version of the repository) and creating a new PR which will need to be manually reviewed and approved before merging. No execution happens after curl and we have full control over the releases of the source repository.
- `scripts/turtles-dev.sh` and `scripts/turtles-quickstart.sh`: quick start scripts for engineers and users. Only for development purposes.
- `scripts/go-install`: this is only called from `Makefile` actions and always with a static pinned version, never `latest`.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
