### PR TITLE
ci: install kind 0.31 in test tools

### DIFF
--- a/.github/workflows/e2e-short.yaml
+++ b/.github/workflows/e2e-short.yaml
@@ -26,8 +26,6 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
-      - name: Display kind version
-        run: kind version
       - name: Display docker version
         run: docker version
       - name: Run e2e tests

--- a/.github/workflows/run-e2e-suite.yaml
+++ b/.github/workflows/run-e2e-suite.yaml
@@ -106,8 +106,6 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
-      - name: Display kind version
-        run: kind version
       - name: Display docker version
         run: docker version
       - name: Docker login

--- a/.github/workflows/run-vsphere-tests.yaml
+++ b/.github/workflows/run-vsphere-tests.yaml
@@ -39,8 +39,6 @@ jobs:
         with:
           cache: false
           go-version-file: go.mod
-      - name: Display kind version
-        run: kind version
       - name: Display docker version
         run: docker version
       - name: Run e2e tests

--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -47,30 +47,18 @@ jobs:
         run: make test-chart
 
       - name: Install kind
-        run: |
-          KIND_VERSION=0.31.0
-          PLATFORM=$(uname)-amd64
-          EXPECTED_SHA256_AMD64=eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa # immutable hash for v0.31.0
-
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-${PLATFORM}
-          echo "$EXPECTED_SHA256_AMD64  kind" | sha256sum --check
-
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
+        run: make kind
 
       - name: Create kind cluster
         run: |
-          kind build node-image --type release --image kindest/node:${{ env.KUBERNETES_MANAGEMENT_VERSION }} ${{ env.KUBERNETES_MANAGEMENT_VERSION }}
-          kind create cluster --name kind --image kindest/node:${{ env.KUBERNETES_MANAGEMENT_VERSION }}
-
-      - name: Display kind version
-        run: kind version
+          hack/tools/bin/kind build node-image --type release --image kindest/node:${{ env.KUBERNETES_MANAGEMENT_VERSION }} ${{ env.KUBERNETES_MANAGEMENT_VERSION }}
+          hack/tools/bin/kind create cluster --name kind --image kindest/node:${{ env.KUBERNETES_MANAGEMENT_VERSION }}
 
       - name: Display docker version
         run: docker version
 
       - name: Add local docker image
-        run: kind load docker-image ${{ env.MANIFEST_IMG }}:${{ env.TAG }}
+        run: hack/tools/bin/kind load docker-image ${{ env.MANIFEST_IMG }}:${{ env.TAG }}
 
       - name: Add rancher chart repo
         run: helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
@@ -158,30 +146,18 @@ jobs:
         run: make build-chart
 
       - name: Install kind
-        run: |
-          KIND_VERSION=0.31.0
-          PLATFORM=$(uname)-amd64
-          EXPECTED_SHA256_AMD64=eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa # immutable hash for v0.31.0
-
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-${PLATFORM}
-          echo "$EXPECTED_SHA256_AMD64  kind" | sha256sum --check
-
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
+        run: make kind
 
       - name: Create kind cluster
         run: |
-          kind build node-image --type release --image kindest/node:${{ env.KUBERNETES_MANAGEMENT_VERSION }} ${{ env.KUBERNETES_MANAGEMENT_VERSION }}
-          kind create cluster --name kind --image kindest/node:${{ env.KUBERNETES_MANAGEMENT_VERSION }}
-
-      - name: Display kind version
-        run: kind version
+          hack/tools/bin/kind build node-image --type release --image kindest/node:${{ env.KUBERNETES_MANAGEMENT_VERSION }} ${{ env.KUBERNETES_MANAGEMENT_VERSION }}
+          hack/tools/bin/kind create cluster --name kind --image kindest/node:${{ env.KUBERNETES_MANAGEMENT_VERSION }}
 
       - name: Display docker version
         run: docker version
 
       - name: Add local docker image
-        run: kind load docker-image ${{ env.MANIFEST_IMG }}:${{ env.TAG }}
+        run: hack/tools/bin/kind load docker-image ${{ env.MANIFEST_IMG }}:${{ env.TAG }}
 
       - name: Setup Rancher Private CA
         run: |

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,9 @@ GOLANGCI_LINT_PKG := github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
 CHART_TESTING_VER := v3.14.0
 
+KIND_VER := v0.31.0
+KIND_VER_SHA256 := eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa
+
 # Registry / images
 TAG ?= dev
 ARCH ?= linux/$(shell go env GOARCH)
@@ -285,7 +288,7 @@ vendor-clean:
 	rm -rf vendor
 
 .PHOHY: dev-env
-dev-env: build-local-rancher-charts ## Create a local development environment
+dev-env: kind build-local-rancher-charts ## Create a local development environment
 	./scripts/turtles-dev.sh ${RANCHER_HOSTNAME}
 
 ## --------------------------------------
@@ -557,6 +560,13 @@ install-etcd-tools: $(TOOLS_BIN_DIR) ## Download and install etcdctl
 	mv /tmp/etcd-tools-unpack/etcd $(TOOLS_BIN_DIR)/etcd
 	rm -rf /tmp/etcd-tools-unpack
 
+kind: # Download kind binary into tools bin folder
+	mkdir -p $(TOOLS_BIN_DIR)
+	curl -Lo "$(TOOLS_BIN_DIR)/kind" "https://kind.sigs.k8s.io/dl/${KIND_VER}/kind-linux-amd64"
+	echo "${KIND_VER_SHA256} $(TOOLS_BIN_DIR)/kind" | sha256sum --check
+	chmod +x $(TOOLS_BIN_DIR)/kind
+	kind version
+
 ## --------------------------------------
 ## Release
 ## --------------------------------------
@@ -660,7 +670,7 @@ test-e2e: ## If MANAGEMENT_CLUSTER_ENVIRONMENT is 'eks', run remote e2e tests, o
 	fi
 
 .PHONY: test-e2e-local
-test-e2e-local: $(GINKGO) $(HELM) $(CLUSTERCTL) $(ENVSUBST) kubectl e2e-image build-local-rancher-charts install-etcd-tools ## Run the end-to-end tests
+test-e2e-local: kind $(GINKGO) $(HELM) $(CLUSTERCTL) $(ENVSUBST) kubectl e2e-image build-local-rancher-charts install-etcd-tools ## Run the end-to-end tests
 	$(E2E_RUN_COMMAND)
 
 .PHONY: test-e2e-remote

--- a/scripts/kind-cluster-with-extramounts.yaml
+++ b/scripts/kind-cluster-with-extramounts.yaml
@@ -3,10 +3,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: capi-test
 nodes:
 - role: control-plane
-  image: kindest/node:v1.36.1
   extraMounts:
-    - hostPath: /tmp/capi-test/etcd
-      containerPath: /tmp/capi-test/etcd
     - hostPath: /var/run/docker.sock
       containerPath: /var/run/docker.sock
   extraPortMappings:

--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -31,6 +31,7 @@ CLUSTER_NAME=${CLUSTER_NAME:-capi-test}
 USE_TILT_DEV=${USE_TILT_DEV:-true}
 TURTLES_VERSION=${TURTLES_VERSION:-dev}
 TURTLES_IMAGE=${TURTLES_IMAGE:-ghcr.io/rancher/turtles:$TURTLES_VERSION}
+KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.36.1}
 
 GITEA_PASSWORD=${GITEA_PASSWORD:-giteaadmin}
 GITEA_INGRESS_CLASS_NAME=${GITEA_INGRESS_CLASS_NAME:-ngrok}
@@ -51,8 +52,8 @@ if pgrep -x ngrok > /dev/null; then
     sleep 2
 fi
 
-kind build node-image --type release --image kindest/node:v1.36.1 v1.36.1
-kind create cluster --config "$BASEDIR/kind-cluster-with-extramounts.yaml" --name $CLUSTER_NAME
+kind build node-image --type release --image kindest/node:$KUBERNETES_VERSION $KUBERNETES_VERSION
+kind create cluster --config "$BASEDIR/kind-cluster-with-extramounts.yaml" --image kindest/node:$KUBERNETES_VERSION --name $CLUSTER_NAME
 docker pull $RANCHER_IMAGE
 kind load docker-image $RANCHER_IMAGE --name $CLUSTER_NAME
 

--- a/test/testenv/bootstrapclusterproviders.go
+++ b/test/testenv/bootstrapclusterproviders.go
@@ -93,6 +93,8 @@ func BuildKindImage(ctx context.Context, version string) {
 			version,
 		},
 	})
+	GinkgoWriter.Printf("kind build stdout: \n%s\n", string(kindBuildImage.Stdout))
+	GinkgoWriter.Printf("kind build stderr: \n%s\n", string(kindBuildImage.Stderr))
 	Expect(kindBuildImage.Error).NotTo(HaveOccurred(), "Failed building kindest/node image")
 	Expect(kindBuildImage.ExitCode).To(Equal(0), "Building kindest/node image returned non-zero exit code")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds more verbosity to the `kind build node-image` when using it in CI, since it occasionally fails.
Also now pins a version of kind to be installed, previously we relied on what was installed on the runner. At the moment it's the same version, the runner is also using 0.31 which is latest.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
