### PR TITLE
chore: bump k8s to 1.36

### DIFF
--- a/.github/workflows/run-vsphere-tests.yaml
+++ b/.github/workflows/run-vsphere-tests.yaml
@@ -37,6 +37,7 @@ jobs:
       - name: setupGo
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
+          cache: false
           go-version-file: go.mod
       - name: Display kind version
         run: kind version

--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -15,7 +15,8 @@ env:
   MANIFEST_IMG: controller
   CONTROLLER_IMG: controller
   PULL_POLICY: Never
-  RANCHER_VERSION: v2.14.0-alpha13
+  RANCHER_VERSION: v2.15.0-alpha4
+  KUBERNETES_MANAGEMENT_VERSION: v1.36.1
 
 jobs:
   prime-test:
@@ -59,8 +60,8 @@ jobs:
 
       - name: Create kind cluster
         run: |
-          kind create cluster --name kind \
-            --image kindest/node@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661 # v1.35
+          kind build node-image --type release --image kindest/node:${{ env.KUBERNETES_MANAGEMENT_VERSION }} ${{ env.KUBERNETES_MANAGEMENT_VERSION }}
+          kind create cluster --name kind --image kindest/node:${{ env.KUBERNETES_MANAGEMENT_VERSION }}
 
       - name: Display kind version
         run: kind version
@@ -170,8 +171,8 @@ jobs:
 
       - name: Create kind cluster
         run: |
-          kind create cluster --name kind \
-            --image kindest/node@sha256:abd489f042d2b644e2d033f5c2d900bc707798d075e8186cb65e3f1367a9d5a1
+          kind build node-image --type release --image kindest/node:${{ env.KUBERNETES_MANAGEMENT_VERSION }} ${{ env.KUBERNETES_MANAGEMENT_VERSION }}
+          kind create cluster --name kind --image kindest/node:${{ env.KUBERNETES_MANAGEMENT_VERSION }}
 
       - name: Display kind version
         run: kind version

--- a/docs/image-builder/vsphere-kubeadm.md
+++ b/docs/image-builder/vsphere-kubeadm.md
@@ -21,7 +21,8 @@ You'll need:
 
 ### 3. Create vSphere Credentials File
 
-Create a `vsphere.json` file with your vSphere credentials:
+Create a `vsphere.json` file with your vSphere credentials.  
+See Confluence for a more specific configuration sample.
 
 ```bash
 cat > packer/ova/vsphere.json <<EOF
@@ -34,7 +35,8 @@ cat > packer/ova/vsphere.json <<EOF
   "datastore": "datastore1",
   "folder": "Templates",
   "network": "VM Network",
-  "insecure_connection": "true"
+  "insecure_connection": "true",
+  "convert_to_template": "true"
 }
 EOF
 ```
@@ -78,6 +80,8 @@ Build Ubuntu 24.04 with your chosen Kubernetes version:
 ```bash
 PACKER_VAR_FILES="$(pwd)/my-k8s-config.json" make build-node-ova-vsphere-ubuntu-2404
 ```
+
+Beware that connection to SSH will take a while. Be patient.
 
 What happens:
 1. Packer connects to vSphere

--- a/examples/applications/ccm/aws/helm-chart.yaml
+++ b/examples/applications/ccm/aws/helm-chart.yaml
@@ -14,8 +14,6 @@ spec:
         - --cloud-provider=aws
         - --use-service-account-credentials=true
         - --configure-cloud-routes=false
-      image: |-
-        tag: v1.34.0
       nodeSelector: |-
         ${- if contains "RKE2ControlPlane" ( .ClusterValues | quote ) }
         node-role.kubernetes.io/control-plane: "true"

--- a/examples/applications/ccm/azure/helm-chart.yaml
+++ b/examples/applications/ccm/azure/helm-chart.yaml
@@ -7,7 +7,7 @@ spec:
     releaseName: cloud-provider-azure
     repo: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
     chart: cloud-provider-azure
-    version: v1.34.5
+    version: v1.36.0
     templateValues:
       infra: |-
         clusterName: ${ .ClusterValues.Cluster.metadata.name }

--- a/examples/applications/csi/vsphere/bundle.yaml
+++ b/examples/applications/csi/vsphere/bundle.yaml
@@ -162,7 +162,6 @@ spec:
       data:
         "trigger-csi-fullsync": "false"
         "pv-to-backingdiskobjectid-mapping": "false"
-        "csi-transaction-support": "false"
       kind: ConfigMap
       metadata:
         name: internal-feature-states.csi.vsphere.vmware.com
@@ -229,10 +228,9 @@ spec:
                   - matchExpressions:
                     - key: node-role.kubernetes.io/controlplane
                       operator: Exists
-                  # uncomment below matchExpressions if you are on a older version of kubernetes and you are using master nodes
-                  # - matchExpressions:
-                  #   - key: node-role.kubernetes.io/master
-                  #     operator: Exists
+                  - matchExpressions:
+                    - key: node-role.kubernetes.io/master
+                      operator: Exists
             serviceAccountName: vsphere-csi-controller
             tolerations:
               - key: node-role.kubernetes.io/master
@@ -292,7 +290,7 @@ spec:
                   - mountPath: /csi
                     name: socket-dir
               - name: vsphere-csi-controller
-                image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:latest
+                image: registry.k8s.io/csi-vsphere/driver:v3.7.0
                 args:
                   - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
                   - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -353,7 +351,7 @@ spec:
                   - name: socket-dir
                     mountPath: /csi
               - name: vsphere-syncer
-                image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/syncer:latest
+                image: registry.k8s.io/csi-vsphere/syncer:v3.7.0
                 args:
                   - "--leader-election"
                   - "--leader-election-lease-duration=30s"
@@ -365,7 +363,7 @@ spec:
                 imagePullPolicy: "Always"
                 ports:
                   - containerPort: 2113
-                    name: prometheus-sync
+                    name: prometheus
                     protocol: TCP
                 env:
                   - name: FULL_SYNC_INTERVAL_MINUTES
@@ -488,7 +486,7 @@ spec:
                     - --mode=kubelet-registration-probe
                   initialDelaySeconds: 3
               - name: vsphere-csi-node
-                image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:latest
+                image: registry.k8s.io/csi-vsphere/driver:v3.7.0
                 args:
                   - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
                   - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -637,7 +635,7 @@ spec:
                   - name: registration-dir
                     mountPath: /registration
               - name: vsphere-csi-node
-                image: us-central1-docker.pkg.dev/k8s-staging-images/csi-vsphere/driver:latest
+                image: registry.k8s.io/csi-vsphere/driver:v3.7.0
                 command:
                   - "csi.exe"
                 args:

--- a/examples/clusterclasses/aws/rke2/clusterclass-ec2-rke2-example.yaml
+++ b/examples/clusterclasses/aws/rke2/clusterclass-ec2-rke2-example.yaml
@@ -259,12 +259,12 @@ spec:
     spec:
       preRKE2Commands:
         - sudo hostnamectl set-hostname $(curl -s http://169.254.169.254/1.0/meta-data/hostname)
-      agentConfig:
-        kubelet:
-          extraArgs:
-            - --cloud-provider=external
+      agentConfig: {}
       serverConfig:
         cloudProviderName: external
+        disableComponents:
+          kubernetesComponents:
+            - cloudController
         etcd:
           backupConfig:
             retention: "10"
@@ -309,9 +309,5 @@ metadata:
 spec:
   template:
     spec:
-      agentConfig:
-        kubelet:
-          extraArgs:
-            - --cloud-provider=external
       preRKE2Commands:
         - sudo hostnamectl set-hostname $(curl -s http://169.254.169.254/1.0/meta-data/hostname)

--- a/examples/clusterclasses/docker/rke2/clusterclass-docker-rke2.yaml
+++ b/examples/clusterclasses/docker/rke2/clusterclass-docker-rke2.yaml
@@ -173,7 +173,6 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.35.0
       bootstrapTimeout: 15m
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2

--- a/examples/clusters/docker/rke2/cluster.yaml
+++ b/examples/clusters/docker/rke2/cluster.yaml
@@ -24,8 +24,8 @@ spec:
     - name: rke2CNI
       value: ""
     - name: dockerImage
-      value: kindest/node:v1.35.0
-    version: v1.35.0+rke2r1
+      value: kindest/node:v1.36.1
+    version: v1.36.0+rke2r1
     workers:
       machineDeployments:
       - class: default-worker

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ ignore (
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/go-logr/logr v1.4.3
-	github.com/onsi/ginkgo/v2 v2.28.3
-	github.com/onsi/gomega v1.40.0
+	github.com/onsi/ginkgo/v2 v2.29.0
+	github.com/onsi/gomega v1.41.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/text v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -109,10 +109,10 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.28.3 h1:4JvMdwtFU0imd8fHx25OJXoDMRexnf8v5NHKYSTTji4=
-github.com/onsi/ginkgo/v2 v2.28.3/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
-github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
-github.com/onsi/gomega v1.40.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
+github.com/onsi/ginkgo/v2 v2.29.0 h1:rfh+ZFjgJhYWRoIqVf3Uwx/W20yLrcrE2h2GmYVRaag=
+github.com/onsi/ginkgo/v2 v2.29.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
+github.com/onsi/gomega v1.41.0 h1:OwKp4pXNgVxf6sCplzYo794OFNuoL2q2SBMU5NSWOjA=
+github.com/onsi/gomega v1.41.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/scripts/kind-cluster-with-extramounts.yaml
+++ b/scripts/kind-cluster-with-extramounts.yaml
@@ -3,7 +3,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: capi-test
 nodes:
 - role: control-plane
-  image: kindest/node:v1.34.0
+  image: kindest/node:v1.36.1
   extraMounts:
     - hostPath: /tmp/capi-test/etcd
       containerPath: /tmp/capi-test/etcd

--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -51,6 +51,7 @@ if pgrep -x ngrok > /dev/null; then
     sleep 2
 fi
 
+kind build node-image --type release --image kindest/node:v1.36.1 v1.36.1
 kind create cluster --config "$BASEDIR/kind-cluster-with-extramounts.yaml" --name $CLUSTER_NAME
 docker pull $RANCHER_IMAGE
 kind load docker-image $RANCHER_IMAGE --name $CLUSTER_NAME

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -39,17 +39,28 @@ variables:
   SECRET_KEYS: "NGROK_AUTHTOKEN,NGROK_API_KEY,RANCHER_HOSTNAME,RANCHER_PASSWORD,CAPG_ENCODED_CREDS,AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AZURE_SUBSCRIPTION_ID,AZURE_CLIENT_ID,AZURE_CLIENT_SECRET,AZURE_TENANT_ID,GCP_PROJECT,GCP_NETWORK_NAME,GCP_IMAGE_ID,VSPHERE_TLS_THUMBPRINT,VSPHERE_SERVER,VSPHERE_DATACENTER,VSPHERE_DATASTORE,VSPHERE_FOLDER,VSPHERE_TEMPLATE,VSPHERE_NETWORK,VSPHERE_RESOURCE_POOL,VSPHERE_USERNAME,VSPHERE_PASSWORD,VSPHERE_KUBE_VIP_IP_KUBEADM,VSPHERE_KUBE_VIP_IP_RKE2,DOCKER_REGISTRY_TOKEN,DOCKER_REGISTRY_USERNAME,DOCKER_REGISTRY_CONFIG"
 
   # Kubernetes Configuration
-  KUBERNETES_VERSION: "v1.35.0" # Depends on kindest/node
-  # Kubernetes version used for the Rancher/CAPI management cluster
-  KUBERNETES_MANAGEMENT_VERSION: "v1.34.0"
-  # The cluster used in chart_upgrade must run a Kubernetes version compatible with an older version of Rancher
-  #   - Use v1.34.0 for Rancher 2.13.2 compatibility (requires < v1.35.0)
-  KUBERNETES_MANAGEMENT_VERSION_CHART_UPGRADE: "v1.34.0"
+
+  # KUBERNETES_VERSION is the Kubernetes version used by default in Kubeadm tests.
+  # It ill trigger a `kind build node-image` first to ensure version exists.
+  KUBERNETES_VERSION: "v1.36.1"
+  # KUBERNETES_MANAGEMENT_VERSION is the Kubernetes version used for the Rancher/CAPI management cluster
+  # It ill trigger a `kind build node-image` first to ensure version exists.
+  KUBERNETES_MANAGEMENT_VERSION: "v1.36.1"
+  # EKS_MANAGEMENT_VERSION is is the Kubernetes version used for the Rancher/CAPI management cluster for EKS environment types.
+  # Run: `aws eks describe-cluster-versions`
+  EKS_MANAGEMENT_VERSION: "v1.35.4"
+  # KUBERNETES_MANAGEMENT_VERSION_CHART_UPGRADE is the cluster version used in chart_upgrade.
+  # It must be a Kubernetes version compatible with an older version of Rancher
+  #   - Use v1.35.0 for Rancher 2.14.3 compatibility (requires < v1.36.0)
+  #   - Depends on public kindest/node images: https://hub.docker.com/r/kindest/node/tags
+  KUBERNETES_MANAGEMENT_VERSION_CHART_UPGRADE: "v1.35.5"
+  # KUBERNETES_VERSION_CHART_UPGRADE is the Kubernetes version to provision the initial Cluster in chart_upgrade.
+  KUBERNETES_VERSION_CHART_UPGRADE: "v1.35.5"
 
   # RKE2 specifics
-  RKE2_KUBERNETES_VERSION: "v1.35.0+rke2r1"
+  RKE2_KUBERNETES_VERSION: "v1.36.0+rke2r1"
   # Kubernetes version used for v2prov
-  V2PROV_RKE2_KUBERNETES_VERSION: "v1.35.3+rke2r1"
+  V2PROV_RKE2_KUBERNETES_VERSION: "v1.36.0+rke2r1"
   RKE2_CNI: "none"
 
   # Azure Configuration
@@ -58,14 +69,11 @@ variables:
   # This is due to the limited availability of published AMIs.
   # For example: https://portal.azure.com/#view/Microsoft_Azure_ComputeHub/ComputeHubMenuBlade/~/communityImagesBrowse
   #              Filter `capi-ubun2-2404` images. Beware: not all versions are published on all regions.
-  # Azure CCM fails to install when using v1.35: the latest available version is v1.34.5
-  #   - https://github.com/kubernetes-sigs/cloud-provider-azure/releases
-  # Use v1.34.3 for now as it is the latest Azure community image available
-  AZURE_KUBERNETES_VERSION: "v1.34.3"
+  AZURE_KUBERNETES_VERSION: "v1.36.1"
   # Use v1.34.3 for RKE2 clusters to align with Kubeadm
-  AZURE_RKE2_KUBERNETES_VERSION: "v1.34.3+rke2r1"
+  AZURE_RKE2_KUBERNETES_VERSION: "v1.36.0+rke2r1"
   # For AKS available versions, run: az aks get-versions --location westeurope
-  AZURE_AKS_KUBERNETES_VERSION: "v1.34.2"
+  AZURE_AKS_KUBERNETES_VERSION: "v1.36.0"
   # Name of the Kubernetes Secret used by ASO to authenticate with Azure (defaults to ASO's own default name)
   AZURE_ASO_CREDENTIAL_SECRET_NAME: "aso-credential-secret"
 
@@ -73,9 +81,9 @@ variables:
   #
   # AWS Kubeadm tests need specific k8s version.
   # Images are self-built and need versioned kubernetes components. See docs/image-builder
-  AWS_KUBERNETES_VERSION: "v1.35.0"
+  AWS_KUBERNETES_VERSION: "v1.36.1"
   # EKS also needs versioned images, that may not be available for recent versions of k8s.
-  # To verify availability, you can run: aws ssm get-parameter --name /aws/service/eks/optimized-ami/1.34/amazon-linux-2023/x86_64/standard/recommended/image_id
+  # To verify availability, you can run: aws ssm get-parameter --name /aws/service/eks/optimized-ami/1.35/amazon-linux-2023/x86_64/standard/recommended/image_id
   # Recent versions will return a 'ParameterNotFound' error, preventing EKS from deploying.
   # NOTE: EKS only supports versions >v1.32 when using `NodeadmConfig` and `AmazonLinux2023`
   AWS_EKS_KUBERNETES_VERSION: "v1.35.0"
@@ -85,15 +93,15 @@ variables:
   AWS_NODE_MACHINE_TYPE: "t3.large"
   AWS_RKE2_CONTROL_PLANE_MACHINE_TYPE: "t3.xlarge"
   AWS_RKE2_NODE_MACHINE_TYPE: "t3.xlarge"
-  AWS_AMI_ID: "ami-0bb0dc2c3c4dbf68f" # Private image. See docs/image-builder
+  AWS_AMI_ID: "ami-032938cfb36a7f7ce" # Private image. See docs/image-builder
 
   # GCP Configuration
   # Images are self-built and need versioned kubernetes components. See docs/image-builder
-  GCP_KUBERNETES_VERSION: "v1.34.1"
+  GCP_KUBERNETES_VERSION: "v1.36.1"
   GCP_GKE_KUBERNETES_VERSION: "v1.35.3"
   GCP_MACHINE_TYPE: "n1-standard-2"
   GCP_REGION: "europe-west2"
-  GCP_IMAGE_ID: "cluster-api-ubuntu-2404-v1-34-1-1762253907" # Private image. See docs/image-builder
+  GCP_IMAGE_ID: "cluster-api-ubuntu-2404-v1-36-1-1779178908" # Private image. See docs/image-builder
   GCP_IMAGE_ID_FORMATTED: "" #Calculated at runtime: https://www.googleapis.com/compute/v1/projects/${GCP_PROJECT_ID}/global/images/${GCP_IMAGE_ID}"
 
   # CLI Tool Paths
@@ -151,4 +159,4 @@ variables:
   # This can be used to configure a downstream cluster with a imagePullSecret.
   DOCKER_REGISTRY_CONFIG: ""
 
-  VSPHERE_TEMPLATE: "turtles-ci/ubuntu-2404-kube-v1.34.1"
+  VSPHERE_TEMPLATE: "turtles-ci/ubuntu-2404-kube-v1.36.1"

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -160,7 +160,8 @@ const (
 	SkipResourceCleanupVar = "SKIP_RESOURCE_CLEANUP"
 	SkipDeletionTestVar    = "SKIP_DELETION_TEST"
 
-	KubernetesVersionChartUpgradeVar = "KUBERNETES_MANAGEMENT_VERSION_CHART_UPGRADE"
+	KubernetesManagementVersionChartUpgradeVar = "KUBERNETES_MANAGEMENT_VERSION_CHART_UPGRADE"
+	KubernetesVersionChartUpgradeVar           = "KUBERNETES_VERSION_CHART_UPGRADE"
 
 	RKE2VersionVar       = "RKE2_KUBERNETES_VERSION"
 	RKE2V2ProvVersionVar = "V2PROV_RKE2_KUBERNETES_VERSION"

--- a/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
+++ b/test/e2e/suites/chart-upgrade/chart_upgrade_test.go
@@ -120,8 +120,11 @@ var _ = Describe("Chart upgrade functionality should work", Ordered, Label(e2e.S
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
 		By("Provisioning workload cluster (validates zero-downtime requirement)")
 
+		e2eConfig := e2e.LoadE2EConfig()
+		kubernetesVersion := e2eConfig.GetVariableOrEmpty(e2e.KubernetesVersionChartUpgradeVar)
+
 		return specs.CreateUsingGitOpsSpecInput{
-			E2EConfig:                      e2e.LoadE2EConfig(),
+			E2EConfig:                      e2eConfig,
 			BootstrapClusterProxy:          bootstrapClusterProxy,
 			ClusterTemplate:                e2e.CAPIDockerRKE2Topology,
 			ClusterName:                    clusterName,
@@ -139,7 +142,9 @@ var _ = Describe("Chart upgrade functionality should work", Ordered, Label(e2e.S
 			RancherManagedFleet:            true,
 			ValidateFleetAgentWasInstalled: true,
 			AdditionalTemplateVariables: map[string]string{
-				"RKE2_CNI": `""`,
+				"RKE2_CNI":                `""`,
+				"KUBERNETES_VERSION":      kubernetesVersion,
+				"RKE2_KUBERNETES_VERSION": kubernetesVersion + "+rke2r1",
 			},
 			AdditionalFleetGitRepos: []framework.FleetCreateGitRepoInput{
 				{

--- a/test/e2e/suites/chart-upgrade/suite_test.go
+++ b/test/e2e/suites/chart-upgrade/suite_test.go
@@ -81,9 +81,10 @@ var _ = SynchronizedBeforeSuite(
 
 		e2eConfig.ManagementClusterName = e2eConfig.ManagementClusterName + "-chart-upgrade"
 		setupClusterResult = testenv.SetupTestCluster(ctx, testenv.SetupTestClusterInput{
-			E2EConfig:         e2eConfig,
-			Scheme:            e2e.InitScheme(),
-			KubernetesVersion: e2eConfig.GetVariableOrEmpty(e2e.KubernetesVersionChartUpgradeVar),
+			E2EConfig:                   e2eConfig,
+			Scheme:                      e2e.InitScheme(),
+			KubernetesManagementVersion: e2eConfig.GetVariableOrEmpty(e2e.KubernetesManagementVersionChartUpgradeVar),
+			KubernetesVersion:           e2eConfig.GetVariableOrEmpty(e2e.KubernetesVersionChartUpgradeVar),
 		})
 
 		testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{

--- a/test/testenv/bootstrapclusterproviders.go
+++ b/test/testenv/bootstrapclusterproviders.go
@@ -18,6 +18,7 @@ package testenv
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -25,15 +26,17 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
+
+	turtlesframework "github.com/rancher/turtles/test/framework"
 )
 
 // CustomClusterProvider is a function type that represents a custom cluster provider.
 // It takes in a context, an E2EConfig, a cluster name, and a Kubernetes version as parameters.
 // It returns a bootstrap.ClusterProvider.
-type CustomClusterProvider func(ctx context.Context, config *clusterctl.E2EConfig, clusterName, kubernetesVersion string) bootstrap.ClusterProvider
+type CustomClusterProvider func(ctx context.Context, config *clusterctl.E2EConfig, clusterName, eksManagementVersion string, kubernetesManagementVersion string, kubernetesDownstreamVersion string) bootstrap.ClusterProvider
 
 // EKSBootstrapCluster is a function that creates a new EKS bootstrap cluster.
-func EKSBootstrapCluster(ctx context.Context, config *clusterctl.E2EConfig, clusterName, kubernetesVersion string) bootstrap.ClusterProvider {
+func EKSBootstrapCluster(ctx context.Context, config *clusterctl.E2EConfig, clusterName, eksManagementVersion string, _ string, _ string) bootstrap.ClusterProvider {
 	By("Creating a new EKS bootstrap cluster")
 
 	region := config.Variables["KUBERNETES_MANAGEMENT_AWS_REGION"]
@@ -42,7 +45,7 @@ func EKSBootstrapCluster(ctx context.Context, config *clusterctl.E2EConfig, clus
 	eksCreateResult := &CreateEKSBootstrapClusterAndValidateImagesInputResult{}
 	CreateEKSBootstrapClusterAndValidateImages(ctx, CreateEKSBootstrapClusterAndValidateImagesInput{
 		Name:       clusterName,
-		Version:    kubernetesVersion,
+		Version:    eksManagementVersion,
 		Region:     region,
 		NumWorkers: 1,
 		Images:     config.Images,
@@ -52,13 +55,24 @@ func EKSBootstrapCluster(ctx context.Context, config *clusterctl.E2EConfig, clus
 }
 
 // KindBootstrapCluster is a function that creates a new kind bootstrap cluster with extra port mappings. This is useful for forwarding requests from the host.
-func KindWithExtraPortMappingsBootstrapCluster(ctx context.Context, config *clusterctl.E2EConfig, clusterName, kubernetesVersion string) bootstrap.ClusterProvider {
+func KindWithExtraPortMappingsBootstrapCluster(ctx context.Context, config *clusterctl.E2EConfig, clusterName, _ string, kubernetesManagementVersion string, kubernetesDownstreamVersion string) bootstrap.ClusterProvider {
+
+	Expect(kubernetesManagementVersion).ShouldNot(BeEmpty(), "kubernetesManagementVersion is required")
+
+	By(fmt.Sprintf("Building kindest/node:%s for management Cluster", kubernetesManagementVersion))
+	BuildKindImage(ctx, kubernetesManagementVersion)
+
+	if len(kubernetesDownstreamVersion) > 0 {
+		By(fmt.Sprintf("Building kindest/node:%s for downstream Clusters", kubernetesDownstreamVersion))
+		BuildKindImage(ctx, kubernetesDownstreamVersion)
+	}
+
 	By("Creating a new kind bootstrap cluster with extra port mappings")
 
 	return bootstrap.CreateKindBootstrapClusterAndLoadImages(ctx, bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
 		Name:               clusterName,
-		KubernetesVersion:  kubernetesVersion,
-		RequiresDockerSock: false,
+		KubernetesVersion:  kubernetesManagementVersion,
+		RequiresDockerSock: true,
 		Images:             config.Images,
 		ExtraPortMappings: []v1alpha4.PortMapping{
 			{ContainerPort: 80, HostPort: 80, Protocol: v1alpha4.PortMappingProtocolTCP},
@@ -66,4 +80,19 @@ func KindWithExtraPortMappingsBootstrapCluster(ctx context.Context, config *clus
 			{ContainerPort: 30002, HostPort: 30002, Protocol: v1alpha4.PortMappingProtocolTCP}, // etcd nodeport
 		},
 	})
+}
+
+func BuildKindImage(ctx context.Context, version string) {
+	kindBuildImage := turtlesframework.RunCommand(ctx, turtlesframework.RunCommandInput{
+		Command: "kind",
+		Args: []string{
+			"build",
+			"node-image",
+			"--type", "release",
+			"--image", fmt.Sprintf("kindest/node:%s", version),
+			version,
+		},
+	})
+	Expect(kindBuildImage.Error).NotTo(HaveOccurred(), "Failed building kindest/node image")
+	Expect(kindBuildImage.ExitCode).To(Equal(0), "Building kindest/node image returned non-zero exit code")
 }

--- a/test/testenv/setupcluster.go
+++ b/test/testenv/setupcluster.go
@@ -56,8 +56,14 @@ type SetupTestClusterInput struct {
 	// ArtifactFolder is the folder where artifacts are stored.
 	ArtifactFolder string `env:"ARTIFACTS_FOLDER"`
 
-	// KubernetesVersion is the version of Kubernetes to use.
-	KubernetesVersion string `env:"KUBERNETES_MANAGEMENT_VERSION"`
+	// EKSManagementVersion is the EKS specific version to use for the management Cluster in EKS environment type.
+	EKSManagementVersion string `env:"EKS_MANAGEMENT_VERSION"`
+
+	// KubernetesVersion is the version of Kubernetes to use for the management Cluster.
+	KubernetesManagementVersion string `env:"KUBERNETES_MANAGEMENT_VERSION"`
+
+	// KubernetesVersion is the version of Kubernetes to use for the downstream Clusters.
+	KubernetesVersion string `env:"KUBERNETES_VERSION"`
 
 	// HelmBinaryPath is the path to the Helm binary.
 	HelmBinaryPath string `env:"HELM_BINARY_PATH"`
@@ -99,16 +105,15 @@ func SetupTestCluster(ctx context.Context, input SetupTestClusterInput) *SetupTe
 	clusterName := createClusterName(input.E2EConfig.ManagementClusterName)
 	result := &SetupTestClusterResult{}
 
-	if input.CustomClusterProvider == nil && input.EnvironmentType == e2e.ManagementClusterEnvironmentEKS {
+	switch input.EnvironmentType {
+	case e2e.ManagementClusterEnvironmentEKS:
 		input.CustomClusterProvider = EKSBootstrapCluster
-	}
-
-	if input.CustomClusterProvider == nil && input.EnvironmentType == e2e.ManagementClusterEnvironmentInternalKind {
+	default:
 		input.CustomClusterProvider = KindWithExtraPortMappingsBootstrapCluster
 	}
 
 	By("Setting up the bootstrap cluster")
-	result.setupCluster(ctx, input.E2EConfig, input.Scheme, clusterName, input.UseExistingCluster, input.KubernetesVersion, input.CustomClusterProvider)
+	result.setupCluster(ctx, input.E2EConfig, input.Scheme, clusterName, input.UseExistingCluster, input.EKSManagementVersion, input.KubernetesManagementVersion, input.KubernetesVersion, input.CustomClusterProvider)
 
 	if input.UseExistingCluster {
 		return result
@@ -125,21 +130,13 @@ func SetupTestCluster(ctx context.Context, input SetupTestClusterInput) *SetupTe
 	return result
 }
 
-func (r *SetupTestClusterResult) setupCluster(ctx context.Context, config *clusterctl.E2EConfig, scheme *runtime.Scheme, clusterName string, useExistingCluster bool, kubernetesVersion string, customClusterProvider CustomClusterProvider) {
+func (r *SetupTestClusterResult) setupCluster(ctx context.Context, config *clusterctl.E2EConfig, scheme *runtime.Scheme, clusterName string, useExistingCluster bool, eksManagementVersion string, kubernetesManagementVersion string, kubernetesDownstreamVersion string, customClusterProvider CustomClusterProvider) {
 	var clusterProvider bootstrap.ClusterProvider
 	kubeconfigPath := ""
 
 	if !useExistingCluster {
-		if customClusterProvider != nil { // if customClusterProvider is provided, use it to create the bootstrap cluster instead of kind
-			clusterProvider = customClusterProvider(ctx, config, clusterName, kubernetesVersion)
-		} else {
-			clusterProvider = bootstrap.CreateKindBootstrapClusterAndLoadImages(ctx, bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
-				Name:               clusterName,
-				KubernetesVersion:  kubernetesVersion,
-				RequiresDockerSock: true,
-				Images:             config.Images,
-			})
-		}
+		Expect(customClusterProvider).ShouldNot(BeNil())
+		clusterProvider = customClusterProvider(ctx, config, clusterName, eksManagementVersion, kubernetesManagementVersion, kubernetesDownstreamVersion)
 
 		Expect(clusterProvider).ToNot(BeNil(), "Failed to create a bootstrap cluster")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps k8s to 1.36 (or otherwise highest available version).
Changes:
- Updates all k8s versions 
- Now builds a `kindest/node` ad-hoc image to not rely on published ones. (See https://kind.sigs.k8s.io/docs/user/quick-start/#building-images and https://github.com/kubernetes-sigs/kind/issues/4157)
- Chart upgrade test now uses an older (compatible with previous Rancher version) Kubernetes version for provisioning the initial downstream Cluster.

Documentation: https://github.com/rancher/turtles-product-docs/pull/212

Test runs:
- e2e long: https://github.com/rancher/turtles/actions/runs/26155298973
- vSphere: https://github.com/rancher/turtles/actions/runs/26118599901

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2337

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
