### PR TITLE
feat: use publish image action in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,12 +32,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-      with:
-        image: tonistiigi/binfmt:qemu-v8.1.5
-        cache-image: false
-
     - name: Read Vault secrets
       uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6
       with:
@@ -47,37 +41,33 @@ jobs:
           secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials registry | STAGE_REGISTRY ;
           secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials username | STAGE_REGISTRY_USERNAME ;
           secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials password | STAGE_REGISTRY_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
 
-    - name: Log into Docker Hub registry
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+    - name: Push community image to DockerHub
+      uses: rancher/ecm-distro-tools/actions/publish-image@5d6e63896fea85836b2fca6dfb9236bcefe2aaa5
       with:
-        username: ${{ env.DOCKER_USERNAME }}
-        password: ${{ env.DOCKER_PASSWORD }}
+        image: turtles
+        tag: ${{ env.TAG }}-${{ matrix.tag-suffix }}
+        platforms: ${{ matrix.platform }}
+        push-to-prime: false
+        public-repo: rancher
+        public-username: ${{ env.DOCKER_USERNAME }}
+        public-password: ${{ env.DOCKER_PASSWORD }}
+        make-target: push-image
 
-    - name: Log into Staging registry
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+    - name: Push prime image to staging registry
+      uses: rancher/ecm-distro-tools/actions/publish-image@5d6e63896fea85836b2fca6dfb9236bcefe2aaa5
       with:
-        username: ${{ env.STAGE_REGISTRY_USERNAME }}
-        password: ${{ env.STAGE_REGISTRY_PASSWORD }}
-        registry: ${{ env.STAGE_REGISTRY }}
-
-    - name: Build and push community image
-      shell: bash
-      env:
-        REGISTRY: docker.io
-        ORG: rancher
-      run: |
-        IID_FILE=$(mktemp)
-        make docker-build-and-push-community TAG=${{ env.TAG }}-${{ matrix.tag-suffix }} REGISTRY=${{ env.REGISTRY }} ORG=${{ env.ORG }} IID_FILE=${IID_FILE} TARGET_PLATFORMS=${{ matrix.platform }}
-
-    - name: Build and push prime image
-      shell: bash
-      env:
-        REGISTRY: ${{ env.STAGE_REGISTRY }}
-        ORG: rancher
-      run: |
-        IID_FILE=$(mktemp)
-        make docker-build-and-push-prime TAG=${{ env.TAG }}-${{ matrix.tag-suffix }} REGISTRY=${{ env.REGISTRY }} ORG=${{ env.ORG }} IID_FILE=${IID_FILE} TARGET_PLATFORMS=${{ matrix.platform }}
+        image: turtles
+        tag: ${{ env.TAG }}-${{ matrix.tag-suffix }}
+        platforms: ${{ matrix.platform }}
+        push-to-public: false
+        prime-repo: rancher
+        identity-registry: ${{ env.PRIME_REGISTRY }}
+        prime-registry: ${{ env.STAGE_REGISTRY }}
+        prime-username: ${{ env.STAGE_REGISTRY_USERNAME }}
+        prime-password: ${{ env.STAGE_REGISTRY_PASSWORD }}
+        prime-make-target: push-prime-image
 
   merge:
     runs-on: ubuntu-latest
@@ -117,14 +107,6 @@ jobs:
         password: ${{ env.STAGE_REGISTRY_PASSWORD }}
         registry: ${{ env.STAGE_REGISTRY }}
 
-    - name: Install Cosign
-      if: ${{ matrix.image-type == 'prime' }}
-      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-    - name: Install slsactl
-      if: ${{ matrix.image-type == 'prime' }}
-      uses: rancherlabs/slsactl/actions/install-slsactl@d70524abe2bec09b488ab946abcb4bef9c1331bf # v0.1.31
-
     - name: Create multi-platform image and push
       shell: bash
       run: |
@@ -154,6 +136,14 @@ jobs:
           echo "MULTI_PLATFORM_IMAGE_TAG"=${MULTI_PLATFORM_IMAGE_TAG} >> "$GITHUB_ENV"
         fi
 
+    - name: Install Cosign
+      if: ${{ matrix.image-type == 'prime' }}
+      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+    - name: Install slsactl
+      if: ${{ matrix.image-type == 'prime' }}
+      uses: rancherlabs/slsactl/actions/install-slsactl@d70524abe2bec09b488ab946abcb4bef9c1331bf # v0.1.31
+
     - name: Sign multi-platform image
       shell: bash
       if: ${{ matrix.image-type == 'prime' }}
@@ -161,7 +151,7 @@ jobs:
         cosign sign \
           --oidc-provider=github-actions \
           --yes \
-          --sign-container-identity="${{ env.PRIME_REGISTRY }}/rancher/${IMAGE}" \
+          --sign-container-identity="${{ env.PRIME_REGISTRY }}/rancher/turtles" \
           "${MULTI_PLATFORM_IMAGE}"
 
     - name: Attest provenance

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,11 +44,12 @@ jobs:
           secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
 
     - name: Push community image to DockerHub
-      uses: rancher/ecm-distro-tools/actions/publish-image@5d6e63896fea85836b2fca6dfb9236bcefe2aaa5
+      uses: rancher/ecm-distro-tools/actions/publish-image@067de5ae5517b661b4d2f10e22cc5a21aa0ac915
       with:
         image: turtles
         tag: ${{ env.TAG }}-${{ matrix.tag-suffix }}
         platforms: ${{ matrix.platform }}
+        push-to-public: true
         push-to-prime: false
         public-repo: rancher
         public-username: ${{ env.DOCKER_USERNAME }}
@@ -56,12 +57,13 @@ jobs:
         make-target: push-image
 
     - name: Push prime image to staging registry
-      uses: rancher/ecm-distro-tools/actions/publish-image@5d6e63896fea85836b2fca6dfb9236bcefe2aaa5
+      uses: rancher/ecm-distro-tools/actions/publish-image@067de5ae5517b661b4d2f10e22cc5a21aa0ac915
       with:
         image: turtles
         tag: ${{ env.TAG }}-${{ matrix.tag-suffix }}
         platforms: ${{ matrix.platform }}
         push-to-public: false
+        push-to-prime: true
         prime-repo: rancher
         identity-registry: ${{ env.PRIME_REGISTRY }}
         prime-registry: ${{ env.STAGE_REGISTRY }}

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ CHART_TESTING_VER := v3.14.0
 TAG ?= dev
 ARCH ?= linux/$(shell go env GOARCH)
 TARGET_BUILD ?= prime
-TARGET_PLATFORMS := linux/amd64,linux/arm64
+TARGET_PLATFORMS ?= linux/amd64,linux/arm64
 MACHINE := rancher-turtles
 REGISTRY ?= ghcr.io
 ORG ?= rancher
@@ -389,16 +389,30 @@ docker-build-and-push: buildx-machine docker-pull-prerequisites ## Run docker-bu
 			--build-arg go_build_tags=$(TARGET_BUILD) \
 			--build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG):$(TAG)
 
-.PHONY: docker-build-and-push-prime
-docker-build-and-push-prime:
-	$(MAKE) docker-build-and-push TARGET_BUILD=prime
-
-.PHONY: docker-build-and-push-community
-docker-build-and-push-community:
-	$(MAKE) docker-build-and-push TARGET_BUILD=community
-
 docker-list-all:
 	@echo $(CONTROLLER_IMG):${TAG}
+
+# The following targets are called by the publish-image action in the release workflow.
+# See .github/workflows/release.yml for details.
+# The docker-build-and-push* targets above were used by the old release workflow.
+.PHONY: push-image
+push-image: docker-pull-prerequisites ## Build and push community image (called by publish-image action)
+	DOCKER_BUILDKIT=1 docker buildx build \
+		$(IID_FILE_FLAG) \
+		$(BUILDX_ARGS) \
+		--platform=$(TARGET_PLATFORMS) \
+		--push \
+		--build-arg builder_image=$(GO_CONTAINER_IMAGE) \
+		--build-arg goproxy=$(GOPROXY) \
+		--build-arg package=. \
+		--build-arg go_build_tags=community \
+		--build-arg ldflags="$(LDFLAGS)" . -t $(REPO)/$(CONTROLLER_IMAGE_NAME):$(TAG)
+
+.PHONY: push-prime-image
+push-prime-image: ## Build and push prime image with SBOM and provenance (called by publish-image action)
+	BUILDX_ARGS="--sbom=true --attest type=provenance,mode=max" \
+	$(MAKE) push-image TARGET_BUILD=prime
+
 
 ##@ Deployment
 

--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,7 @@ docker-build-community: ## Build docker image with community tag
 	$(MAKE) docker-build TARGET_BUILD=community
 
 .PHONY: docker-build-and-push
-docker-build-and-push: buildx-machine docker-pull-prerequisites ## Run docker-build-and-push targets for all architectures
+docker-build-and-push: buildx-machine docker-pull-prerequisites ## Build and push multi-arch image for all platforms
 	DOCKER_BUILDKIT=1 BUILDX_BUILDER=$(MACHINE) docker buildx build $(ADDITIONAL_COMMANDS) \
 			--platform $(TARGET_PLATFORMS) \
 			--push \
@@ -394,7 +394,6 @@ docker-list-all:
 
 # The following targets are called by the publish-image action in the release workflow.
 # See .github/workflows/release.yml for details.
-# The docker-build-and-push* targets above were used by the old release workflow.
 .PHONY: push-image
 push-image: docker-pull-prerequisites ## Build and push community image (called by publish-image action)
 	DOCKER_BUILDKIT=1 docker buildx build \


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces the manual Docker login + docker buildx build steps in the release job with [rancher/ecm-distro-tools/actions/publish-image](https://github.com/rancher/ecm-distro-tools/tree/master/actions/publish-image) - the standard action used across Rancher projects for publishing community and prime images. The main goal of this PR is to introduce as minimal changes as possible to the existing workflow structure while introducing a new action and keeping the resulting artifacts identical.

Things that got changed:
- replaced QEMU setup, registry logins, and inline docker buildx build steps with two publish-image action calls (community + prime)
- moved Cosign/slsactl installation to after imagetools creation, and  fixing a bug where signing ran per-arch before instead of on the final multi-arch manifest now
- added `PRIME_REGISTRY` vault secret to the release job (required by publish-image for --sign-container-identity when signing per-arch prime images)
- replaced `docker-build-and-push-*` targets with new `push-image` / `push-prime-image` called by the action;
- changed `TARGET_PLATFORMS :=` to `?=` in Makefile so the action can pass per-arch platform values via environment.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Since this is a release workflow it is challenging to test it properly, however, this is what I could do:
- All code tested in my personal fork, where I have 2 commits: 1st is the main changes (what we have in this PR) and the second is what I had to rework to make it run successfully in my fork (not included in this PR): https://github.com/rancher/turtles/compare/main...furkatgofurov7:turtles:main
- verified that the full workflow [run](https://github.com/furkatgofurov7/turtles/actions/runs/25367574900) and [fake release](https://github.com/furkatgofurov7/turtles/releases/tag/v0.99.5-test.) was created fine 
- verified that Multi-arch manifest structure matches lastest release artifacts `rancher/turtles:v0.26.1` (linux/amd64 + linux/arm64 + attestations)
- verified Cosign signature and SLSA provenance attestation on the multi-arch manifest

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


Takes inspiration from: https://github.com/rancher/turtles/pull/2300

