### PR TITLE
bump go to 1.25.9

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/examples
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/agnivade/levenshtein v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles
 
-go 1.25.8
+go 1.25.9
 
 ignore (
 	./hack/tools/krew

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/test
 
-go 1.25.8
+go 1.25.9
 
 replace github.com/rancher/turtles => ../
 

--- a/tilt/project/Tiltfile
+++ b/tilt/project/Tiltfile
@@ -295,7 +295,7 @@ def get_port_forwards(debug):
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.25.8 as tilt-helper
+FROM golang:1.25.9 as tilt-helper
 # Support live reloading with Tilt
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/restart.sh  && \


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes:
- [CVE-2026-32280](https://github.com/advisories/GHSA-m4pr-4j3g-9v7v)
- [CVE-2026-32282](https://github.com/advisories/GHSA-xj38-jxc5-rppx)
- [CVE-2026-32281](https://github.com/advisories/GHSA-gjvh-7jh8-7xhm)
- [CVE-2026-32288](https://github.com/advisories/GHSA-x4jj-h2v8-hqqv)
- [CVE-2026-32289](https://github.com/advisories/GHSA-7mr4-xjxg-34g6)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
