### PR TITLE
Improve Image Pull Secret Support

### DIFF
--- a/charts/rancher-turtles-providers/templates/addon-fleet.yaml
+++ b/charts/rancher-turtles-providers/templates/addon-fleet.yaml
@@ -104,6 +104,13 @@ spec:
     name: {{ index .Values "providers" "addonFleet" "configSecret" "name" }}
     namespace: {{ index .Values "providers" "addonFleet" "configSecret" "namespace" }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+  deployment:
+    imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- if index .Values "providers" "addonFleet" "fetchConfig" }}
   fetchConfig:
     {{- if index .Values "providers" "addonFleet" "fetchConfig" "url" }}

--- a/charts/rancher-turtles-providers/templates/bootstrap-kubeadm.yaml
+++ b/charts/rancher-turtles-providers/templates/bootstrap-kubeadm.yaml
@@ -40,6 +40,13 @@ spec:
     name: {{ index .Values "providers" "bootstrapKubeadm" "configSecret" "name" }}
     namespace: {{ index .Values "providers" "bootstrapKubeadm" "configSecret" "namespace" }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+  deployment:
+    imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- if index .Values "providers" "bootstrapKubeadm" "fetchConfig" }}
   fetchConfig:
     {{- if index .Values "providers" "bootstrapKubeadm" "fetchConfig" "url" }}

--- a/charts/rancher-turtles-providers/templates/bootstrap-rke2.yaml
+++ b/charts/rancher-turtles-providers/templates/bootstrap-rke2.yaml
@@ -40,6 +40,13 @@ spec:
     name: {{ index .Values "providers" "bootstrapRKE2" "configSecret" "name" }}
     namespace: {{ index .Values "providers" "bootstrapRKE2" "configSecret" "namespace" }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+  deployment:
+    imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- if index .Values "providers" "bootstrapRKE2" "fetchConfig" }}
   fetchConfig:
     {{- if index .Values "providers" "bootstrapRKE2" "fetchConfig" "url" }}

--- a/charts/rancher-turtles-providers/templates/controlplane-kubeadm.yaml
+++ b/charts/rancher-turtles-providers/templates/controlplane-kubeadm.yaml
@@ -40,6 +40,13 @@ spec:
     name: {{ index .Values "providers" "controlplaneKubeadm" "configSecret" "name" }}
     namespace: {{ index .Values "providers" "controlplaneKubeadm" "configSecret" "namespace" }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+  deployment:
+    imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- if index .Values "providers" "controlplaneKubeadm" "fetchConfig" }}
   fetchConfig:
     {{- if index .Values "providers" "controlplaneKubeadm" "fetchConfig" "url" }}

--- a/charts/rancher-turtles-providers/templates/controlplane-rke2.yaml
+++ b/charts/rancher-turtles-providers/templates/controlplane-rke2.yaml
@@ -40,6 +40,13 @@ spec:
     name: {{ index .Values "providers" "controlplaneRKE2" "configSecret" "name" }}
     namespace: {{ index .Values "providers" "controlplaneRKE2" "configSecret" "namespace" }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+  deployment:
+    imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- if index .Values "providers" "controlplaneRKE2" "fetchConfig" }}
   fetchConfig:
     {{- if index .Values "providers" "controlplaneRKE2" "fetchConfig" "url" }}

--- a/charts/rancher-turtles-providers/templates/infrastructure-aws.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-aws.yaml
@@ -48,6 +48,13 @@ spec:
     name: {{ index .Values "providers" "infrastructureAWS" "configSecret" "name" }}
     namespace: {{ index .Values "providers" "infrastructureAWS" "configSecret" "namespace" }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+  deployment:
+    imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- if index .Values "providers" "infrastructureAWS" "fetchConfig" }}
   fetchConfig:
     {{- if index .Values "providers" "infrastructureAWS" "fetchConfig" "url" }}

--- a/charts/rancher-turtles-providers/templates/infrastructure-azure.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-azure.yaml
@@ -48,6 +48,13 @@ spec:
     name: {{ index .Values "providers" "infrastructureAzure" "configSecret" "name" }}
     namespace: {{ index .Values "providers" "infrastructureAzure" "configSecret" "namespace" }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+  deployment:
+    imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- if index .Values "providers" "infrastructureAzure" "fetchConfig" }}
   fetchConfig:
     {{- if index .Values "providers" "infrastructureAzure" "fetchConfig" "url" }}

--- a/charts/rancher-turtles-providers/templates/infrastructure-docker.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-docker.yaml
@@ -40,6 +40,13 @@ spec:
     name: {{ index .Values "providers" "infrastructureDocker" "configSecret" "name" }}
     namespace: {{ index .Values "providers" "infrastructureDocker" "configSecret" "namespace" }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+  deployment:
+    imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- if index .Values "providers" "infrastructureDocker" "fetchConfig" }}
   fetchConfig:
     {{- if index .Values "providers" "infrastructureDocker" "fetchConfig" "url" }}

--- a/charts/rancher-turtles-providers/templates/infrastructure-gcp.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-gcp.yaml
@@ -48,6 +48,13 @@ spec:
     name: {{ index .Values "providers" "infrastructureGCP" "configSecret" "name" }}
     namespace: {{ index .Values "providers" "infrastructureGCP" "configSecret" "namespace" }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+  deployment:
+    imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- if index .Values "providers" "infrastructureGCP" "fetchConfig" }}
   fetchConfig:
     {{- if index .Values "providers" "infrastructureGCP" "fetchConfig" "url" }}

--- a/charts/rancher-turtles-providers/templates/infrastructure-vsphere.yaml
+++ b/charts/rancher-turtles-providers/templates/infrastructure-vsphere.yaml
@@ -48,6 +48,13 @@ spec:
     name: {{ index .Values "providers" "infrastructureVSphere" "configSecret" "name" }}
     namespace: {{ index .Values "providers" "infrastructureVSphere" "configSecret" "namespace" }}
 {{- end }}
+{{- if .Values.imagePullSecrets }}
+  deployment:
+    imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- if index .Values "providers" "infrastructureVSphere" "fetchConfig" }}
   fetchConfig:
     {{- if index .Values "providers" "infrastructureVSphere" "fetchConfig" "url" }}

--- a/charts/rancher-turtles-providers/values.schema.json
+++ b/charts/rancher-turtles-providers/values.schema.json
@@ -137,6 +137,13 @@
   },
   "type": "object",
   "properties": {
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "Secret names to use when pulling images for provider deployments.",
+      "items": {
+        "type": "string"
+      }
+    },
     "providers": {
       "type": "object",
       "description": "Providers configuration.",

--- a/charts/rancher-turtles-providers/values.yaml
+++ b/charts/rancher-turtles-providers/values.yaml
@@ -2,6 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# imagePullSecrets: Secret names to use when pulling images for provider deployments.
+imagePullSecrets: []
+# imagePullSecrets:
+#   - secret1
+
 # providers: Providers configuration.
 providers:
   # addonFleet: Cluster API Add-on Provider for Fleet (CAAPF).

--- a/charts/rancher-turtles/templates/clusterctl-cm-cleanup-job.yaml
+++ b/charts/rancher-turtles/templates/clusterctl-cm-cleanup-job.yaml
@@ -51,6 +51,12 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: pre-upgrade-job
       containers:
       - name: rancher-clusterctl-configmap-cleanup

--- a/charts/rancher-turtles/templates/core-provider.yaml
+++ b/charts/rancher-turtles/templates/core-provider.yaml
@@ -35,11 +35,19 @@ spec:
     {{- else if index .Values "cluster-api-operator" "cluster-api" "core" "fetchConfig" "selector" }}
     selector: {{ index .Values "cluster-api-operator" "cluster-api" "core" "fetchConfig" "selector" | toYaml | nindent 6 }}
     {{- end }}
-{{- if index .Values "cluster-api-operator" "cluster-api" "core" "imageUrl" }}
+{{- if or (index .Values "cluster-api-operator" "cluster-api" "core" "imageUrl") .Values.imagePullSecrets }}
   deployment:
+{{- if .Values.imagePullSecrets }}
+    imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- if index .Values "cluster-api-operator" "cluster-api" "core" "imageUrl" }}
     containers:
       - name: manager
         imageUrl: {{ index .Values "cluster-api-operator" "cluster-api" "core" "imageUrl" }}
+{{- end }}
 {{- end }}
 ---
 apiVersion: v1

--- a/charts/rancher-turtles/templates/deployment.yaml
+++ b/charts/rancher-turtles/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       imagePullSecrets:
       {{- range .Values.imagePullSecrets }}
         - name: {{ . }}
-      {{- end }}  
+      {{- end }}
       {{- end }}
       containers:
       - args:

--- a/charts/rancher-turtles/templates/post-delete-job.yaml
+++ b/charts/rancher-turtles/templates/post-delete-job.yaml
@@ -66,6 +66,12 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: post-delete-job
       containers:
       - name: cluster-api-operator-mutatingwebhook-cleanup
@@ -99,6 +105,12 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: post-delete-job
       containers:
       - name: cluster-api-operator-validatingwebhook-cleanup
@@ -132,6 +144,12 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: post-delete-job
       restartPolicy: Never
       containers:
@@ -166,6 +184,12 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: post-delete-job
       restartPolicy: Never
       containers:

--- a/charts/rancher-turtles/templates/pre-delete-job.yaml
+++ b/charts/rancher-turtles/templates/pre-delete-job.yaml
@@ -55,6 +55,12 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: pre-delete-job
       containers:
       - name: rancher-capiprovider-cleanup
@@ -91,6 +97,12 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: pre-delete-job
       containers:
       - name: rancher-clusterctlconfig-cleanup


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the turtles chart to use the existing `imagePullSecrets` value in `values.yaml` throughout all of the workloads deployed by the chart. It also updates `core-provider.yaml` to pass the configured image pull secrets to the core CAPI provider deployed by turtles. 

This approach works as the turtles CAPIProvider embeds the [upstream ProviderSpec](https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/api/v1alpha2/provider_types.go#L41), which in turn [supports image pull secrets](https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/api/v1alpha2/provider_types.go#L235). This ensures that turtles can be automatically deployed onto a Rancher instance which only has access to an authenticated private registry. 


I was able to test these changes against a local development build of Rancher and confirmed that both turtles and the core CAPI controllers pulled their images successfully. If there are other areas of turtles that also need to be updated with these pull secrets, let me know. 

Relates to: https://github.com/rancher/rancher/issues/54806

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
