### PR TITLE
core provider is now under rancher/ org

### DIFF
--- a/.github/workflows/fetch-core-capi-airgapped.yml
+++ b/.github/workflows/fetch-core-capi-airgapped.yml
@@ -7,7 +7,6 @@ on:
         description: CAPI Core version (ex. 'v1.2.3' or empty for latest)
         required: false
 
-
 env:
   TURTLES_REF: "${{ github.ref_name }}"
   GH_TOKEN: "${{ github.token }}"
@@ -36,7 +35,7 @@ jobs:
           CAPI_MANIFEST_UPDATE_VERSION=${{ inputs.capi_version }}
           if [ -z "${CAPI_MANIFEST_UPDATE_VERSION}" ]; then
             echo "Fetching latest CAPI Core version"
-            CAPI_MANIFEST_UPDATE_VERSION=$(curl -s "https://api.github.com/repos/rancher-sandbox/cluster-api/releases/latest" | jq -r ".tag_name")
+            CAPI_MANIFEST_UPDATE_VERSION=$(curl -s "https://api.github.com/repos/rancher/cluster-api/releases/latest" | jq -r ".tag_name")
             echo "Found version ${CAPI_MANIFEST_UPDATE_VERSION}"
           fi
           echo "CAPI_MANIFEST_UPDATE_VERSION=${CAPI_MANIFEST_UPDATE_VERSION}" >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ REPO ?= rancher/turtles
 
 CAPI_UPSTREAM_REPO ?= https://github.com/kubernetes-sigs/cluster-api
 CAPI_UPSTREAM_RELEASES ?= $(CAPI_UPSTREAM_REPO)/releases
-CAPI_MANIFEST_UPDATE_VERSION ?= $(shell curl -s "https://api.github.com/repos/rancher-sandbox/cluster-api/releases/latest" | jq -r ".tag_name")
+CAPI_MANIFEST_UPDATE_VERSION ?= $(shell curl -s "https://api.github.com/repos/rancher/cluster-api/releases/latest" | jq -r ".tag_name")
 CAPI_MANIFEST_OUTPUT_FILE ?= $(CHART_DIR)/templates/core-provider-configmap.yaml
 
 # Use GOPROXY environment variable if set

--- a/hack/fetch-core-capi.sh
+++ b/hack/fetch-core-capi.sh
@@ -2,7 +2,7 @@
 
 # script-specific variables
 CAPI_VERSION="${CAPI_VERSION:-latest}"
-CAPI_RELEASE_URL="${CAPI_RELEASE_URL:-https://github.com/rancher-sandbox/cluster-api/releases/${CAPI_VERSION}/core-components.yaml}"
+CAPI_RELEASE_URL="${CAPI_RELEASE_URL:-https://github.com/rancher/cluster-api/releases/${CAPI_VERSION}/core-components.yaml}"
 CORE_CAPI_NAMESPACE="${CORE_CAPI_NAMESPACE:-cattle-capi-system}"
 OUTPUT_FILE="${OUTPUT_FILE:-/tmp/core-provider-configmap.yaml}"
 ARTIFACTS_FOLDER="${ARTIFACTS_FOLDER:-_artifacts}"

--- a/internal/controllers/clusterctl/config-prime.yaml
+++ b/internal/controllers/clusterctl/config-prime.yaml
@@ -11,7 +11,7 @@ data:
     providers:
     # Cluster API core provider
     - name:         "cluster-api"
-      url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.12.2/core-components.yaml"
+      url:          "https://github.com/rancher/cluster-api/releases/v1.12.2/core-components.yaml"
       type:         "CoreProvider"
 
     # Infrastructure providers
@@ -33,7 +33,7 @@ data:
 
     # Bootstrap providers
     - name:         "kubeadm"
-      url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.12.2/bootstrap-components.yaml"
+      url:          "https://github.com/rancher/cluster-api/releases/v1.12.2/bootstrap-components.yaml"
       type:         "BootstrapProvider"
     - name:         "rke2"
       url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.24.3/bootstrap-components.yaml"
@@ -41,7 +41,7 @@ data:
 
     # ControlPlane providers
     - name:         "kubeadm"
-      url:          "https://github.com/rancher-sandbox/cluster-api/releases/v1.12.2/control-plane-components.yaml"
+      url:          "https://github.com/rancher/cluster-api/releases/v1.12.2/control-plane-components.yaml"
       type:         "ControlPlaneProvider"
     - name:         "rke2"
       url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/v0.24.3/control-plane-components.yaml"

--- a/internal/controllers/clusterctl/config_test.go
+++ b/internal/controllers/clusterctl/config_test.go
@@ -63,7 +63,7 @@ data:
     providers:
       - name: core
         type: CoreProvider
-        url: https://github.com/rancher-sandbox/cluster-api/releases/v1.12.2/core-components.yaml
+        url: https://github.com/rancher/cluster-api/releases/v1.12.2/core-components.yaml
       - name: gcp
         type: InfrastructureProvider
         url: https://github.com/rancher/cluster-api-provider-gcp/releases/v1.11.1/infrastructure-components.yaml
@@ -135,7 +135,7 @@ data:
 		Expect(configRepo.Providers).To(ContainElement(v1alpha1.Provider{
 			Name: "core",
 			Type: "CoreProvider",
-			URL:  "https://github.com/rancher-sandbox/cluster-api/releases/v1.12.2/core-components.yaml",
+			URL:  "https://github.com/rancher/cluster-api/releases/v1.12.2/core-components.yaml",
 		}))
 
 		// Ensure gcp infrastructure provider is updated

--- a/updatecli/updatecli.d/capiproviders.yaml
+++ b/updatecli/updatecli.d/capiproviders.yaml
@@ -94,8 +94,8 @@ targets:
     kind: file
     spec:
       file: ./internal/controllers/clusterctl/config-prime.yaml
-      matchpattern: "https://github.com/rancher-sandbox/cluster-api/releases/(.*)/"
-      replacepattern: 'https://github.com/rancher-sandbox/cluster-api/releases/{{ source "capirelease" }}/'
+      matchpattern: "https://github.com/rancher/cluster-api/releases/(.*)/"
+      replacepattern: 'https://github.com/rancher/cluster-api/releases/{{ source "capirelease" }}/'
     scmid: turtles
     sourceid: capirelease # Will be ignored as `replacepattern` is specified
   bumpcapicommunity:


### PR DESCRIPTION
**What this PR does / why we need it**:

The downstream core provider repository is now under the `rancher/` organization. This PR changes references to point to the correct path.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
