### PR TITLE
fix: call build-chart target to avoid invoking notes tool

### DIFF
--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -40,7 +40,7 @@ jobs:
         run: make docker-build-prime
 
       - name: Package operator chart
-        run: make release-chart
+        run: make build-chart
 
       - name: Run chart-testing (lint)
         run: make test-chart
@@ -154,7 +154,7 @@ jobs:
         run: make docker-build-community TAG=${{ env.TAG }}
 
       - name: Package operator chart
-        run: make release-chart
+        run: make build-chart
 
       - name: Install kind
         run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a hotfix for the failing test chart action.

```
notes --repository rancher/turtles -add-kubernetes-version-support=false -from=tags/v0.26.0-rc.0 -release=v0.0.1 -branch=release/v0.26 > out/charts/rancher-turtles/RELEASE_NOTES.md
2026/04/29 07:04:03 Computing diff between tags/v0.26.0-rc.0 and heads/release/v0.26
2026/04/29 07:04:03 Calling endpoint repos/rancher/turtles/compare/v0.26.0-rc.0...release/v0.26?per_page=250&page=1&
2026/04/29 07:04:04 Total of 1 pages and 99 elements read
2026/04/29 07:04:04 Reading ref heads/release/v0.26 for upper limit
2026/04/29 07:04:05 Reading commit a0f39062bd01d56c09933e2a1bd19dc532299cdf for upper limit
2026/04/29 07:04:05 Listing PRs from 2026-02-04 13:35:40 +0000 UTC to 2026-04-24 11:25:16 +0000 UTC
2026/04/29 07:04:05 Calling endpoint search/issues?per_page=100&page=1&q=repo:rancher/turtles+is:pr+is:merged+merged:2026-02-04T13:35:40Z..2026-04-24T11:25:16Z+base:release/v0.26+base:main
2026/04/29 07:04:07 Calling endpoint search/issues?per_page=100&page=2&q=repo:rancher/turtles+is:pr+is:merged+merged:2026-02-04T13:35:40Z..2026-04-24T11:25:16Z+base:release/v0.26+base:main
2026/04/29 07:04:08 Total of 2 pages and 145 elements read
2026/04/29 07:04:08 Found 145 PRs in github
2026/04/29 07:04:08 45 PRs match the commits from the git diff
2026/04/29 07:04:08 expected 47 PRs from commit list but only found 45
```

By calling `build-chart` we simply avoid calling notes.
This is not a long term solution, just a way to suppress the failure.

For the proper solution see: https://github.com/rancher/turtles/issues/2244

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
