### PR TITLE
bump capa to v2.11.1

### DIFF
--- a/charts/rancher-turtles-providers/values.yaml
+++ b/charts/rancher-turtles-providers/values.yaml
@@ -359,7 +359,7 @@ images:
     tag: v0.24.3
   infrastructureAWS:
     repository: rancher/cluster-api-aws-controller
-    tag: v2.10.1
+    tag: v2.11.1
   infrastructureAzure:
     repository: rancher/cluster-api-azure-controller
     tag: v1.22.0

--- a/internal/controllers/clusterctl/config-prime.yaml
+++ b/internal/controllers/clusterctl/config-prime.yaml
@@ -16,7 +16,7 @@ data:
 
     # Infrastructure providers
     - name:         "aws"
-      url:          "https://github.com/rancher/cluster-api-provider-aws/releases/v2.10.1/infrastructure-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-aws/releases/v2.11.1/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "azure"
       url:          "https://github.com/rancher/cluster-api-provider-azure/releases/v1.22.0/infrastructure-components.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump CAPA to latest version v2.11.1.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

A follow up to this will update the Kubernetes version used for testing AWS cluster provisioning with Kubernetes version >v1.32.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
