### PR TITLE
fix: return error from DefaultSynchronizer.Get instead of silently dropping it

### DIFF
--- a/internal/sync/core.go
+++ b/internal/sync/core.go
@@ -51,6 +51,7 @@ func (s *DefaultSynchronizer[T]) Get(ctx context.Context) error {
 	objKey := client.ObjectKeyFromObject(s.Destination)
 	if err := s.client.Get(ctx, objKey, s.Destination); client.IgnoreNotFound(err) != nil {
 		log.Error(err, "Unable to get mirrored manifest: "+objKey.String())
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
What this PR does / why we need it:

`DefaultSynchronizer.Get` logs non-NotFound errors but always returns `nil` - errors get silently dropped. The sync pipeline continues with stale destination state, no requeue triggered.

`interface.go` collects `syncer.Get(ctx)` errors expecting them to propagate - they never do.

Fix is one line: return the error. NotFound still returns nil (intentional, unchanged).

Reproduces on any transient non-404 API error: rate limiting (429), timeouts, auth errors (403), server errors (500).

Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:

Checklist:
- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests