### PR TITLE
test: provision v1.35 eks clusters

### DIFF
--- a/examples/clusterclasses/aws/eks/clusterclass-eks-example.yaml
+++ b/examples/clusterclasses/aws/eks/clusterclass-eks-example.yaml
@@ -20,7 +20,7 @@ spec:
           templateRef:
             name: "eks-md-0"
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
-            kind: EKSConfigTemplate
+            kind: NodeadmConfigTemplate
         infrastructure:
           templateRef:
             name: "eks-md-0"
@@ -40,6 +40,12 @@ spec:
           description: "AWS SSH key name to use"
           type: string
           default: ""
+    - name: eksLookupType
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: "AmazonLinux2023"
     - name: instanceType
       required: false
       schema:
@@ -102,6 +108,10 @@ spec:
                   - default-worker
           jsonPatches:
             - op: add
+              path: /spec/template/spec/ami/eksLookupType
+              valueFrom:
+                variable: eksLookupType
+            - op: add
               path: /spec/template/spec/sshKeyName
               valueFrom:
                 variable: sshKeyName
@@ -138,11 +148,15 @@ metadata:
 spec:
   template:
     spec:
+      ami:
+        eksLookupType: "AmazonLinux2023"
+      cloudInit:
+        insecureSkipSecretsManager: true
       instanceType: "replaced_by_patch"
       iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
-kind: EKSConfigTemplate
+kind: NodeadmConfigTemplate
 metadata:
   name: "eks-md-0"
 spec:

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -81,8 +81,8 @@ variables:
   # EKS also needs versioned images, that may not be available for recent versions of k8s.
   # To verify availability, you can run: aws ssm get-parameter --name /aws/service/eks/optimized-ami/1.34/amazon-linux-2023/x86_64/standard/recommended/image_id
   # Recent versions will return a 'ParameterNotFound' error, preventing EKS from deploying.
-  # NOTE: EKS does not support versions >v1.32 because there's a bug when using Amazon Linux 2023, see https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5700
-  AWS_EKS_KUBERNETES_VERSION: "v1.32.0" #See: https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/docs/proposal/20250922-nodeadm-bootstrap.md
+  # NOTE: EKS only supports versions >v1.32 when using `NodeadmConfig` and `AmazonLinux2023`
+  AWS_EKS_KUBERNETES_VERSION: "v1.35.0"
   AWS_REGION: "eu-west-2"
   KUBERNETES_MANAGEMENT_AWS_REGION: "eu-west-2"
   AWS_CONTROL_PLANE_MACHINE_TYPE: "t3.large"


### PR DESCRIPTION

kind/providers
kind/test

**What this PR does / why we need it**:

After bumping CAPA, `NodeadmConfigTemplate` supports provisioning EKS clusters >1.32.

`insecureSkipSecretsManager` needs to be enabled, as stated in the [CAPA book](https://cluster-api-aws.sigs.k8s.io/topics/eks/creating-a-cluster.html?highlight=nodeadmconfig#secrets-manager):

> Amazon Linux 2023 does not have the proper tooling to use the secrets manager flow for bootstrapping. CAPA uses a custom cloud-init datasource to fetch the secure contents like the kubeadm tokens from secrets manager. Crucially, there is no current support for publishing CAPA-compatible AL2023 AMIs that include this necessary custom cloud-init datasource.
>
> Therefore, whenever creating AWSMachineTemplate objects insecureSkipSecretsManager must be set to true.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2247

**Special notes for your reviewer**:

- Full E2E run: https://github.com/rancher/turtles/actions/runs/25494635927

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
