### PR TITLE
fix: remove addon finalizer

### DIFF
--- a/internal/controllers/import_controller.go
+++ b/internal/controllers/import_controller.go
@@ -54,6 +54,8 @@ import (
 
 const (
 	missingLabelMsg = "missing label"
+	// FleetAddonFinalizer is the finalizer added by CAAPF to guard cleanup.
+	FleetAddonFinalizer = "fleet.addons.cluster.x-k8s.io"
 )
 
 // CAPIImportReconciler represents a reconciler for importing CAPI clusters in Rancher.
@@ -322,7 +324,7 @@ func (r *CAPIImportReconciler) reconcileNormal(ctx context.Context, capiCluster 
 	rancherCluster = cmp.Or(rancherCluster, updatedCluster)
 
 	r.optOutOfClusterOwner(ctx, rancherCluster)
-	r.reconcileExternalFleetManagement(ctx, rancherCluster)
+	r.reconcileExternalFleetManagement(ctx, rancherCluster, capiCluster)
 
 	addedFinalizer := controllerutil.AddFinalizer(rancherCluster, managementv3.CapiClusterFinalizer)
 	if addedFinalizer {
@@ -532,27 +534,43 @@ func (r *CAPIImportReconciler) optOutOfClusterOwner(ctx context.Context, rancher
 
 // reconcileExternalFleetManagement adds or removes the `provisioning.cattle.io/externally-managed` annotation
 // based on the feature gate `use-caapf`.
-func (r *CAPIImportReconciler) reconcileExternalFleetManagement(ctx context.Context, rancherCluster *managementv3.Cluster) {
-	log := log.FromContext(ctx)
-
+func (r *CAPIImportReconciler) reconcileExternalFleetManagement(ctx context.Context, rancherCluster *managementv3.Cluster,
+	capiCluster *clusterv1.Cluster,
+) {
 	annotations := rancherCluster.GetAnnotations()
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
 
 	if feature.Gates.Enabled(feature.UseCAAPF) {
-		if _, found := annotations[turtlesannotations.ExternalFleetAnnotation]; !found {
-			annotations[turtlesannotations.ExternalFleetAnnotation] = trueValue
-			rancherCluster.SetAnnotations(annotations)
+		addFleetAnnotation(ctx, annotations, rancherCluster)
 
-			log.Info("Added fleet annotation to Rancher cluster")
-		}
+		controllerutil.AddFinalizer(capiCluster, FleetAddonFinalizer)
 	} else {
-		if _, found := annotations[turtlesannotations.ExternalFleetAnnotation]; found {
-			delete(annotations, turtlesannotations.ExternalFleetAnnotation)
-			rancherCluster.SetAnnotations(annotations)
+		removeFleetAnnotation(ctx, annotations, rancherCluster)
 
-			log.Info("Removed fleet annotation from Rancher cluster")
-		}
+		controllerutil.RemoveFinalizer(capiCluster, FleetAddonFinalizer)
+	}
+}
+
+func addFleetAnnotation(ctx context.Context, annotations map[string]string, rancherCluster *managementv3.Cluster) {
+	log := log.FromContext(ctx)
+
+	if _, found := annotations[turtlesannotations.ExternalFleetAnnotation]; !found {
+		annotations[turtlesannotations.ExternalFleetAnnotation] = trueValue
+		rancherCluster.SetAnnotations(annotations)
+
+		log.Info("Added fleet annotation to Rancher cluster")
+	}
+}
+
+func removeFleetAnnotation(ctx context.Context, annotations map[string]string, rancherCluster *managementv3.Cluster) {
+	log := log.FromContext(ctx)
+
+	if _, found := annotations[turtlesannotations.ExternalFleetAnnotation]; found {
+		delete(annotations, turtlesannotations.ExternalFleetAnnotation)
+		rancherCluster.SetAnnotations(annotations)
+
+		log.Info("Removed fleet annotation from Rancher cluster")
 	}
 }

--- a/internal/controllers/import_controller.go
+++ b/internal/controllers/import_controller.go
@@ -544,8 +544,6 @@ func (r *CAPIImportReconciler) reconcileExternalFleetManagement(ctx context.Cont
 
 	if feature.Gates.Enabled(feature.UseCAAPF) {
 		addFleetAnnotation(ctx, annotations, rancherCluster)
-
-		controllerutil.AddFinalizer(capiCluster, FleetAddonFinalizer)
 	} else {
 		removeFleetAnnotation(ctx, annotations, rancherCluster)
 

--- a/test/e2e/specs/import_gitops.go
+++ b/test/e2e/specs/import_gitops.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"time"
 
@@ -102,7 +103,7 @@ type CreateUsingGitOpsSpecInput struct {
 	// VerifyETCDSize can be used to verify ETCD database size and for the supported environments,
 	// collect debug data.
 	VerifyETCDSize bool
-	
+
 	// RancherManagedFleet is used to determine whether the `provisioning.cattle.io/externally-managed`
 	// annotation should be present or not in an imported test cluster.
 	RancherManagedFleet bool
@@ -279,8 +280,25 @@ func CreateUsingGitOpsSpec(ctx context.Context, inputGetter func() CreateUsingGi
 			WaitRancherIntervals:    input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher"),
 			WaitKubeconfigIntervals: input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-kubeconfig"),
 			SkipLatestFeatureChecks: input.SkipLatestFeatureChecks,
-			RancherManagedFleet:           input.RancherManagedFleet,
+			RancherManagedFleet:     input.RancherManagedFleet,
 		})
+
+		// Validate that CAPI cluster does not have CAAPF finalizer, when CAAPF is disabled
+		if input.RancherManagedFleet {
+			By("CAPI cluster should not have the 'fleet.addons.cluster.x-k8s.io' finalizer")
+			Eventually(func() bool {
+				capiCluster := framework.GetClusterByName(
+					ctx,
+					framework.GetClusterByNameInput{
+						Getter:    input.BootstrapClusterProxy.GetClient(),
+						Name:      input.ClusterName,
+						Namespace: namespace.Name,
+					},
+				)
+
+				return slices.Contains(capiCluster.GetFinalizers(), "fleet.addons.cluster.x-k8s.io")
+			}, capiClusterCreateWait...).Should(BeFalse(), "Failed to detect that 'fleet.addons.cluster.x-k8s.io' finalizer was removed from CAPI cluster")
+		}
 
 		if !input.SkipClusterAvailableWait {
 			By("Waiting for the CAPI Cluster to be Available")


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR removes the finalizer that is added by CAAPF, when the feature gate `use-caapf` is set to false. By removing the finalizer, CAPI deletion should work as expected. The objects that CAAPF creates and are behind this finaliser (i.e. should be cleaned up) are:
- An annotation `field.cattle.io/allow-fleetworkspace-creation-for-existing-namespace` of the CAPI cluster namespace which is used to allow for existing namespaces to be created as Fleet Workspace objects.
- A BundleNamespaceMapping object which is used to map Fleet bundles to CAPI cluster namespaces ([ref](https://fleet.rancher.io/explanations/namespaces#_cross_namespace_deployments))

These 2 remaining objects will be cleaned up in a follow-up PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2303 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
