### PR TITLE
fix: check upstream clusterctl config for known providers

### DIFF
--- a/internal/controllers/clusterctl/config.go
+++ b/internal/controllers/clusterctl/config.go
@@ -24,7 +24,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/blang/semver/v4"
 	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	accorev1 "k8s.io/client-go/applyconfigurations/core/v1"
@@ -40,7 +39,6 @@ import (
 var config *corev1.ConfigMap
 
 const (
-	latestVersionKey = "latest"
 	// ConfigPath is the path of the mounted clusterctl config.
 	ConfigPath = "/config/clusterctl.yaml"
 )
@@ -207,59 +205,31 @@ func extractNamespace(imageURI string) string {
 	return imageURI
 }
 
-// GetProviderVersion collects version of the collected provider overrides state.
-// Returns latest if the version is not found.
-func (r *ConfigRepository) GetProviderVersion(ctx context.Context, name, providerType string) (version string, providerKnown bool) {
+// GetProviderVersion gets the version of the provider parsing the provider URL in the clusterctl config.
+// It will return the found version if any, empty otherwise.
+func (r *ConfigRepository) GetProviderVersion(ctx context.Context, name, providerType string) (string, error) {
+	log := log.FromContext(ctx)
+
 	for _, provider := range r.Providers {
 		if provider.Name == name && strings.EqualFold(provider.Type, providerType) {
-			return collectVersion(ctx, provider.URL), true
+			log.V(5).Info("Provider found in Turtles clusterctl config")
+			return parseVersionFromURL(provider.URL)
 		}
 	}
 
-	return latestVersionKey, false
+	return "", nil
 }
 
-func collectVersion(ctx context.Context, url string) string {
+// parseVersionFromURL parses the version from the provider URL.
+// For example: "https://github.com/rancher/cluster-api-provider-aws/releases/v2.11.1/infrastructure-components.yaml"
+// Beware that "latest" is also a valid version, this does not check for a semantic version format.
+func parseVersionFromURL(url string) (string, error) {
 	version := strings.Split(url, "/")
 	slices.Reverse(version)
 
 	if len(version) < 2 {
-		log.FromContext(ctx).Info("Provider url is invalid for version resolve, defaulting to latest", "url", url)
-
-		return latestVersionKey
+		return "", fmt.Errorf("Provider url is invalid for version resolve: %s", url)
 	}
 
-	return version[1]
-}
-
-// IsLatestVersion checks version against the expected max version, and returns false
-// if the version given is newer then the latest in the clusterctlconfig override.
-func (r *ConfigRepository) IsLatestVersion(providerVersion, expected string) (bool, error) {
-	// Return true for providers without version boundary or unknown providers
-	if providerVersion == latestVersionKey {
-		return true, nil
-	}
-
-	version, _ := strings.CutPrefix(providerVersion, "v")
-
-	maxVersion, err := semver.Parse(version)
-	if err != nil {
-		return false, fmt.Errorf("unable to parse default provider version %s: %w", providerVersion, err)
-	}
-
-	expected = cmp.Or(expected, latestVersionKey)
-	if expected == latestVersionKey {
-		// Latest should be reduced to the actual version set on the clusterctlprovider resource
-		return false, nil
-	}
-
-	version, _ = strings.CutPrefix(expected, "v")
-
-	desiredVersion, err := semver.Parse(version)
-	if err != nil {
-		return false, fmt.Errorf("unable to parse desired version %s: %w", expected, err)
-	}
-
-	// Disallow versions beyond current clusterctl.yaml override default
-	return maxVersion.LTE(desiredVersion), nil
+	return version[1], nil
 }

--- a/internal/provider/defaults.go
+++ b/internal/provider/defaults.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
+	configclient "sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 	"sigs.k8s.io/cluster-api/util/conditions"
 
 	turtlesv1 "github.com/rancher/turtles/api/v1alpha1"
@@ -38,8 +39,9 @@ const (
 	// AzureProvider is the default capz provider name.
 	AzureProvider = "azure"
 	// GCPProvider is the default capg provider name.
-	GCPProvider = "gcp"
-	trueValue   = "true"
+	GCPProvider        = "gcp"
+	trueValue          = "true"
+	latestVersionValue = "latest"
 )
 
 // SetProviderSpec sets the default values for the provider spec and updates to latest available version.
@@ -103,15 +105,36 @@ func setLatestVersion(ctx context.Context, cl client.Client, provider *turtlesv1
 		return err
 	}
 
+	// Check if the provider is known by Turtles. This includes the ClusterctlConfig overrides.
 	providerVersion, knownProvider := config.GetProviderVersion(ctx, provider.ProviderName(), provider.Spec.Type.ToKind())
 
-	latest, err := config.IsLatestVersion(providerVersion, provider.Spec.Version)
+	// Check if the provider is known by the clusterctl embedded list. See `clusterctl config repositories`.
+	initConfig, err := configclient.New(ctx, "/config/clusterctl.yaml")
+	if err != nil {
+		return fmt.Errorf("initializing clusterctl config client: %w", err)
+	}
+	upstreamProviders, err := initConfig.Providers().List()
+	if err != nil {
+		return fmt.Errorf("listing upstream providers: %w", err)
+	}
+	upstreamKnownProvider := false
+	for _, upstreamProvider := range upstreamProviders {
+		if provider.ProviderName() == upstreamProvider.Name() {
+			upstreamKnownProvider = true
+			break
+		}
+	}
+
+	// Check if version is latest
+	latest, err := config.IsLatestVersion(provider.Spec.Version, providerVersion)
 	if err != nil {
 		return err
 	}
 
 	switch {
-	case !knownProvider:
+	case !knownProvider && !upstreamKnownProvider:
+		// Provider is not known by Turtles and clusterctl.
+		// It is not possible to determine a version to install.
 		conditions.Set(provider, metav1.Condition{
 			Type:               string(turtlesv1.CheckLatestVersionTime),
 			Status:             metav1.ConditionUnknown,
@@ -127,8 +150,11 @@ func setLatestVersion(ctx context.Context, cl client.Client, provider *turtlesv1
 			Message:            "Latest version is set",
 			LastTransitionTime: metav1.Now(),
 		})
-
-		provider.Spec.Version = providerVersion
+		if providerVersion != clusterctl.LatestVersionKey {
+			provider.Spec.Version = providerVersion
+		} else {
+			provider.Spec.Version = ""
+		}
 
 	case !latest && !provider.Spec.EnableAutomaticUpdate:
 		conditions.Set(provider, metav1.Condition{
@@ -154,7 +180,11 @@ func setLatestVersion(ctx context.Context, cl client.Client, provider *turtlesv1
 			})
 		}
 
-		provider.Spec.Version = providerVersion
+		if providerVersion != clusterctl.LatestVersionKey {
+			provider.Spec.Version = providerVersion
+		} else {
+			provider.Spec.Version = ""
+		}
 	}
 
 	return nil

--- a/internal/provider/latest_version.go
+++ b/internal/provider/latest_version.go
@@ -1,0 +1,117 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	turtlesv1 "github.com/rancher/turtles/api/v1alpha1"
+	"github.com/rancher/turtles/internal/controllers/clusterctl"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	configclient "sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+)
+
+// lookupLatestVersion tries to find the latest available version of a given provider.
+// This is used to notify the user there's a new version available, or automatically update to it
+// if automatic updates are enabled.
+//
+// The lookup strategy follows this order:
+//  1. Lookup against Turtles clusterctl config. This is built from the embedded clusterctl config
+//     and includes user defined ClusterctlConfig overrides if any. We always expect a pinned version here, not "latest".
+//  2. If the provider repository is not found in Turtles clusterctl config, the upstream list of providers is used.
+//     This is equivalent of running `clusterctl config repositories`.
+//  3. If a provider is found in this upstream list, leave the version empty and let cluster-api-operator do the remote version lookup.
+//
+// The function returns the version if the provider was found and a version was pinned, empty otherwise.
+func lookupLatestVersion(ctx context.Context, cl client.Client, provider *turtlesv1.CAPIProvider) (latestVersion string, providerKnown bool, lookupError error) {
+	log := log.FromContext(ctx)
+
+	if provider.Spec.Version == "" {
+		log.V(5).Info("Provider has empty version. Can not compare to determine latest.")
+		return "", false, fmt.Errorf("Can not compare empty provider version to determine if there are updates.")
+	}
+
+	// Load the Turtles clusterctl config.
+	config, err := clusterctl.ClusterConfig(ctx, cl)
+	if err != nil {
+		return "", false, fmt.Errorf("getting Turtles clusterctl config: %w", err)
+	}
+
+	// 1. Check if the provider is known by Turtles. This includes the ClusterctlConfig user overrides if any.
+	foundProviderVersion, err := config.GetProviderVersion(ctx, provider.ProviderName(), provider.Spec.Type.ToKind())
+	if err != nil {
+		return "", false, fmt.Errorf("getting provider version from Turtles clusterctl config")
+	}
+
+	if foundProviderVersion != "" {
+		log.V(5).Info(fmt.Sprintf("Provider found in Turtles config. Found version: %s", foundProviderVersion))
+
+		if latestAvailableVersion, err := getLatestAvailableVersion(ctx, provider.Spec.Version, foundProviderVersion); err != nil {
+			return latestAvailableVersion, true, nil
+		} else {
+			return "", true, fmt.Errorf("determining latest available version: %w", err)
+		}
+	}
+
+	// 2. If the provider is not known by Turtles, lookup the upstream provider list.
+	if foundProviderVersion == "" {
+		configClient, err := configclient.New(ctx, "/config/clusterctlconfig.yaml")
+		if err != nil {
+			return "", false, fmt.Errorf("initializing config client: %w", err)
+		}
+
+		knownProviders, err := configClient.Providers().List()
+		if err != nil {
+			return "", false, fmt.Errorf("initializing config client: %w", err)
+		}
+	}
+
+	return "", false, nil
+}
+
+// getLatestAvailableVersion compares two semantic versions and returns the highest available.
+func getLatestAvailableVersion(ctx context.Context, currentVersion, comparedVersion string) (string, error) {
+	log := log.FromContext(ctx)
+
+	providerNeedsUpdate, err := needsUpdate(currentVersion, comparedVersion)
+	if err != nil {
+		return "", fmt.Errorf("determining if provider needs update from Turtles clusterctl config: %w", err)
+	}
+
+	if providerNeedsUpdate {
+		log.V(5).Info(fmt.Sprintf("Provider can be updated to: %s", comparedVersion))
+		return comparedVersion, nil
+	} else {
+		log.V(5).Info(fmt.Sprintf("Provider version %s is already up to date.", currentVersion))
+		return currentVersion, nil
+	}
+}
+
+// needsUpdate checks the current version against the compared version.
+func needsUpdate(currentVersion, comparedVersion string) (bool, error) {
+	if currentVersion == "" {
+		return false, fmt.Errorf("Can not compare empty provider version")
+	}
+	if comparedVersion == "" {
+		return false, fmt.Errorf("Can not compare empty expected version")
+	}
+
+	current, _ := strings.CutPrefix(currentVersion, "v")
+
+	currentSemVer, err := semver.Parse(current)
+	if err != nil {
+		return false, fmt.Errorf("parsing the current provider version %s: %w", currentVersion, err)
+	}
+
+	compared, _ := strings.CutPrefix(comparedVersion, "v")
+
+	comparedSemVer, err := semver.Parse(compared)
+	if err != nil {
+		return false, fmt.Errorf("parsing the compared version %s: %w", comparedVersion, err)
+	}
+
+	return currentSemVer.LT(comparedSemVer), nil
+}

--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -90,7 +90,7 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # Build and load the controller image
-make docker-build-prime
+make docker-build-community
 kind load docker-image $TURTLES_IMAGE --name $CLUSTER_NAME
 
 # Deploy Gitea test Nodeport
@@ -223,8 +223,8 @@ install_local_providers_chart() {
         --timeout 180s
 }
 
-echo "Installing local Rancher Turtles Providers..."
-install_local_providers_chart
+#echo "Installing local Rancher Turtles Providers..."
+#install_local_providers_chart
 
 echo "Exposing ETCD..."
 kubectl apply -f test/e2e/data/etcd/test-nodeport.yaml

--- a/tilt/project/Tiltfile
+++ b/tilt/project/Tiltfile
@@ -231,7 +231,7 @@ def build_go_binary(context, reload_deps, debug, go_main, binary_name, label):
         gcflags = gcflags,
         go_main = go_main,
         ldflags = ldflags,
-        tags = "prime",
+        tags = "community",
         binary_name = binary_name,
     )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is work in progress.
A tentative fix for https://github.com/rancher/turtles/issues/2436

It does however introduce a new issue with EnableAutomaticUpdate feature.
```yaml
    - lastTransitionTime: "2026-05-27T13:09:36Z"
      message: Provider version update available. Current latest is latest
      observedGeneration: 2
      reason: UpdateAvailable
      status: "False"
      type: CheckLatestVersionTime
```

So if anything the code needs to be improved to do an early calculation/fetch of the latest available version.
Maybe adopting the same logic as in https://github.com/kubernetes-sigs/cluster-api-operator/blob/release-0.27/internal/controller/manifests_downloader.go#L89-L97:

```go

	if spec.Version == "" && p.repo != nil {
		// User didn't set the version, try to get repository default.
		spec.Version = p.repo.DefaultVersion()

		log.Info("Using repository default version", "version", spec.Version)

		// Add version to the provider spec.
		p.provider.SetSpec(spec)
	}
```

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
