### PR TITLE
fix: use go generate for release against Rancher

### DIFF
--- a/.github/scripts/release-against-rancher.sh
+++ b/.github/scripts/release-against-rancher.sh
@@ -132,12 +132,7 @@ fi
 
 yq --inplace ".turtlesVersion = \"${NEW_CHART_VERSION}+up${NEW_TURTLES_VERSION_SHORT}\"" ./build.yaml
 
-# Downloads dapper
-make .dapper
-
-# DAPPER_MODE=bind will make sure we output everything that changed
-DAPPER_MODE=bind ./.dapper go generate ./... || true
-DAPPER_MODE=bind ./.dapper rm -rf go .config
+go generate ./...
 
 git add .
 git commit -m "$COMMIT_MSG"


### PR DESCRIPTION
**What this PR does / why we need it**:

We used to need dapper to be able to run `go generate ./...` in the release action of rancher/rancher. This was to make sure we install the same dependencies (`controller-gen`) as the one used for r/r. Now we can just run `go generate ./...` and go tools will install the tool at the appropriate version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #2353 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
