### PR TITLE
make release workflow comply with immutability

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -58,8 +58,10 @@ jobs:
           rm -rf .cr-index
           mkdir -p .cr-index
 
-      - name: Run chart-releaser upload
-        run: cr upload --skip-existing -c "$(git rev-parse HEAD)" --generate-release-notes --release-name-template "${{ inputs.tag }}" --make-release-latest=false
+      - name: Run chart-releaser upload (draft release)
+        # Phase 1: create release as draft so all assets can be verified before publishing.
+        # The release must be manually undrafted from the GitHub UI - be careful not to mark it as latest.
+        run: cr upload --skip-existing -c "$(git rev-parse HEAD)" --generate-release-notes --release-name-template "${{ inputs.tag }}" --make-release-latest=false --draft
 
       - name: Verify chart asset present (recover if missing)
         run: |
@@ -69,11 +71,6 @@ jobs:
             exit 1
           fi
           ASSET_NAME=$(basename "${CHART_FILE}")
-
-          if ! gh release view "${{ inputs.tag }}" > /dev/null 2>&1; then
-            echo "ERROR: Release '${{ inputs.tag }}' not found."
-            exit 1
-          fi
 
           FOUND=$(gh release view "${{ inputs.tag }}" \
             --json assets \
@@ -89,3 +86,8 @@ jobs:
 
       - name: Run chart-releaser index
         run: cr index --push --release-name-template "${{ inputs.tag }}"
+
+      # Phase 2: once the draft-first process is validated over a few releases,
+      # uncomment the step below and enable immutable releases.
+      # - name: Publish release
+      #   run: gh release edit "${{ inputs.tag }}" --draft=false --latest=false


### PR DESCRIPTION
### Problem
Currently, `cr upload` creates and immediately publishes the GitHub release in a single step. This means the release is public and mutable from the moment it was created.

This causes two problems:

1. **Chart asset missing on re-run** ([example](https://github.com/rancher/turtles/actions/runs/22062100408/job/63745117786)): if `cr upload` failed mid-way (e.g. a 504 from GitHub), re-running the job would skip creating the release (via `--skip-existing`) but also skip uploading the `.tgz` asset, leaving the release with no chart attached.
2. **Immutability violation**: the `Verify chart asset present` recovery step introduced to fix the above used `gh release upload --clobber` to attach the missing asset to an already-published release. Once we enable immutable releases, modifying a published release will no longer be possible, so this recovery step would break.

### What this PR does

Adds `--draft` to `cr upload` so the release is created in draft state. This means:

- The release is **mutable throughout** the entire job: `cr upload`, asset verification, recovery upload, and `cr index` all operate on a draft release
- The **recovery step is safe to keep** as-is because `gh release upload --clobber` on a draft should be perfectly valid
- The release is only made visible to users after a **manual undraft** from the GitHub UI

This directly fixes the immutability violation while continuing to address the original chart-missing scenario we had to fix with the recovery step.

### Path to immutable releases

This PR is **Phase 1** of a gradual migration:

**Phase 1 (this PR):** Draft-first flow, manual undraft. Gives us confidence that the suggested process works reliably without the risk of being stuck with a broken immutable release.

**Phase 2 (follow-up, once Phase 1 is validated over a few releases):** Uncomment the `Publish release` step already included in the workflow. This automates the undraft as the very last step, only after all assets are confirmed present, fully following [GitHub's recommended immutable release workflow](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)

**Phase 3 (no code change needed, a follow-up once Phase 2 is validated):** Enable immutable releases in the
repository settings under **Settings -> Releases -> "Enable release immutability"**.

I will create a follow-up issue to track Phase 2 and 3 which should not block this work and anyways it will take time to get there.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: #2359

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
