### PR TITLE
remove last reference to rancher-sandbox

### DIFF
--- a/updatecli/updatecli.d/capiproviders.yaml
+++ b/updatecli/updatecli.d/capiproviders.yaml
@@ -20,7 +20,7 @@ sources:
     kind: githubrelease
     name: Get the latest core CAPI release
     spec:
-      owner: "rancher-sandbox"
+      owner: "rancher"
       repository: "cluster-api"
       token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'


### PR DESCRIPTION
**What this PR does / why we need it**:

This removes the final reference to the `rancher-sandbox` organization that was left behind in the previous PR.

**Which issue(s) this PR fixes**:
Fixes #2297

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
