### PR TITLE
Revert make release workflow comply with immutability (2416)

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -58,10 +58,8 @@ jobs:
           rm -rf .cr-index
           mkdir -p .cr-index
 
-      - name: Run chart-releaser upload (draft release)
-        # Phase 1: create release as draft so all assets can be verified before publishing.
-        # The release must be manually undrafted from the GitHub UI - be careful not to mark it as latest.
-        run: cr upload --skip-existing -c "$(git rev-parse HEAD)" --generate-release-notes --release-name-template "${{ inputs.tag }}" --make-release-latest=false --draft
+      - name: Run chart-releaser upload
+        run: cr upload --skip-existing -c "$(git rev-parse HEAD)" --generate-release-notes --release-name-template "${{ inputs.tag }}" --make-release-latest=false
 
       - name: Verify chart asset present (recover if missing)
         run: |
@@ -71,6 +69,11 @@ jobs:
             exit 1
           fi
           ASSET_NAME=$(basename "${CHART_FILE}")
+
+          if ! gh release view "${{ inputs.tag }}" > /dev/null 2>&1; then
+            echo "ERROR: Release '${{ inputs.tag }}' not found."
+            exit 1
+          fi
 
           FOUND=$(gh release view "${{ inputs.tag }}" \
             --json assets \
@@ -86,8 +89,3 @@ jobs:
 
       - name: Run chart-releaser index
         run: cr index --push --release-name-template "${{ inputs.tag }}"
-
-      # Phase 2: once the draft-first process is validated over a few releases,
-      # uncomment the step below and enable immutable releases.
-      # - name: Publish release
-      #   run: gh release edit "${{ inputs.tag }}" --draft=false --latest=false


### PR DESCRIPTION
This reverts commit 2367933f7f82fea09d34566fc31b11c51c1da041.

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
#2416 introduced --draft argument to chart release and it will break the workflow. I will rework the workflow later with gh CLI, but to unblock upcoming rc, this is reverting the change.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
