### PR TITLE
bug: add missing Makefile targets to regenerate all chart artifacts

### DIFF
--- a/.github/scripts/release-against-charts.sh
+++ b/.github/scripts/release-against-charts.sh
@@ -142,9 +142,15 @@ sed -i "s/${PREV_CHART_VERSION}/${NEW_CHART_VERSION}/g" ./packages/rancher-turtl
 git add packages/rancher-turtles
 git commit -m "$COMMIT_MSG"
 
+# Fully regenerate chart artifacts
+make pull-scripts
+PACKAGE=rancher-turtles make prepare
+PACKAGE=rancher-turtles make icon
+PACKAGE=rancher-turtles make patch
+PACKAGE=rancher-turtles make clean
 PACKAGE=rancher-turtles make charts
-git add ./assets/rancher-turtles ./charts/rancher-turtles index.yaml
-git commit -m "make charts"
+git add .
+git commit -m "PACKAGE=rancher-turtles make prepare/icon/patch/clean/charts"
 
 # Prepends to list
 yq --inplace ".rancher-turtles = [\"${NEW_CHART_VERSION}+up${NEW_TURTLES_VERSION_SHORT}\"] + .rancher-turtles" release.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds missing Makefile targets to regenerate chart artifacts while auto-opening a bump PR against the rancher/charts repository.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2325

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
