### PR TITLE
bump go to 1.25.10

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/examples
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/agnivade/levenshtein v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles
 
-go 1.25.9
+go 1.25.10
 
 ignore (
 	./hack/tools/krew

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/test
 
-go 1.25.9
+go 1.25.10
 
 replace github.com/rancher/turtles => ../
 

--- a/tilt/project/Tiltfile
+++ b/tilt/project/Tiltfile
@@ -295,7 +295,7 @@ def get_port_forwards(debug):
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.25.9 as tilt-helper
+FROM golang:1.25.10 as tilt-helper
 # Support live reloading with Tilt
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/restart.sh  && \


### PR DESCRIPTION
**What this PR does / why we need it**:

Go 1.25.10 fixes a series of security issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Should be back-ported to release branch.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
