### PR TITLE
[release/v0.27] fix: pass prime build tag when releasing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
         public-repo: rancher
         public-username: ${{ env.DOCKER_USERNAME }}
         public-password: ${{ env.DOCKER_PASSWORD }}
-        make-target: push-image
+        make-target: push-community-image
 
     - name: Push prime image to staging registry
       uses: rancher/ecm-distro-tools/actions/publish-image@a7a867a6376bf4a1cee397558f3c85393769f069

--- a/Makefile
+++ b/Makefile
@@ -408,8 +408,12 @@ push-image: docker-pull-prerequisites ## Build and push community image (called 
 		--build-arg builder_image=$(GO_CONTAINER_IMAGE) \
 		--build-arg goproxy=$(GOPROXY) \
 		--build-arg package=. \
-		--build-arg go_build_tags=community \
+		--build-arg go_build_tags=$(TARGET_BUILD) \
 		--build-arg ldflags="$(LDFLAGS)" . -t $(REPO)/$(CONTROLLER_IMAGE_NAME):$(TAG)
+
+.PHONY: push-community-image
+push-community-image: ## Build and push community image
+	$(MAKE) push-image TARGET_BUILD=community
 
 .PHONY: push-prime-image
 push-prime-image: ## Build and push prime image with SBOM and provenance (called by publish-image action)


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove hardcoded `community` Docker build tag from Prime image creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2428

**Special notes for your reviewer**:

There are multiple actions in Makefile that can be removed or merged into newer actions. We need to clean it up when we get some time as technical debt can get worse if we don't do it soon.

For now, this is just targeting the fix to resolve the release blocker.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
