### PR TITLE
chore: use GKE version 1.35.3

### DIFF
--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -94,7 +94,7 @@ variables:
   # GCP Configuration
   # Images are self-built and need versioned kubernetes components. See docs/image-builder
   GCP_KUBERNETES_VERSION: "v1.34.1"
-  GCP_GKE_KUBERNETES_VERSION: "v1.35.1"
+  GCP_GKE_KUBERNETES_VERSION: "v1.35.3"
   GCP_MACHINE_TYPE: "n1-standard-2"
   GCP_REGION: "europe-west2"
   GCP_IMAGE_ID: "cluster-api-ubuntu-2404-v1-34-1-1762253907" # Private image. See docs/image-builder


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Should fix e2e failures where GKE fails with:

```txt
2026-05-18T01:43:06.083637276Z E0518 01:43:06.083529       1 reconcile.go:354] "Error creating GKE cluster" err=<
2026-05-18T01:43:06.083664517Z 	rpc error: code = InvalidArgument desc = No valid versions with the prefix "1.35.1" found.
2026-05-18T01:43:06.083668010Z 	error details: name = RequestInfo id = 0xcb014f25b4d9b4f4 data =
2026-05-18T01:43:06.083671852Z  > controller="gcpmanagedcontrolplane" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="GCPManagedControlPlane" GCPManagedControlPlane="creategitops-jxym2i
```

Most likely 1.35.1 was removed from the stable channel.

New version works: https://github.com/rancher/turtles/actions/runs/26021558640/job/76484493824

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
