### PR TITLE
bump caprke2 to v0.24.3

### DIFF
--- a/charts/rancher-turtles-providers/values.yaml
+++ b/charts/rancher-turtles-providers/values.yaml
@@ -345,13 +345,13 @@ images:
     tag: v1.12.2
   bootstrapRKE2:
     repository: rancher/cluster-api-provider-rke2-bootstrap
-    tag: v0.24.2
+    tag: v0.24.3
   controlplaneKubeadm:
     repository: rancher/kubeadm-control-plane-controller
     tag: v1.12.2
   controlplaneRKE2:
     repository: rancher/cluster-api-provider-rke2-controlplane
-    tag: v0.24.2
+    tag: v0.24.3
   infrastructureAWS:
     repository: rancher/cluster-api-aws-controller
     tag: v2.10.1

--- a/internal/controllers/clusterctl/config-prime.yaml
+++ b/internal/controllers/clusterctl/config-prime.yaml
@@ -36,7 +36,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.12.2/bootstrap-components.yaml"
       type:         "BootstrapProvider"
     - name:         "rke2"
-      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.24.2/bootstrap-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.24.3/bootstrap-components.yaml"
       type:         "BootstrapProvider"
 
     # ControlPlane providers
@@ -44,7 +44,7 @@ data:
       url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.12.2/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
     - name:         "rke2"
-      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.24.2/control-plane-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.24.3/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
 
     # Addon providers

--- a/internal/controllers/clusterctl/config_test.go
+++ b/internal/controllers/clusterctl/config_test.go
@@ -69,7 +69,7 @@ data:
         url: https://github.com/rancher/cluster-api-provider-gcp/releases/v1.11.1/infrastructure-components.yaml
       - name: rke2
         type: ControlPlaneProvider
-        url: https://github.com/rancher/cluster-api-provider-rke2/releases/v0.24.2/control-plane-components.yaml
+        url: https://github.com/rancher/cluster-api-provider-rke2/releases/v0.24.3/control-plane-components.yaml
     images:
       image1:
         repository: repo1
@@ -98,7 +98,7 @@ data:
 							{
 								Name: "rke2",
 								Type: "BootstrapProvider",
-								URL:  "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.24.2/bootstrap-components.yaml",
+								URL:  "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.24.3/bootstrap-components.yaml",
 							},
 							{
 								Name: "fleet",
@@ -149,14 +149,14 @@ data:
 		Expect(configRepo.Providers).To(ContainElement(v1alpha1.Provider{
 			Name: "rke2",
 			Type: "ControlPlaneProvider",
-			URL:  "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.24.2/control-plane-components.yaml",
+			URL:  "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.24.3/control-plane-components.yaml",
 		}))
 
 		// Ensure a new rke2 bootstrap provider is added
 		Expect(configRepo.Providers).To(ContainElement(v1alpha1.Provider{
 			Name: "rke2",
 			Type: "BootstrapProvider",
-			URL:  "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.24.2/bootstrap-components.yaml",
+			URL:  "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.24.3/bootstrap-components.yaml",
 		}))
 
 		// Ensure a new fleet addon provider is added


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch release of CAPRKE2 bumps the Go version to 1.25.9 to fix multiple CVEs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
