### PR TITLE
feat: translate Rancher AWS Cloud Credentials to `AWSClusterStaticIdentity`

### DIFF
--- a/api/v1alpha1/capiprovider_types.go
+++ b/api/v1alpha1/capiprovider_types.go
@@ -29,7 +29,6 @@ const (
 
 // CAPIProviderSpec defines the desired state of CAPIProvider.
 // +kubebuilder:validation:XValidation:message="CAPI Provider version should be in the semver format prefixed with 'v'. Example: v1.9.3",rule="!has(self.version) || self.version.matches(r\"\"\"^v([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-]+)?$\"\"\")"
-// +kubebuilder:validation:XValidation:message="Config secret namespace is always equal to the resource namespace and should not be set.",rule="!has(self.configSecret) || !has(self.configSecret.__namespace__)"
 // +kubebuilder:validation:XValidation:message="One of fetchConfig oci, url or selector should be set.",rule="!has(self.fetchConfig) || [has(self.fetchConfig.oci), has(self.fetchConfig.url), has(self.fetchConfig.selector)].exists_one(e, e)"
 //
 //nolint:lll

--- a/charts/rancher-turtles/templates/deployment.yaml
+++ b/charts/rancher-turtles/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - args:
         - --leader-elect
-        - --feature-gates=agent-tls-mode={{ index .Values "features" "agent-tls-mode" "enabled"}},no-cert-manager={{ index .Values "features" "no-cert-manager" "enabled"}},use-rancher-default-registry={{ index .Values "features" "use-rancher-default-registry" "enabled"}},use-caapf={{ index .Values "features" "use-caapf" "enabled"}}
+        - --feature-gates=agent-tls-mode={{ index .Values "features" "agent-tls-mode" "enabled"}},no-cert-manager={{ index .Values "features" "no-cert-manager" "enabled"}},use-rancher-default-registry={{ index .Values "features" "use-rancher-default-registry" "enabled"}},use-caapf={{ index .Values "features" "use-caapf" "enabled"}},rancher-credential-translation={{ index .Values "features" "rancher-credential-translation" "enabled"}}
         {{- range .Values.managerArguments }}
         - {{ . }}
         {{- end }}  

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -40,7 +40,10 @@ features:
   # use-caapf: Alpha feature to make Turtles rely on CAAPF to install Fleet in CAPI workload clusters.
   use-caapf:
     # enabled: Turn on or off.
-    enabled: false 
+    enabled: false
+  rancher-credential-translation:
+    # enabled: Turn on or off.
+    enabled: false
 # volumes: Volumes for controller pods.
 volumes:
   - name: clusterctl-config

--- a/config/crd/bases/turtles-capi.cattle.io_capiproviders.yaml
+++ b/config/crd/bases/turtles-capi.cattle.io_capiproviders.yaml
@@ -3245,9 +3245,6 @@ spec:
             - message: 'CAPI Provider version should be in the semver format prefixed
                 with ''v''. Example: v1.9.3'
               rule: '!has(self.version) || self.version.matches(r"""^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$""")'
-            - message: Config secret namespace is always equal to the resource namespace
-                and should not be set.
-              rule: '!has(self.configSecret) || !has(self.configSecret.__namespace__)'
             - message: One of fetchConfig oci, url or selector should be set.
               rule: '!has(self.fetchConfig) || [has(self.fetchConfig.oci), has(self.fetchConfig.url),
                 has(self.fetchConfig.selector)].exists_one(e, e)'

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -53,6 +53,7 @@ rules:
   - infrastructure.cluster.x-k8s.io
   resources:
   - '*'
+  - awsclusterstaticidentities
   verbs:
   - create
   - delete

--- a/examples/clusterclasses/aws/rke2/clusterclass-ec2-rke2-example.yaml
+++ b/examples/clusterclasses/aws/rke2/clusterclass-ec2-rke2-example.yaml
@@ -73,7 +73,6 @@ spec:
         openAPIV3Schema:
           description: The AWSClusterStaticIdentity resource name referencing the credentials to create the Cluster.
           type: string
-          default: cluster-identity
   patches:
     - name: awsClusterTemplate
       definitions:
@@ -99,7 +98,7 @@ spec:
             matchResources:
               infrastructureCluster: true
           jsonPatches:
-            - op: add
+            - op: replace
               path: /spec/template/spec/identityRef/name
               valueFrom:
                 variable: awsClusterIdentityName
@@ -167,7 +166,7 @@ spec:
     spec:
       identityRef:
         kind: AWSClusterStaticIdentity
-        name: cluster-identity
+        name: default
       bastion:
         enabled: false
       controlPlaneLoadBalancer:

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -37,6 +37,11 @@ const (
 
 	// UseCAAPF if enabled Turtles will rely on CAAPF to install CNI and other dependencies on CAPI workload clusters.
 	UseCAAPF featuregate.Feature = "use-caapf"
+
+	// RancherCCTranslation if enabled Turtles will translate Rancher AWS Cloud Credentials
+	// into CAPI-specific static identity objects (`AWSClusterStaticIdentity`).
+	// NOTE: currently this feature is only available for CAPA and `AWSClusterStaticIdentity`.
+	RancherCCTranslation featuregate.Feature = "rancher-credential-translation"
 )
 
 func init() {
@@ -50,4 +55,5 @@ var DefaultGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	NoCertManager:             {Default: true, PreRelease: featuregate.Beta},
 	UseRancherDefaultRegistry: {Default: true, PreRelease: featuregate.Beta},
 	UseCAAPF:                  {Default: false, PreRelease: featuregate.Alpha},
+	RancherCCTranslation:      {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/internal/controllers/aws_translator.go
+++ b/internal/controllers/aws_translator.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,6 +39,12 @@ const (
 	//nolint:gosec  // This is not a hardcoded secret, just a key name.
 	rancherAWSSecretKeyField = "amazonec2credentialConfig-secretKey"
 )
+
+// allowedAWSClusterNamespace is the only namespace where AWSClusterStaticIdentities will be allowed to be used.
+// for now it only supports `fleet-default`.
+var allowedAWSClusterNamespaceList = []string{
+	"fleet-default",
+}
 
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclusterstaticidentities,verbs=get;list;watch;create;update;patch;delete
 
@@ -53,17 +60,15 @@ func (a *AWSTranslator) Translate(ctx context.Context, cl client.Client, credent
 		return "", nil
 	}
 
-	identityName := credential.Name
-
-	if err := generateCredentialSecret(ctx, cl, identityName, accessKeyID, secretAccessKey, a.ProviderNamespace()); err != nil {
+	if err := createOrUpdateCredentialSecret(ctx, cl, credential, accessKeyID, secretAccessKey, a.ProviderNamespace()); err != nil {
 		return "", err
 	}
 
-	if err := generateAWSClusterStaticIdentity(ctx, cl, identityName); err != nil {
+	if err := createOrUpdateAWSClusterStaticIdentity(ctx, cl, credential); err != nil {
 		return "", err
 	}
 
-	return identityName, nil
+	return credential.Name, nil
 }
 
 // Cleanup removes the translated CAPA identity and referenced secret for the given Cloud Credential.
@@ -73,24 +78,32 @@ func (a *AWSTranslator) Cleanup(ctx context.Context, cl client.Client, credentia
 	identityName := credential.Name
 
 	awsIdentity := awsClusterStaticIdentity(identityName)
-	if err := cl.Delete(ctx, awsIdentity); err != nil && !apierrors.IsNotFound(err) {
+
+	if err := cl.Get(ctx, types.NamespacedName{Name: identityName}, awsIdentity); err == nil {
+		if isObjectOwnedBySecret(awsIdentity, credential) {
+			if err := cl.Delete(ctx, awsIdentity); err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+
+			log.Info("Deleted AWSClusterStaticIdentity", "name", identityName)
+		}
+	} else if !apierrors.IsNotFound(err) {
 		return err
 	}
 
-	log.Info("Deleted AWSClusterStaticIdentity", "name", identityName)
+	credSecret := &corev1.Secret{}
 
-	credSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      identityName,
-			Namespace: a.ProviderNamespace(),
-		},
-	}
+	if err := cl.Get(ctx, types.NamespacedName{Name: identityName, Namespace: a.ProviderNamespace()}, credSecret); err == nil {
+		if isObjectOwnedBySecret(credSecret, credential) {
+			if err := cl.Delete(ctx, credSecret); err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
 
-	if err := cl.Delete(ctx, credSecret); err != nil && !apierrors.IsNotFound(err) {
+			log.Info("Deleted credentials secret", "namespace", a.ProviderNamespace(), "name", identityName)
+		}
+	} else if !apierrors.IsNotFound(err) {
 		return err
 	}
-
-	log.Info("Deleted credentials secret", "namespace", a.ProviderNamespace(), "name", identityName)
 
 	return nil
 }
@@ -120,47 +133,57 @@ func awsClusterStaticIdentity(name string) *unstructured.Unstructured {
 	return obj
 }
 
-// generateCredentialSecret creates or updates the credentials Secret in the CAPA system namespace.
-func generateCredentialSecret(ctx context.Context, cl client.Client, name, accessKeyID, secretAccessKey, providerNs string) error {
+// createOrUpdateCredentialSecret creates or updates the credentials Secret in the CAPA system namespace.
+func createOrUpdateCredentialSecret(ctx context.Context, cl client.Client, sourceSecret *corev1.Secret, accessKey, secretKey, ns string) error {
 	credSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: providerNs,
+			Name:      sourceSecret.Name,
+			Namespace: ns,
 		},
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, cl, credSecret, func() error {
+		if err := verifySecretOwnership(credSecret, sourceSecret); err != nil {
+			return err
+		}
+
 		credSecret.Data = map[string][]byte{
-			"AccessKeyID":     []byte(accessKeyID),
-			"SecretAccessKey": []byte(secretAccessKey),
+			"AccessKeyID":     []byte(accessKey),
+			"SecretAccessKey": []byte(secretKey),
 		}
 
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("creating/updating credentials secret %s/%s: %w", providerNs, name, err)
+		return fmt.Errorf("creating/updating credentials secret %s/%s: %w", ns, sourceSecret.Name, err)
 	}
 
 	return nil
 }
 
-// generateAWSClusterStaticIdentity creates or updates the AWSClusterStaticIdentity referencing
+// createOrUpdateAWSClusterStaticIdentity creates or updates the AWSClusterStaticIdentity referencing
 // the credentials secret.
-func generateAWSClusterStaticIdentity(ctx context.Context, cl client.Client, name string) error {
-	awsIdentity := awsClusterStaticIdentity(name)
+func createOrUpdateAWSClusterStaticIdentity(ctx context.Context, cl client.Client, sourceSecret *corev1.Secret) error {
+	awsIdentity := awsClusterStaticIdentity(sourceSecret.Name)
 
 	identitySpec := map[string]any{
-		"secretRef":         name,
-		"allowedNamespaces": map[string]any{},
+		"secretRef": sourceSecret.Name,
+		"allowedNamespaces": map[string]any{
+			"list": allowedAWSClusterNamespaceList,
+		},
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, cl, awsIdentity, func() error {
+		if err := verifySecretOwnership(awsIdentity, sourceSecret); err != nil {
+			return err
+		}
+
 		awsIdentity.Object["spec"] = identitySpec
 
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("creating/updating AWSClusterStaticIdentity %s: %w", name, err)
+		return fmt.Errorf("creating/updating AWSClusterStaticIdentity %s: %w", sourceSecret.Name, err)
 	}
 
 	return nil

--- a/internal/controllers/aws_translator.go
+++ b/internal/controllers/aws_translator.go
@@ -1,0 +1,167 @@
+/*
+Copyright © 2023 - 2026 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// rancherAWSAccessKeyField is the field name in Rancher Cloud Credential secrets for the AWS access key ID.
+	rancherAWSAccessKeyField = "amazonec2credentialConfig-accessKey"
+
+	// rancherAWSSecretKeyField is the field name in Rancher Cloud Credential secrets for the AWS secret key.
+	//nolint:gosec  // This is not a hardcoded secret, just a key name.
+	rancherAWSSecretKeyField = "amazonec2credentialConfig-secretKey"
+)
+
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclusterstaticidentities,verbs=get;list;watch;create;update;patch;delete
+
+// AWSTranslator implements the Translator interface for AWS credentials.
+type AWSTranslator struct{}
+
+// Translate is the main method for translation Cloud Credentials into CAPA identities.
+func (a *AWSTranslator) Translate(ctx context.Context, cl client.Client, credential *corev1.Secret) (string, error) {
+	accessKeyID := string(credential.Data[rancherAWSAccessKeyField])
+	secretAccessKey := string(credential.Data[rancherAWSSecretKeyField])
+
+	if accessKeyID == "" || secretAccessKey == "" {
+		return "", nil
+	}
+
+	identityName := credential.Name
+
+	if err := generateCredentialSecret(ctx, cl, identityName, accessKeyID, secretAccessKey, a.ProviderNamespace()); err != nil {
+		return "", err
+	}
+
+	if err := generateAWSClusterStaticIdentity(ctx, cl, identityName); err != nil {
+		return "", err
+	}
+
+	return identityName, nil
+}
+
+// Cleanup removes the translated CAPA identity and referenced secret for the given Cloud Credential.
+func (a *AWSTranslator) Cleanup(ctx context.Context, cl client.Client, credential *corev1.Secret) error {
+	log := log.FromContext(ctx)
+
+	identityName := credential.Name
+
+	awsIdentity := awsClusterStaticIdentity(identityName)
+	if err := cl.Delete(ctx, awsIdentity); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	log.Info("Deleted AWSClusterStaticIdentity", "name", identityName)
+
+	credSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      identityName,
+			Namespace: a.ProviderNamespace(),
+		},
+	}
+
+	if err := cl.Delete(ctx, credSecret); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	log.Info("Deleted credentials secret", "namespace", a.ProviderNamespace(), "name", identityName)
+
+	return nil
+}
+
+// DriverName is the name of the provider in the Rancher Cloud Credential Secret.
+func (a *AWSTranslator) DriverName() string { return "aws" }
+
+// ProviderName is the name of the CAPI provider.
+func (a *AWSTranslator) ProviderName() string { return "aws" }
+
+// ProviderNamespace is the namespace where the `CAPIProvider` is installed.
+func (a *AWSTranslator) ProviderNamespace() string { return "capa-system" }
+
+// Finalizer is the finalizer set on the original Rancher Cloud Credential to control garbage collection of translated resources.
+func (a *AWSTranslator) Finalizer() string { return "cloudcredential.cattle.io/aws-identity-finalizer" }
+
+// awsClusterStaticIdentity returns an unstructured AWSClusterStaticIdentity with the given name.
+func awsClusterStaticIdentity(name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "AWSClusterStaticIdentity",
+	})
+	obj.SetName(name)
+
+	return obj
+}
+
+// generateCredentialSecret creates or updates the credentials Secret in the CAPA system namespace.
+func generateCredentialSecret(ctx context.Context, cl client.Client, name, accessKeyID, secretAccessKey, providerNs string) error {
+	credSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: providerNs,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, cl, credSecret, func() error {
+		credSecret.Data = map[string][]byte{
+			"AccessKeyID":     []byte(accessKeyID),
+			"SecretAccessKey": []byte(secretAccessKey),
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("creating/updating credentials secret %s/%s: %w", providerNs, name, err)
+	}
+
+	return nil
+}
+
+// generateAWSClusterStaticIdentity creates or updates the AWSClusterStaticIdentity referencing
+// the credentials secret.
+func generateAWSClusterStaticIdentity(ctx context.Context, cl client.Client, name string) error {
+	awsIdentity := awsClusterStaticIdentity(name)
+
+	identitySpec := map[string]any{
+		"secretRef":         name,
+		"allowedNamespaces": map[string]any{},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, cl, awsIdentity, func() error {
+		awsIdentity.Object["spec"] = identitySpec
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("creating/updating AWSClusterStaticIdentity %s: %w", name, err)
+	}
+
+	return nil
+}

--- a/internal/controllers/credentialtranslation_controller.go
+++ b/internal/controllers/credentialtranslation_controller.go
@@ -1,0 +1,369 @@
+/*
+Copyright © 2023 - 2026 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	turtlesv1 "github.com/rancher/turtles/api/v1alpha1"
+	turtlesannotations "github.com/rancher/turtles/util/annotations"
+)
+
+const (
+	// awsDriverAnnotationValue is the value of the driver annotation that identifies AWS credentials.
+	awsDriverAnnotationValue = "aws"
+
+	// awsRancherCCFinalizer is the finalizer added to Rancher Cloud Credentials to ensure
+	// cleanup of the derived AWSClusterStaticIdentity when the credential is deleted.
+	awsRancherCCFinalizer = "cloudcredential.cattle.io/aws-identity-finalizer"
+
+	// capaProviderSpecName is CAPA's CAPIProvider `spec.name`.
+	capaProviderSpecName = "aws"
+
+	// capaProviderNamespace is the default namespace where CAPA is installed and where the credentials secret will be created.
+	// defaults to `capa-system`.
+	capaProviderNamespace = "capa-system"
+
+	// rancherAWSAccessKeyField is the field name in Rancher Cloud Credential secrets for the AWS access key ID.
+	rancherAWSAccessKeyField = "amazonec2credentialConfig-accessKey"
+
+	// rancherAWSSecretKeyField is the field name in Rancher Cloud Credential secrets for the AWS secret key.
+	//nolint:gosec  // This is not a hardcoded secret, just a key name.
+	rancherAWSSecretKeyField = "amazonec2credentialConfig-secretKey"
+)
+
+// RancherCredentialReconciler reconciles Rancher Cloud Credentials in the cattle-global-data
+// namespace into CAPA-specific AWSClusterStaticIdentity resources. This enables users to reuse
+// Rancher Cloud Credentials when provisioning AWS clusters with CAPI/CAPA.
+type RancherCredentialReconciler struct {
+	Client client.Client
+
+	// CAPASystemNamespace is the namespace where the CAPA controller is installed and where
+	// the credentials secret will be created. Defaults to "capa-system".
+	CAPASystemNamespace string
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *RancherCredentialReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	if r.CAPASystemNamespace == "" {
+		r.CAPASystemNamespace = capaProviderNamespace
+	}
+
+	log := log.FromContext(ctx)
+
+	log.Info("Watching AWS Cloud Credential secrets")
+
+	secretPredicate := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetNamespace() == rancherCredentialsNamespace &&
+			obj.GetAnnotations()[driverNameAnnotation] == awsDriverAnnotationValue
+	})
+
+	capiProviderPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			providerObj, ok := e.Object.(*turtlesv1.CAPIProvider)
+			if !ok {
+				return false
+			}
+
+			return providerObj.Spec.Type == turtlesv1.Infrastructure &&
+				providerObj.Spec.Name == capaProviderSpecName
+		},
+
+		UpdateFunc: func(_ event.UpdateEvent) bool {
+			return false
+		},
+
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return false
+		},
+
+		GenericFunc: func(_ event.GenericEvent) bool {
+			return false
+		},
+	}
+
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named("rancher-credential-translation").
+		WithOptions(options).
+		For(&corev1.Secret{}, builder.WithPredicates(secretPredicate)).
+		Watches(
+			&turtlesv1.CAPIProvider{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueAllMatchingSecrets),
+			builder.WithPredicates(capiProviderPredicate),
+		).
+		Complete(r); err != nil {
+		return fmt.Errorf("creating RancherCredential translation controller: %w", err)
+	}
+
+	return nil
+}
+
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclusterstaticidentities,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile watches Rancher Cloud Credentials for AWS and translates them into
+// AWSClusterStaticIdentity resources for use with CAPA.
+func (r *RancherCredentialReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	credential := &corev1.Secret{}
+	if err := r.Client.Get(ctx, req.NamespacedName, credential); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// verify that the CAPA CAPIProvider is available and ready
+	var provider turtlesv1.CAPIProvider
+
+	err := r.Client.Get(ctx, types.NamespacedName{
+		Name:      capaProviderSpecName,
+		Namespace: capaProviderNamespace,
+	}, &provider)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, err
+	}
+
+	if provider.Status.Phase != turtlesv1.Ready {
+		return ctrl.Result{RequeueAfter: defaultRequeueDuration}, nil
+	}
+
+	if err := r.Client.Get(ctx, req.NamespacedName, credential); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if credential.GetAnnotations()[driverNameAnnotation] != awsDriverAnnotationValue {
+		return ctrl.Result{}, nil
+	}
+
+	if !credential.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, credential)
+	}
+
+	return r.reconcileNormal(ctx, credential)
+}
+
+// reconcileNormal handles creation and updates of the AWSClusterStaticIdentity for a given
+// Rancher Cloud Credential.
+func (r *RancherCredentialReconciler) reconcileNormal(ctx context.Context, credential *corev1.Secret) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+
+	log.Info("Reconciling AWS Cloud Credentials to CAPA translation", "credential", client.ObjectKeyFromObject(credential))
+
+	// add finalizer to the credential so we can clean up derived resources on deletion.
+	if !controllerutil.ContainsFinalizer(credential, awsRancherCCFinalizer) {
+		patch := client.MergeFrom(credential.DeepCopy())
+		controllerutil.AddFinalizer(credential, awsRancherCCFinalizer)
+
+		if err := r.Client.Patch(ctx, credential, patch); err != nil {
+			return ctrl.Result{}, fmt.Errorf("adding finalizer to credential %s: %w", client.ObjectKeyFromObject(credential), err)
+		}
+
+		log.Info("Added finalizer to AWS credential", "credential", client.ObjectKeyFromObject(credential))
+	}
+
+	accessKeyID := string(credential.Data[rancherAWSAccessKeyField])
+	secretAccessKey := string(credential.Data[rancherAWSSecretKeyField])
+
+	if accessKeyID == "" || secretAccessKey == "" {
+		log.Info("AWS credential secret is missing required keys, skipping",
+			"credential", client.ObjectKeyFromObject(credential),
+			"missingKeys", fmt.Sprintf("%s or %s", rancherAWSAccessKeyField, rancherAWSSecretKeyField))
+
+		return ctrl.Result{}, nil
+	}
+
+	identityName := credential.Name
+
+	if err := r.reconcileCredentialSecret(ctx, identityName, accessKeyID, secretAccessKey); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if err := r.reconcileAWSClusterStaticIdentity(ctx, identityName); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// annotate the original Rancher credential with a reference to the AWSClusterStaticIdentity.
+	if credential.GetAnnotations()[turtlesannotations.AWSClusterStaticIdentityRefAnnotation] != identityName {
+		patch := client.MergeFrom(credential.DeepCopy())
+
+		annotations := credential.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+
+		annotations[turtlesannotations.AWSClusterStaticIdentityRefAnnotation] = identityName
+		credential.SetAnnotations(annotations)
+
+		if err := r.Client.Patch(ctx, credential, patch); err != nil {
+			return ctrl.Result{}, fmt.Errorf("annotating credential %s with identity reference: %w", client.ObjectKeyFromObject(credential), err)
+		}
+
+		log.Info("Annotated AWS credential with AWSClusterStaticIdentity reference",
+			"credential", client.ObjectKeyFromObject(credential),
+			"identity", identityName)
+	}
+
+	log.Info("Successfully reconciled AWS credential translation",
+		"credential", client.ObjectKeyFromObject(credential),
+		"identity", identityName)
+
+	return ctrl.Result{}, nil
+}
+
+// reconcileDelete cleans up the AWSClusterStaticIdentity and its credentials secret when
+// the Rancher Cloud Credential is deleted.
+func (r *RancherCredentialReconciler) reconcileDelete(ctx context.Context, credential *corev1.Secret) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+
+	if !controllerutil.ContainsFinalizer(credential, awsRancherCCFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	identityName := credential.Name
+
+	awsIdentity := r.awsClusterStaticIdentity(identityName)
+	if err := r.Client.Delete(ctx, awsIdentity); err != nil && !apierrors.IsNotFound(err) {
+		return ctrl.Result{}, fmt.Errorf("deleting AWSClusterStaticIdentity %s: %w", identityName, err)
+	}
+
+	log.Info("Deleted AWSClusterStaticIdentity", "name", identityName)
+
+	credSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      identityName,
+			Namespace: r.CAPASystemNamespace,
+		},
+	}
+
+	if err := r.Client.Delete(ctx, credSecret); err != nil && !apierrors.IsNotFound(err) {
+		return ctrl.Result{}, fmt.Errorf("deleting credentials secret %s/%s: %w", r.CAPASystemNamespace, identityName, err)
+	}
+
+	log.Info("Deleted credentials secret", "namespace", r.CAPASystemNamespace, "name", identityName)
+
+	// Remove the finalizer so the credential can be garbage-collected.
+	patch := client.MergeFrom(credential.DeepCopy())
+	controllerutil.RemoveFinalizer(credential, awsRancherCCFinalizer)
+
+	if err := r.Client.Patch(ctx, credential, patch); err != nil {
+		return ctrl.Result{}, fmt.Errorf("removing finalizer from credential %s: %w", client.ObjectKeyFromObject(credential), err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// reconcileCredentialSecret creates or updates the credentials Secret in the CAPA system namespace.
+func (r *RancherCredentialReconciler) reconcileCredentialSecret(ctx context.Context, name, accessKeyID, secretAccessKey string) error {
+	credSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: r.CAPASystemNamespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, credSecret, func() error {
+		credSecret.Data = map[string][]byte{
+			"AccessKeyID":     []byte(accessKeyID),
+			"SecretAccessKey": []byte(secretAccessKey),
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("creating/updating credentials secret %s/%s: %w", r.CAPASystemNamespace, name, err)
+	}
+
+	return nil
+}
+
+// reconcileAWSClusterStaticIdentity creates or updates the AWSClusterStaticIdentity referencing
+// the credentials secret.
+func (r *RancherCredentialReconciler) reconcileAWSClusterStaticIdentity(ctx context.Context, name string) error {
+	awsIdentity := r.awsClusterStaticIdentity(name)
+
+	identitySpec := map[string]any{
+		"secretRef":         name,
+		"allowedNamespaces": map[string]any{},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, awsIdentity, func() error {
+		awsIdentity.Object["spec"] = identitySpec
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("creating/updating AWSClusterStaticIdentity %s: %w", name, err)
+	}
+
+	return nil
+}
+
+// enqueueAllMatchingSecrets runs when CAPA is installed and the `CAPIProvider` is ready.
+func (r *RancherCredentialReconciler) enqueueAllMatchingSecrets(ctx context.Context, _ client.Object) []ctrl.Request {
+	var secretList corev1.SecretList
+
+	err := r.Client.List(ctx, &secretList, client.InNamespace(rancherCredentialsNamespace))
+	if err != nil {
+		return nil
+	}
+
+	var requests []ctrl.Request
+
+	for _, secret := range secretList.Items {
+		if secret.GetAnnotations()[driverNameAnnotation] == awsDriverAnnotationValue {
+			requests = append(requests, ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      secret.Name,
+					Namespace: secret.Namespace,
+				},
+			})
+		}
+	}
+
+	return requests
+}
+
+// awsClusterStaticIdentity returns an unstructured AWSClusterStaticIdentity with the given name.
+func (r *RancherCredentialReconciler) awsClusterStaticIdentity(name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: "v1beta2",
+		Kind:    "AWSClusterStaticIdentity",
+	})
+	obj.SetName(name)
+
+	return obj
+}

--- a/internal/controllers/credentialtranslation_controller.go
+++ b/internal/controllers/credentialtranslation_controller.go
@@ -22,9 +22,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -40,64 +37,65 @@ import (
 	turtlesannotations "github.com/rancher/turtles/util/annotations"
 )
 
-const (
-	// awsDriverAnnotationValue is the value of the driver annotation that identifies AWS credentials.
-	awsDriverAnnotationValue = "aws"
+// CredentialTranslator defines the interface for cloud-specific translation logic.
+type CredentialTranslator interface {
+	// DriverName returns the Rancher driver annotation value (e.g. "aws", "azure").
+	DriverName() string
+	// ProviderName returns the CAPA/CAPZ CAPIProvider spec name (e.g. "aws", "azure").
+	ProviderName() string
+	// ProviderNamespace returns the namespace where the CAPIProvider is installed (e.g. "capa-system").
+	ProviderNamespace() string
+	// Finalizer returns the specific finalizer to attach to the Rancher Secret.
+	Finalizer() string
 
-	// awsRancherCCFinalizer is the finalizer added to Rancher Cloud Credentials to ensure
-	// cleanup of the derived AWSClusterStaticIdentity when the credential is deleted.
-	awsRancherCCFinalizer = "cloudcredential.cattle.io/aws-identity-finalizer"
+	// Translate handles creating/updating the CAPI-specific identity resources.
+	// It returns the name of the identity resource created so the core controller can annotate the secret.
+	Translate(ctx context.Context, cl client.Client, credential *corev1.Secret) (string, error)
 
-	// capaProviderSpecName is CAPA's CAPIProvider `spec.name`.
-	capaProviderSpecName = "aws"
-
-	// capaProviderNamespace is the default namespace where CAPA is installed and where the credentials secret will be created.
-	// defaults to `capa-system`.
-	capaProviderNamespace = "capa-system"
-
-	// rancherAWSAccessKeyField is the field name in Rancher Cloud Credential secrets for the AWS access key ID.
-	rancherAWSAccessKeyField = "amazonec2credentialConfig-accessKey"
-
-	// rancherAWSSecretKeyField is the field name in Rancher Cloud Credential secrets for the AWS secret key.
-	//nolint:gosec  // This is not a hardcoded secret, just a key name.
-	rancherAWSSecretKeyField = "amazonec2credentialConfig-secretKey"
-)
+	// Cleanup removes the CAPI-specific identity resources when the Rancher secret is deleted.
+	Cleanup(ctx context.Context, cl client.Client, credential *corev1.Secret) error
+}
 
 // RancherCredentialReconciler reconciles Rancher Cloud Credentials in the cattle-global-data
-// namespace into CAPA-specific AWSClusterStaticIdentity resources. This enables users to reuse
-// Rancher Cloud Credentials when provisioning AWS clusters with CAPI/CAPA.
+// namespace into CAPI-specific identity resources. This enables users to reuse
+// Rancher Cloud Credentials when provisioning.
 type RancherCredentialReconciler struct {
 	Client client.Client
-
-	// CAPASystemNamespace is the namespace where the CAPA controller is installed and where
-	// the credentials secret will be created. Defaults to "capa-system".
-	CAPASystemNamespace string
+	// Translators holds provider-specific logic referenced by driver name (e.g. "aws" -> AWSTranslator)
+	Translators map[string]CredentialTranslator
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *RancherCredentialReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
-	if r.CAPASystemNamespace == "" {
-		r.CAPASystemNamespace = capaProviderNamespace
-	}
-
 	log := log.FromContext(ctx)
 
-	log.Info("Watching AWS Cloud Credential secrets")
+	log.Info("Watching Rancher Cloud Credential secrets")
 
 	secretPredicate := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		return obj.GetNamespace() == rancherCredentialsNamespace &&
-			obj.GetAnnotations()[driverNameAnnotation] == awsDriverAnnotationValue
+		if obj.GetNamespace() != rancherCredentialsNamespace {
+			return false
+		}
+
+		driver := obj.GetAnnotations()[driverNameAnnotation]
+		_, supported := r.Translators[driver]
+
+		return supported
 	})
 
 	capiProviderPredicate := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			providerObj, ok := e.Object.(*turtlesv1.CAPIProvider)
-			if !ok {
+			if !ok || providerObj.Spec.Type != turtlesv1.Infrastructure {
 				return false
 			}
 
-			return providerObj.Spec.Type == turtlesv1.Infrastructure &&
-				providerObj.Spec.Name == capaProviderSpecName
+			for _, t := range r.Translators {
+				if providerObj.Spec.Name == t.ProviderName() {
+					return true
+				}
+			}
+
+			return false
 		},
 
 		UpdateFunc: func(_ event.UpdateEvent) bool {
@@ -130,22 +128,30 @@ func (r *RancherCredentialReconciler) SetupWithManager(ctx context.Context, mgr 
 }
 
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
-//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclusterstaticidentities,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile watches Rancher Cloud Credentials for AWS and translates them into
 // AWSClusterStaticIdentity resources for use with CAPA.
 func (r *RancherCredentialReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+
 	credential := &corev1.Secret{}
 	if err := r.Client.Get(ctx, req.NamespacedName, credential); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	driverName := credential.GetAnnotations()[driverNameAnnotation]
+
+	translator, supported := r.Translators[driverName]
+	if !supported {
+		return ctrl.Result{}, nil
 	}
 
 	// verify that the CAPA CAPIProvider is available and ready
 	var provider turtlesv1.CAPIProvider
 
 	err := r.Client.Get(ctx, types.NamespacedName{
-		Name:      capaProviderSpecName,
-		Namespace: capaProviderNamespace,
+		Name:      translator.ProviderName(),
+		Namespace: translator.ProviderNamespace(),
 	}, &provider)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -156,66 +162,46 @@ func (r *RancherCredentialReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	if provider.Status.Phase != turtlesv1.Ready {
+		log.Info("CAPIProvider is installed but not Ready.", "provider", translator.ProviderName(), "namespace", translator.ProviderNamespace())
 		return ctrl.Result{RequeueAfter: defaultRequeueDuration}, nil
 	}
 
-	if err := r.Client.Get(ctx, req.NamespacedName, credential); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-
-	if credential.GetAnnotations()[driverNameAnnotation] != awsDriverAnnotationValue {
-		return ctrl.Result{}, nil
-	}
-
 	if !credential.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, credential)
+		log.Info("Rancher Cloud Credential is marked for deletion, reconciling delete", "credential", client.ObjectKeyFromObject(credential))
+		return r.reconcileDelete(ctx, credential, translator)
 	}
 
-	return r.reconcileNormal(ctx, credential)
+	return r.reconcileNormal(ctx, credential, translator)
 }
 
 // reconcileNormal handles creation and updates of the AWSClusterStaticIdentity for a given
 // Rancher Cloud Credential.
-func (r *RancherCredentialReconciler) reconcileNormal(ctx context.Context, credential *corev1.Secret) (ctrl.Result, error) {
+func (r *RancherCredentialReconciler) reconcileNormal(ctx context.Context, credential *corev1.Secret, t CredentialTranslator) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 
-	log.Info("Reconciling AWS Cloud Credentials to CAPA translation", "credential", client.ObjectKeyFromObject(credential))
+	log.Info("Reconciling Cloud Credentials to CAPI translation", "credential", client.ObjectKeyFromObject(credential))
 
-	// add finalizer to the credential so we can clean up derived resources on deletion.
-	if !controllerutil.ContainsFinalizer(credential, awsRancherCCFinalizer) {
+	// add finalizer so we can cleanup resources on deletion.
+	if !controllerutil.ContainsFinalizer(credential, t.Finalizer()) {
 		patch := client.MergeFrom(credential.DeepCopy())
-		controllerutil.AddFinalizer(credential, awsRancherCCFinalizer)
+		controllerutil.AddFinalizer(credential, t.Finalizer())
 
 		if err := r.Client.Patch(ctx, credential, patch); err != nil {
 			return ctrl.Result{}, fmt.Errorf("adding finalizer to credential %s: %w", client.ObjectKeyFromObject(credential), err)
 		}
-
-		log.Info("Added finalizer to AWS credential", "credential", client.ObjectKeyFromObject(credential))
 	}
 
-	accessKeyID := string(credential.Data[rancherAWSAccessKeyField])
-	secretAccessKey := string(credential.Data[rancherAWSSecretKeyField])
+	identityName, err := t.Translate(ctx, r.Client, credential)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
-	if accessKeyID == "" || secretAccessKey == "" {
-		log.Info("AWS credential secret is missing required keys, skipping",
-			"credential", client.ObjectKeyFromObject(credential),
-			"missingKeys", fmt.Sprintf("%s or %s", rancherAWSAccessKeyField, rancherAWSSecretKeyField))
-
+	if identityName == "" {
 		return ctrl.Result{}, nil
 	}
 
-	identityName := credential.Name
-
-	if err := r.reconcileCredentialSecret(ctx, identityName, accessKeyID, secretAccessKey); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if err := r.reconcileAWSClusterStaticIdentity(ctx, identityName); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	// annotate the original Rancher credential with a reference to the AWSClusterStaticIdentity.
-	if credential.GetAnnotations()[turtlesannotations.AWSClusterStaticIdentityRefAnnotation] != identityName {
+	// annotate the original Rancher credential with a reference to the CAPI identity translated object.
+	if credential.GetAnnotations()[turtlesannotations.CAPIIdentityRefAnnotation] != identityName {
 		patch := client.MergeFrom(credential.DeepCopy())
 
 		annotations := credential.GetAnnotations()
@@ -223,59 +209,32 @@ func (r *RancherCredentialReconciler) reconcileNormal(ctx context.Context, crede
 			annotations = map[string]string{}
 		}
 
-		annotations[turtlesannotations.AWSClusterStaticIdentityRefAnnotation] = identityName
+		annotations[turtlesannotations.CAPIIdentityRefAnnotation] = identityName
 		credential.SetAnnotations(annotations)
 
 		if err := r.Client.Patch(ctx, credential, patch); err != nil {
 			return ctrl.Result{}, fmt.Errorf("annotating credential %s with identity reference: %w", client.ObjectKeyFromObject(credential), err)
 		}
-
-		log.Info("Annotated AWS credential with AWSClusterStaticIdentity reference",
-			"credential", client.ObjectKeyFromObject(credential),
-			"identity", identityName)
 	}
-
-	log.Info("Successfully reconciled AWS credential translation",
-		"credential", client.ObjectKeyFromObject(credential),
-		"identity", identityName)
 
 	return ctrl.Result{}, nil
 }
 
-// reconcileDelete cleans up the AWSClusterStaticIdentity and its credentials secret when
+// reconcileDelete cleans up the CAPI identity and its credentials secret when
 // the Rancher Cloud Credential is deleted.
-func (r *RancherCredentialReconciler) reconcileDelete(ctx context.Context, credential *corev1.Secret) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
-
-	if !controllerutil.ContainsFinalizer(credential, awsRancherCCFinalizer) {
+func (r *RancherCredentialReconciler) reconcileDelete(ctx context.Context, credential *corev1.Secret, t CredentialTranslator) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(credential, t.Finalizer()) {
 		return ctrl.Result{}, nil
 	}
 
-	identityName := credential.Name
-
-	awsIdentity := r.awsClusterStaticIdentity(identityName)
-	if err := r.Client.Delete(ctx, awsIdentity); err != nil && !apierrors.IsNotFound(err) {
-		return ctrl.Result{}, fmt.Errorf("deleting AWSClusterStaticIdentity %s: %w", identityName, err)
+	// first removed the CAPI identity objects
+	if err := t.Cleanup(ctx, r.Client, credential); err != nil {
+		return ctrl.Result{}, err
 	}
 
-	log.Info("Deleted AWSClusterStaticIdentity", "name", identityName)
-
-	credSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      identityName,
-			Namespace: r.CAPASystemNamespace,
-		},
-	}
-
-	if err := r.Client.Delete(ctx, credSecret); err != nil && !apierrors.IsNotFound(err) {
-		return ctrl.Result{}, fmt.Errorf("deleting credentials secret %s/%s: %w", r.CAPASystemNamespace, identityName, err)
-	}
-
-	log.Info("Deleted credentials secret", "namespace", r.CAPASystemNamespace, "name", identityName)
-
-	// Remove the finalizer so the credential can be garbage-collected.
+	// remove the finalizer so the original cloud credential can be garbage-collected.
 	patch := client.MergeFrom(credential.DeepCopy())
-	controllerutil.RemoveFinalizer(credential, awsRancherCCFinalizer)
+	controllerutil.RemoveFinalizer(credential, t.Finalizer())
 
 	if err := r.Client.Patch(ctx, credential, patch); err != nil {
 		return ctrl.Result{}, fmt.Errorf("removing finalizer from credential %s: %w", client.ObjectKeyFromObject(credential), err)
@@ -284,54 +243,27 @@ func (r *RancherCredentialReconciler) reconcileDelete(ctx context.Context, crede
 	return ctrl.Result{}, nil
 }
 
-// reconcileCredentialSecret creates or updates the credentials Secret in the CAPA system namespace.
-func (r *RancherCredentialReconciler) reconcileCredentialSecret(ctx context.Context, name, accessKeyID, secretAccessKey string) error {
-	credSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: r.CAPASystemNamespace,
-		},
+// enqueueAllMatchingSecrets runs when `CAPIProvider` is installed and ready.
+func (r *RancherCredentialReconciler) enqueueAllMatchingSecrets(ctx context.Context, obj client.Object) []ctrl.Request {
+	provider, ok := obj.(*turtlesv1.CAPIProvider)
+	if !ok {
+		return nil
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, credSecret, func() error {
-		credSecret.Data = map[string][]byte{
-			"AccessKeyID":     []byte(accessKeyID),
-			"SecretAccessKey": []byte(secretAccessKey),
+	var targetProvider string
+
+	for _, t := range r.Translators {
+		if t.ProviderName() == provider.Spec.Name {
+			targetProvider = t.DriverName()
+			break
 		}
+	}
 
+	if targetProvider == "" {
 		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("creating/updating credentials secret %s/%s: %w", r.CAPASystemNamespace, name, err)
 	}
 
-	return nil
-}
-
-// reconcileAWSClusterStaticIdentity creates or updates the AWSClusterStaticIdentity referencing
-// the credentials secret.
-func (r *RancherCredentialReconciler) reconcileAWSClusterStaticIdentity(ctx context.Context, name string) error {
-	awsIdentity := r.awsClusterStaticIdentity(name)
-
-	identitySpec := map[string]any{
-		"secretRef":         name,
-		"allowedNamespaces": map[string]any{},
-	}
-
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, awsIdentity, func() error {
-		awsIdentity.Object["spec"] = identitySpec
-
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("creating/updating AWSClusterStaticIdentity %s: %w", name, err)
-	}
-
-	return nil
-}
-
-// enqueueAllMatchingSecrets runs when CAPA is installed and the `CAPIProvider` is ready.
-func (r *RancherCredentialReconciler) enqueueAllMatchingSecrets(ctx context.Context, _ client.Object) []ctrl.Request {
+	// List and enqueue only secrets for this specific provider
 	var secretList corev1.SecretList
 
 	err := r.Client.List(ctx, &secretList, client.InNamespace(rancherCredentialsNamespace))
@@ -342,28 +274,12 @@ func (r *RancherCredentialReconciler) enqueueAllMatchingSecrets(ctx context.Cont
 	var requests []ctrl.Request
 
 	for _, secret := range secretList.Items {
-		if secret.GetAnnotations()[driverNameAnnotation] == awsDriverAnnotationValue {
+		if secret.GetAnnotations()[driverNameAnnotation] == targetProvider {
 			requests = append(requests, ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      secret.Name,
-					Namespace: secret.Namespace,
-				},
+				NamespacedName: client.ObjectKeyFromObject(&secret),
 			})
 		}
 	}
 
 	return requests
-}
-
-// awsClusterStaticIdentity returns an unstructured AWSClusterStaticIdentity with the given name.
-func (r *RancherCredentialReconciler) awsClusterStaticIdentity(name string) *unstructured.Unstructured {
-	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "infrastructure.cluster.x-k8s.io",
-		Version: "v1beta2",
-		Kind:    "AWSClusterStaticIdentity",
-	})
-	obj.SetName(name)
-
-	return obj
 }

--- a/internal/controllers/credentialtranslation_controller_test.go
+++ b/internal/controllers/credentialtranslation_controller_test.go
@@ -45,6 +45,8 @@ var _ = Describe("Rancher Cloud Credentials Translation", func() {
 		rancherAWSSecret            *corev1.Secret
 		rancherAzureSecret          *corev1.Secret
 		translatedSecret            *corev1.Secret
+		existingSecret              *corev1.Secret
+		capaNs                      *corev1.Namespace
 		translatedIdentity          *unstructured.Unstructured
 	)
 
@@ -77,7 +79,20 @@ var _ = Describe("Rancher Cloud Credentials Translation", func() {
 									"spec": {
 										Type: "object",
 										Properties: map[string]apiextensionsv1.JSONSchemaProps{
-											"secretName": {Type: "string"},
+											"secretRef": {Type: "string"},
+											"allowedNamespaces": {
+												Type: "object",
+												Properties: map[string]apiextensionsv1.JSONSchemaProps{
+													"list": {
+														Type: "array",
+														Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+															Schema: &apiextensionsv1.JSONSchemaProps{
+																Type: "string",
+															},
+														},
+													},
+												},
+											},
 										},
 									},
 								},
@@ -107,7 +122,7 @@ var _ = Describe("Rancher Cloud Credentials Translation", func() {
 			Expect(testEnv.Create(ctx, globalDataNs)).ToNot(HaveOccurred())
 		}
 
-		capaNs := &corev1.Namespace{
+		capaNs = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: r.Translators["aws"].ProviderNamespace(),
 			},
@@ -160,6 +175,16 @@ var _ = Describe("Rancher Cloud Credentials Translation", func() {
 			},
 		}
 
+		existingSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rancherAWSSecret.GetName(),
+				Namespace: capaNs.Name,
+			},
+			StringData: map[string]string{
+				"testData": "test-unchanged-data",
+			},
+		}
+
 		translatedIdentity = &unstructured.Unstructured{}
 		translatedIdentity.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   "infrastructure.cluster.x-k8s.io",
@@ -195,6 +220,7 @@ var _ = Describe("Rancher Cloud Credentials Translation", func() {
 			capaProvider,
 			rancherAWSSecret,
 			translatedSecret,
+			existingSecret,
 			translatedIdentity,
 		}
 		Expect(test.CleanupAndWait(ctx, cl, clientObjs...)).To(Succeed())
@@ -223,13 +249,35 @@ var _ = Describe("Rancher Cloud Credentials Translation", func() {
 				Name: rancherAWSSecret.GetName(),
 			}, translatedIdentity)).ToNot(HaveOccurred())
 
+			g.Expect(translatedIdentity.GetAnnotations()).To(HaveKeyWithValue(
+				cloudCredentialSecretAnnotation, string(rancherAWSSecret.UID)))
+
+			secretRef, found, err := unstructured.NestedString(translatedIdentity.Object, "spec", "secretRef")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(found).To(BeTrue(), "secretRef field should exist")
+
+			g.Expect(secretRef).To(Equal(rancherAWSSecret.GetName()))
+
+			allowedNs, found, err := unstructured.NestedMap(translatedIdentity.Object, "spec", "allowedNamespaces")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(found).To(BeTrue(), "allowedNamespaces field should exist")
+
+			Expect(allowedNs).To(HaveKeyWithValue(
+				"list",
+				ContainElement("fleet-default"),
+			))
+
 			g.Expect(cl.Get(ctx, types.NamespacedName{
 				Name:      rancherAWSSecret.GetName(),
 				Namespace: r.Translators["aws"].ProviderNamespace(),
 			}, translatedSecret)).ToNot(HaveOccurred())
 
-			g.Expect(translatedSecret.Data).To(HaveKeyWithValue("AccessKeyID", rancherAWSSecret.Data[rancherAWSAccessKeyField]))
-			g.Expect(translatedSecret.Data).To(HaveKeyWithValue("SecretAccessKey", rancherAWSSecret.Data[rancherAWSSecretKeyField]))
+			g.Expect(translatedSecret.Data).To(HaveKeyWithValue(
+				"AccessKeyID", rancherAWSSecret.Data[rancherAWSAccessKeyField]))
+			g.Expect(translatedSecret.Data).To(HaveKeyWithValue(
+				"SecretAccessKey", rancherAWSSecret.Data[rancherAWSSecretKeyField]))
+			g.Expect(translatedSecret.GetAnnotations()).To(HaveKeyWithValue(
+				cloudCredentialSecretAnnotation, string(rancherAWSSecret.UID)))
 
 			updatedRancherSecret := &corev1.Secret{}
 			g.Expect(cl.Get(ctx, types.NamespacedName{
@@ -290,6 +338,61 @@ var _ = Describe("Rancher Cloud Credentials Translation", func() {
 				Name:      rancherAWSSecret.GetName(),
 				Namespace: r.Translators["aws"].ProviderNamespace(),
 			}, translatedSecret))).To(BeTrue())
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+	})
+
+	It("Should not delete existing secret when a collision is detected and Rancher Cloud Credential is removed", func() {
+		Expect(cl.Create(ctx, provider)).ToNot(HaveOccurred())
+		patchBase := client.MergeFrom(provider.DeepCopy())
+		provider.Status = turtlesv1.CAPIProviderStatus{
+			Phase: turtlesv1.Ready,
+		}
+
+		err := cl.Status().Patch(ctx, provider, patchBase)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(cl.Create(ctx, existingSecret)).ToNot(HaveOccurred())
+
+		Eventually(ctx, func(g Gomega) {
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: rancherAWSSecret.Namespace,
+					Name:      rancherAWSSecret.Name,
+				},
+			})
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring("collision detected"))
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+
+		err = cl.Delete(ctx, rancherAWSSecret)
+		Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+
+		Eventually(ctx, func(g Gomega) {
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: rancherAWSSecret.Namespace,
+					Name:      rancherAWSSecret.Name,
+				},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			updatedRancherSecret := &corev1.Secret{}
+
+			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
+				Namespace: rancherAWSSecret.Namespace,
+				Name:      rancherAWSSecret.Name,
+			}, updatedRancherSecret))).To(BeTrue())
+
+			updatedExistingSecret := &corev1.Secret{}
+
+			g.Expect(cl.Get(ctx, types.NamespacedName{
+				Name:      existingSecret.GetName(),
+				Namespace: existingSecret.GetNamespace(),
+			}, updatedExistingSecret)).ToNot(HaveOccurred())
+			g.Expect(updatedExistingSecret.Data).To(HaveKeyWithValue(
+				"testData", []byte("test-unchanged-data")))
+
+			g.Expect(updatedExistingSecret.GetAnnotations()).ToNot(HaveKey(cloudCredentialSecretAnnotation))
 		}).WithTimeout(10 * time.Second).Should(Succeed())
 	})
 
@@ -369,6 +472,46 @@ var _ = Describe("Rancher Cloud Credentials Translation", func() {
 				"AccessKeyID", updatedRancherSecret.Data[rancherAWSAccessKeyField]))
 			g.Expect(translatedSecret.Data).To(HaveKeyWithValue(
 				"SecretAccessKey", updatedRancherSecret.Data[rancherAWSSecretKeyField]))
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+	})
+
+	It("Should not translate Rancher Cloud Credential secret when a collision is detected (a secret with the same name already exists)", func() {
+		Expect(cl.Create(ctx, provider)).ToNot(HaveOccurred())
+		patchBase := client.MergeFrom(provider.DeepCopy())
+		provider.Status = turtlesv1.CAPIProviderStatus{
+			Phase: turtlesv1.Ready,
+		}
+
+		err := cl.Status().Patch(ctx, provider, patchBase)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(cl.Create(ctx, existingSecret)).ToNot(HaveOccurred())
+
+		Eventually(ctx, func(g Gomega) {
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: rancherAWSSecret.Namespace,
+					Name:      rancherAWSSecret.Name,
+				},
+			})
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring("collision detected"))
+
+			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
+				Name: rancherAWSSecret.GetName(),
+			}, translatedIdentity))).To(BeTrue())
+
+			updatedExistingSecret := &corev1.Secret{}
+
+			g.Expect(cl.Get(ctx, types.NamespacedName{
+				Name:      existingSecret.GetName(),
+				Namespace: existingSecret.GetNamespace(),
+			}, updatedExistingSecret)).ToNot(HaveOccurred())
+
+			g.Expect(updatedExistingSecret.Data).To(HaveKeyWithValue(
+				"testData", []byte("test-unchanged-data")))
+
+			g.Expect(updatedExistingSecret.GetAnnotations()).ToNot(HaveKey(cloudCredentialSecretAnnotation))
 		}).WithTimeout(10 * time.Second).Should(Succeed())
 	})
 

--- a/internal/controllers/credentialtranslation_controller_test.go
+++ b/internal/controllers/credentialtranslation_controller_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	turtlesv1 "github.com/rancher/turtles/api/v1alpha1"
 	"github.com/rancher/turtles/internal/test"
+	turtlesannotations "github.com/rancher/turtles/util/annotations"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,12 +37,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-var _ = Describe("Credential Translation", func() {
+var _ = Describe("Rancher Cloud Credentials Translation", func() {
 	var (
 		r                           *RancherCredentialReconciler
 		awsClusterStaticIdentityCRD *apiextensionsv1.CustomResourceDefinition
 		provider                    *turtlesv1.CAPIProvider
-		rancherSecret               *corev1.Secret
+		rancherAWSSecret            *corev1.Secret
+		rancherAzureSecret          *corev1.Secret
 		translatedSecret            *corev1.Secret
 		translatedIdentity          *unstructured.Unstructured
 	)
@@ -51,8 +53,10 @@ var _ = Describe("Credential Translation", func() {
 		SetContext(ctx)
 
 		r = &RancherCredentialReconciler{
-			Client:              cl,
-			CAPASystemNamespace: capaProviderNamespace,
+			Client: cl,
+			Translators: map[string]CredentialTranslator{
+				"aws": &AWSTranslator{},
+			},
 		}
 
 		awsClusterStaticIdentityCRD = &apiextensionsv1.CustomResourceDefinition{
@@ -105,7 +109,7 @@ var _ = Describe("Credential Translation", func() {
 
 		capaNs := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: capaProviderNamespace,
+				Name: r.Translators["aws"].ProviderNamespace(),
 			},
 		}
 		if apierrors.IsNotFound(testEnv.Get(ctx, client.ObjectKeyFromObject(capaNs), &corev1.Namespace{})) {
@@ -114,7 +118,7 @@ var _ = Describe("Credential Translation", func() {
 
 		provider = &turtlesv1.CAPIProvider{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      capaProviderSpecName,
+				Name:      r.Translators["aws"].ProviderName(),
 				Namespace: capaNs.Name,
 			},
 			Spec: turtlesv1.CAPIProviderSpec{
@@ -122,9 +126,28 @@ var _ = Describe("Credential Translation", func() {
 			},
 		}
 
-		rancherSecret = &corev1.Secret{
+		rancherAWSSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:         "cctest",
+				GenerateName: "cc-",
+				Namespace:    rancherCredentialsNamespace,
+				Annotations: map[string]string{
+					"field.cattle.io/name": "aws-cred",
+					driverNameAnnotation:   "aws",
+				},
+			},
+			StringData: map[string]string{
+				rancherAWSAccessKeyField: "access-key",
+				rancherAWSSecretKeyField: "secret-key",
+			},
+		}
+		if apierrors.IsNotFound(testEnv.Get(ctx, client.ObjectKeyFromObject(rancherAWSSecret), &corev1.Secret{})) {
+			Expect(testEnv.Create(ctx, rancherAWSSecret)).ToNot(HaveOccurred())
+		}
+
+		rancherAzureSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:         "cctest-azure",
 				GenerateName: "cc-",
 				Namespace:    rancherCredentialsNamespace,
 			},
@@ -132,7 +155,7 @@ var _ = Describe("Credential Translation", func() {
 
 		translatedSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      rancherSecret.GetName(),
+				Name:      rancherAWSSecret.GetName(),
 				Namespace: capaNs.Name,
 			},
 		}
@@ -148,11 +171,12 @@ var _ = Describe("Credential Translation", func() {
 	AfterEach(func() {
 		capaProvider := &turtlesv1.CAPIProvider{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      capaProviderSpecName,
-				Namespace: capaProviderNamespace,
+				Name:      r.Translators["aws"].ProviderName(),
+				Namespace: r.Translators["aws"].ProviderNamespace(),
 			},
 		}
 
+		// NOTE: deleting `CAPIProvider` occasionally causes flakes.
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			if err := cl.Get(ctx, client.ObjectKeyFromObject(capaProvider), capaProvider); err != nil {
 				return client.IgnoreNotFound(err)
@@ -168,7 +192,8 @@ var _ = Describe("Credential Translation", func() {
 		Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
 
 		clientObjs := []client.Object{
-			rancherSecret,
+			capaProvider,
+			rancherAWSSecret,
 			translatedSecret,
 			translatedIdentity,
 		}
@@ -185,64 +210,184 @@ var _ = Describe("Credential Translation", func() {
 		err := cl.Status().Patch(ctx, provider, patchBase)
 		Expect(err).NotTo(HaveOccurred())
 
-		rancherSecret.Annotations = map[string]string{
-			"field.cattle.io/name": "aws-cred",
-			driverNameAnnotation:   "aws",
-		}
-		rancherSecret.StringData = map[string]string{
-			"amazonec2credentialConfig-accessKey":     "access-key",
-			"amazonec2credentialConfig-secretKey":     "secret-key",
-			"amazonec2credentialConfig-defaultRegion": "us-east-1",
-		}
-		Expect(cl.Create(ctx, rancherSecret)).ToNot(HaveOccurred())
-
 		Eventually(ctx, func(g Gomega) {
 			_, err := r.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Namespace: rancherSecret.Namespace,
-					Name:      rancherSecret.Name,
+					Namespace: rancherAWSSecret.Namespace,
+					Name:      rancherAWSSecret.Name,
 				},
 			})
 			g.Expect(err).ToNot(HaveOccurred())
 
 			g.Expect(cl.Get(ctx, types.NamespacedName{
-				Name: rancherSecret.GetName(),
+				Name: rancherAWSSecret.GetName(),
 			}, translatedIdentity)).ToNot(HaveOccurred())
 
 			g.Expect(cl.Get(ctx, types.NamespacedName{
-				Name:      rancherSecret.GetName(),
-				Namespace: capaProviderNamespace,
+				Name:      rancherAWSSecret.GetName(),
+				Namespace: r.Translators["aws"].ProviderNamespace(),
 			}, translatedSecret)).ToNot(HaveOccurred())
+
+			g.Expect(translatedSecret.Data).To(HaveKeyWithValue("AccessKeyID", rancherAWSSecret.Data[rancherAWSAccessKeyField]))
+			g.Expect(translatedSecret.Data).To(HaveKeyWithValue("SecretAccessKey", rancherAWSSecret.Data[rancherAWSSecretKeyField]))
+
+			updatedRancherSecret := &corev1.Secret{}
+			g.Expect(cl.Get(ctx, types.NamespacedName{
+				Name:      rancherAWSSecret.GetName(),
+				Namespace: rancherAWSSecret.GetNamespace(),
+			}, updatedRancherSecret)).ToNot(HaveOccurred())
+
+			g.Expect(updatedRancherSecret.GetAnnotations()[turtlesannotations.CAPIIdentityRefAnnotation]).To(Equal(translatedIdentity.GetName()))
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+	})
+
+	It("Should delete translated CAPI identity when Rancher Cloud Credential is removed", func() {
+		Expect(cl.Create(ctx, provider)).ToNot(HaveOccurred())
+		patchBase := client.MergeFrom(provider.DeepCopy())
+		provider.Status = turtlesv1.CAPIProviderStatus{
+			Phase: turtlesv1.Ready,
+		}
+
+		err := cl.Status().Patch(ctx, provider, patchBase)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(ctx, func(g Gomega) {
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: rancherAWSSecret.Namespace,
+					Name:      rancherAWSSecret.Name,
+				},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(cl.Get(ctx, types.NamespacedName{
+				Name: rancherAWSSecret.GetName(),
+			}, translatedIdentity)).ToNot(HaveOccurred())
+
+			g.Expect(cl.Get(ctx, types.NamespacedName{
+				Name:      rancherAWSSecret.GetName(),
+				Namespace: r.Translators["aws"].ProviderNamespace(),
+			}, translatedSecret)).ToNot(HaveOccurred())
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+
+		err = cl.Delete(ctx, rancherAWSSecret)
+		Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+
+		Eventually(ctx, func(g Gomega) {
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: rancherAWSSecret.Namespace,
+					Name:      rancherAWSSecret.Name,
+				},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
+				Name: rancherAWSSecret.GetName(),
+			}, translatedIdentity))).To(BeTrue())
+
+			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
+				Name:      rancherAWSSecret.GetName(),
+				Namespace: r.Translators["aws"].ProviderNamespace(),
+			}, translatedSecret))).To(BeTrue())
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+	})
+
+	It("Should update AWSClusterStaticIdentity when AWS Cloud Credential changes", func() {
+		Expect(cl.Create(ctx, provider)).ToNot(HaveOccurred())
+		patchBase := client.MergeFrom(provider.DeepCopy())
+		provider.Status = turtlesv1.CAPIProviderStatus{
+			Phase: turtlesv1.Ready,
+		}
+
+		err := cl.Status().Patch(ctx, provider, patchBase)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(ctx, func(g Gomega) {
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: rancherAWSSecret.Namespace,
+					Name:      rancherAWSSecret.Name,
+				},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(cl.Get(ctx, types.NamespacedName{
+				Name: rancherAWSSecret.GetName(),
+			}, translatedIdentity)).ToNot(HaveOccurred())
+
+			g.Expect(cl.Get(ctx, types.NamespacedName{
+				Name:      rancherAWSSecret.GetName(),
+				Namespace: r.Translators["aws"].ProviderNamespace(),
+			}, translatedSecret)).ToNot(HaveOccurred())
+
+			g.Expect(translatedSecret.Data).To(HaveKeyWithValue(
+				"AccessKeyID", rancherAWSSecret.Data[rancherAWSAccessKeyField]))
+			g.Expect(translatedSecret.Data).To(HaveKeyWithValue(
+				"SecretAccessKey", rancherAWSSecret.Data[rancherAWSSecretKeyField]))
+
+			updatedRancherSecret := &corev1.Secret{}
+			g.Expect(cl.Get(ctx, types.NamespacedName{
+				Name:      rancherAWSSecret.GetName(),
+				Namespace: rancherAWSSecret.GetNamespace(),
+			}, updatedRancherSecret)).ToNot(HaveOccurred())
+
+			g.Expect(updatedRancherSecret.GetAnnotations()[turtlesannotations.CAPIIdentityRefAnnotation]).To(Equal(translatedIdentity.GetName()))
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+
+		// update existing Cloud Credentials Secret
+		updatedRancherSecret := &corev1.Secret{}
+		Expect(cl.Get(ctx, types.NamespacedName{
+			Name:      rancherAWSSecret.GetName(),
+			Namespace: rancherAWSSecret.GetNamespace(),
+		}, updatedRancherSecret)).ToNot(HaveOccurred())
+
+		patchRancherSecret := client.MergeFrom(updatedRancherSecret.DeepCopy())
+
+		updatedRancherSecret.StringData = map[string]string{
+			rancherAWSAccessKeyField: "new-access-key",
+			rancherAWSSecretKeyField: "new-secret-key",
+		}
+
+		Expect(cl.Patch(ctx, updatedRancherSecret, patchRancherSecret)).To(Succeed())
+
+		Eventually(ctx, func(g Gomega) {
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: rancherAWSSecret.Namespace,
+					Name:      rancherAWSSecret.Name,
+				},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(cl.Get(ctx, types.NamespacedName{
+				Name:      rancherAWSSecret.GetName(),
+				Namespace: r.Translators["aws"].ProviderNamespace(),
+			}, translatedSecret)).ToNot(HaveOccurred())
+
+			g.Expect(translatedSecret.Data).To(HaveKeyWithValue(
+				"AccessKeyID", updatedRancherSecret.Data[rancherAWSAccessKeyField]))
+			g.Expect(translatedSecret.Data).To(HaveKeyWithValue(
+				"SecretAccessKey", updatedRancherSecret.Data[rancherAWSSecretKeyField]))
 		}).WithTimeout(10 * time.Second).Should(Succeed())
 	})
 
 	It("Should requeue and not translate when CAPA CAPIProvider is installed but not yet ready", func() {
 		Expect(cl.Create(ctx, provider)).ToNot(HaveOccurred())
 
-		rancherSecret.Annotations = map[string]string{
-			"field.cattle.io/name": "aws-cred",
-			driverNameAnnotation:   "aws",
-		}
-		rancherSecret.StringData = map[string]string{
-			"amazonec2credentialConfig-accessKey":     "access-key",
-			"amazonec2credentialConfig-secretKey":     "secret-key",
-			"amazonec2credentialConfig-defaultRegion": "us-east-1",
-		}
-		Expect(cl.Create(ctx, rancherSecret)).ToNot(HaveOccurred())
-
 		Eventually(ctx, func(g Gomega) {
 			res, err := r.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Namespace: rancherSecret.Namespace,
-					Name:      rancherSecret.Name,
+					Namespace: rancherAWSSecret.Namespace,
+					Name:      rancherAWSSecret.Name,
 				},
 			})
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(res.RequeueAfter).ToNot(BeZero())
 
 			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
-				Name:      rancherSecret.GetName(),
-				Namespace: capaProviderNamespace,
+				Name:      rancherAWSSecret.GetName(),
+				Namespace: r.Translators["aws"].ProviderNamespace(),
 			}, translatedSecret))).To(BeTrue())
 		}).WithTimeout(10 * time.Second).Should(Succeed())
 	})
@@ -251,35 +396,24 @@ var _ = Describe("Credential Translation", func() {
 		capaProvider := &turtlesv1.CAPIProvider{}
 		Eventually(ctx, func(g Gomega) {
 			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
-				Name:      capaProviderSpecName,
-				Namespace: capaProviderNamespace,
+				Name:      r.Translators["aws"].ProviderName(),
+				Namespace: r.Translators["aws"].ProviderNamespace(),
 			}, capaProvider))).To(BeTrue())
 		}).WithTimeout(10 * time.Second).Should(Succeed())
-
-		rancherSecret.Annotations = map[string]string{
-			"field.cattle.io/name": "aws-cred",
-			driverNameAnnotation:   "aws",
-		}
-		rancherSecret.StringData = map[string]string{
-			"amazonec2credentialConfig-accessKey":     "access-key",
-			"amazonec2credentialConfig-secretKey":     "secret-key",
-			"amazonec2credentialConfig-defaultRegion": "us-east-1",
-		}
-		Expect(cl.Create(ctx, rancherSecret)).ToNot(HaveOccurred())
 
 		Eventually(ctx, func(g Gomega) {
 			res, err := r.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Namespace: rancherSecret.Namespace,
-					Name:      rancherSecret.Name,
+					Namespace: rancherAWSSecret.Namespace,
+					Name:      rancherAWSSecret.Name,
 				},
 			})
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(res.RequeueAfter).To(BeZero())
 
 			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
-				Name:      rancherSecret.GetName(),
-				Namespace: capaProviderNamespace,
+				Name:      rancherAWSSecret.GetName(),
+				Namespace: r.Translators["aws"].ProviderNamespace(),
 			}, translatedSecret))).To(BeTrue())
 		}).WithTimeout(10 * time.Second).Should(Succeed())
 	})
@@ -290,36 +424,25 @@ var _ = Describe("Credential Translation", func() {
 		capaProvider := &turtlesv1.CAPIProvider{}
 		Eventually(ctx, func(g Gomega) {
 			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
-				Name:      capaProviderSpecName,
-				Namespace: capaProviderNamespace,
+				Name:      r.Translators["aws"].ProviderName(),
+				Namespace: r.Translators["aws"].ProviderNamespace(),
 			}, capaProvider))).To(BeTrue())
 		}).WithTimeout(10 * time.Second).Should(Succeed())
-
-		rancherSecret.Annotations = map[string]string{
-			"field.cattle.io/name": "aws-cred",
-			driverNameAnnotation:   "aws",
-		}
-		rancherSecret.StringData = map[string]string{
-			"amazonec2credentialConfig-accessKey":     "access-key",
-			"amazonec2credentialConfig-secretKey":     "secret-key",
-			"amazonec2credentialConfig-defaultRegion": "us-east-1",
-		}
-		Expect(cl.Create(ctx, rancherSecret)).ToNot(HaveOccurred())
 
 		translatedSecret := &corev1.Secret{}
 
 		Eventually(ctx, func(g Gomega) {
 			_, err := r.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Namespace: rancherSecret.Namespace,
-					Name:      rancherSecret.Name,
+					Namespace: rancherAWSSecret.Namespace,
+					Name:      rancherAWSSecret.Name,
 				},
 			})
 			g.Expect(err).ToNot(HaveOccurred())
 
 			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
-				Name:      rancherSecret.GetName(),
-				Namespace: capaProviderNamespace,
+				Name:      rancherAWSSecret.GetName(),
+				Namespace: r.Translators["aws"].ProviderNamespace(),
 			}, translatedSecret))).To(BeTrue())
 		}).WithTimeout(10 * time.Second).Should(Succeed())
 
@@ -335,19 +458,19 @@ var _ = Describe("Credential Translation", func() {
 		Eventually(ctx, func(g Gomega) {
 			_, err := r.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Namespace: rancherSecret.Namespace,
-					Name:      rancherSecret.Name,
+					Namespace: rancherAWSSecret.Namespace,
+					Name:      rancherAWSSecret.Name,
 				},
 			})
 			g.Expect(err).ToNot(HaveOccurred())
 
 			g.Expect(cl.Get(ctx, types.NamespacedName{
-				Name: rancherSecret.GetName(),
+				Name: rancherAWSSecret.GetName(),
 			}, translatedIdentity)).ToNot(HaveOccurred())
 
 			g.Expect(cl.Get(ctx, types.NamespacedName{
-				Name:      rancherSecret.GetName(),
-				Namespace: capaProviderNamespace,
+				Name:      rancherAWSSecret.GetName(),
+				Namespace: r.Translators["aws"].ProviderNamespace(),
 			}, translatedSecret)).ToNot(HaveOccurred())
 		}).WithTimeout(10 * time.Second).Should(Succeed())
 	})
@@ -362,26 +485,31 @@ var _ = Describe("Credential Translation", func() {
 		err := cl.Status().Patch(ctx, provider, patchBase)
 		Expect(err).NotTo(HaveOccurred())
 
-		rancherSecret.Annotations = map[string]string{
+		rancherAzureSecret.Annotations = map[string]string{
 			"field.cattle.io/name": "azure-cred",
 			driverNameAnnotation:   "azure",
 		}
-		rancherSecret.StringData = map[string]string{
+		rancherAzureSecret.StringData = map[string]string{
 			"sampleazure": "sample-azure-key",
 		}
-		Expect(cl.Create(ctx, rancherSecret)).ToNot(HaveOccurred())
+		Expect(cl.Create(ctx, rancherAzureSecret)).ToNot(HaveOccurred())
 
 		Eventually(ctx, func(g Gomega) {
 			_, err := r.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Namespace: rancherSecret.Namespace,
-					Name:      rancherSecret.Name,
+					Namespace: rancherAzureSecret.Namespace,
+					Name:      rancherAzureSecret.Name,
 				},
 			})
 			g.Expect(err).ToNot(HaveOccurred())
 
 			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
-				Name: rancherSecret.GetName(),
+				Name:      rancherAzureSecret.GetName(),
+				Namespace: r.Translators["aws"].ProviderNamespace(),
+			}, translatedSecret))).To(BeTrue())
+
+			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
+				Name: rancherAzureSecret.GetName(),
 			}, translatedIdentity))).To(BeTrue())
 		}).WithTimeout(10 * time.Second).Should(Succeed())
 	})

--- a/internal/controllers/credentialtranslation_controller_test.go
+++ b/internal/controllers/credentialtranslation_controller_test.go
@@ -1,0 +1,388 @@
+/*
+Copyright © 2023 - 2026 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	turtlesv1 "github.com/rancher/turtles/api/v1alpha1"
+	"github.com/rancher/turtles/internal/test"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Credential Translation", func() {
+	var (
+		r                           *RancherCredentialReconciler
+		awsClusterStaticIdentityCRD *apiextensionsv1.CustomResourceDefinition
+		provider                    *turtlesv1.CAPIProvider
+		rancherSecret               *corev1.Secret
+		translatedSecret            *corev1.Secret
+		translatedIdentity          *unstructured.Unstructured
+	)
+
+	BeforeEach(func() {
+		SetClient(testEnv)
+		SetContext(ctx)
+
+		r = &RancherCredentialReconciler{
+			Client:              cl,
+			CAPASystemNamespace: capaProviderNamespace,
+		}
+
+		awsClusterStaticIdentityCRD = &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "awsclusterstaticidentities.infrastructure.cluster.x-k8s.io",
+			},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Group: "infrastructure.cluster.x-k8s.io",
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+					{
+						Name:    "v1beta2",
+						Served:  true,
+						Storage: true,
+						Schema: &apiextensionsv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
+									"spec": {
+										Type: "object",
+										Properties: map[string]apiextensionsv1.JSONSchemaProps{
+											"secretName": {Type: "string"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Scope: apiextensionsv1.ClusterScoped,
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
+					Plural:   "awsclusterstaticidentities",
+					Singular: "awsclusterstaticidentity",
+					Kind:     "AWSClusterStaticIdentity",
+					ListKind: "AWSClusterStaticIdentityList",
+				},
+			},
+		}
+		if apierrors.IsNotFound(testEnv.Get(ctx, client.ObjectKeyFromObject(awsClusterStaticIdentityCRD), &apiextensionsv1.CustomResourceDefinition{})) {
+			Expect(testEnv.Create(ctx, awsClusterStaticIdentityCRD)).ToNot(HaveOccurred())
+		}
+
+		globalDataNs := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: rancherCredentialsNamespace,
+			},
+		}
+		if apierrors.IsNotFound(testEnv.Get(ctx, client.ObjectKeyFromObject(globalDataNs), &corev1.Namespace{})) {
+			Expect(testEnv.Create(ctx, globalDataNs)).ToNot(HaveOccurred())
+		}
+
+		capaNs := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: capaProviderNamespace,
+			},
+		}
+		if apierrors.IsNotFound(testEnv.Get(ctx, client.ObjectKeyFromObject(capaNs), &corev1.Namespace{})) {
+			Expect(testEnv.Create(ctx, capaNs)).ToNot(HaveOccurred())
+		}
+
+		provider = &turtlesv1.CAPIProvider{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      capaProviderSpecName,
+				Namespace: capaNs.Name,
+			},
+			Spec: turtlesv1.CAPIProviderSpec{
+				Type: turtlesv1.Infrastructure,
+			},
+		}
+
+		rancherSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:         "cctest",
+				GenerateName: "cc-",
+				Namespace:    rancherCredentialsNamespace,
+			},
+		}
+
+		translatedSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rancherSecret.GetName(),
+				Namespace: capaNs.Name,
+			},
+		}
+
+		translatedIdentity = &unstructured.Unstructured{}
+		translatedIdentity.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "infrastructure.cluster.x-k8s.io",
+			Version: "v1beta2",
+			Kind:    "AWSClusterStaticIdentity",
+		})
+	})
+
+	AfterEach(func() {
+		capaProvider := &turtlesv1.CAPIProvider{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      capaProviderSpecName,
+				Namespace: capaProviderNamespace,
+			},
+		}
+
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if err := cl.Get(ctx, client.ObjectKeyFromObject(capaProvider), capaProvider); err != nil {
+				return client.IgnoreNotFound(err)
+			}
+
+			capaProvider.SetFinalizers(nil)
+
+			return cl.Update(ctx, capaProvider)
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = cl.Delete(ctx, capaProvider)
+		Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+
+		clientObjs := []client.Object{
+			rancherSecret,
+			translatedSecret,
+			translatedIdentity,
+		}
+		Expect(test.CleanupAndWait(ctx, cl, clientObjs...)).To(Succeed())
+	})
+
+	It("Should reconcile and translate Rancher Cloud Credential secret when CAPA is installed", func() {
+		Expect(cl.Create(ctx, provider)).ToNot(HaveOccurred())
+		patchBase := client.MergeFrom(provider.DeepCopy())
+		provider.Status = turtlesv1.CAPIProviderStatus{
+			Phase: turtlesv1.Ready,
+		}
+
+		err := cl.Status().Patch(ctx, provider, patchBase)
+		Expect(err).NotTo(HaveOccurred())
+
+		rancherSecret.Annotations = map[string]string{
+			"field.cattle.io/name": "aws-cred",
+			driverNameAnnotation:   "aws",
+		}
+		rancherSecret.StringData = map[string]string{
+			"amazonec2credentialConfig-accessKey":     "access-key",
+			"amazonec2credentialConfig-secretKey":     "secret-key",
+			"amazonec2credentialConfig-defaultRegion": "us-east-1",
+		}
+		Expect(cl.Create(ctx, rancherSecret)).ToNot(HaveOccurred())
+
+		Eventually(ctx, func(g Gomega) {
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: rancherSecret.Namespace,
+					Name:      rancherSecret.Name,
+				},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(cl.Get(ctx, types.NamespacedName{
+				Name: rancherSecret.GetName(),
+			}, translatedIdentity)).ToNot(HaveOccurred())
+
+			g.Expect(cl.Get(ctx, types.NamespacedName{
+				Name:      rancherSecret.GetName(),
+				Namespace: capaProviderNamespace,
+			}, translatedSecret)).ToNot(HaveOccurred())
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+	})
+
+	It("Should requeue and not translate when CAPA CAPIProvider is installed but not yet ready", func() {
+		Expect(cl.Create(ctx, provider)).ToNot(HaveOccurred())
+
+		rancherSecret.Annotations = map[string]string{
+			"field.cattle.io/name": "aws-cred",
+			driverNameAnnotation:   "aws",
+		}
+		rancherSecret.StringData = map[string]string{
+			"amazonec2credentialConfig-accessKey":     "access-key",
+			"amazonec2credentialConfig-secretKey":     "secret-key",
+			"amazonec2credentialConfig-defaultRegion": "us-east-1",
+		}
+		Expect(cl.Create(ctx, rancherSecret)).ToNot(HaveOccurred())
+
+		Eventually(ctx, func(g Gomega) {
+			res, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: rancherSecret.Namespace,
+					Name:      rancherSecret.Name,
+				},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(res.RequeueAfter).ToNot(BeZero())
+
+			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
+				Name:      rancherSecret.GetName(),
+				Namespace: capaProviderNamespace,
+			}, translatedSecret))).To(BeTrue())
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+	})
+
+	It("Should not error when CAPA is not installed (Cloud Credentials are not translated) and not requeue", func() {
+		capaProvider := &turtlesv1.CAPIProvider{}
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
+				Name:      capaProviderSpecName,
+				Namespace: capaProviderNamespace,
+			}, capaProvider))).To(BeTrue())
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+
+		rancherSecret.Annotations = map[string]string{
+			"field.cattle.io/name": "aws-cred",
+			driverNameAnnotation:   "aws",
+		}
+		rancherSecret.StringData = map[string]string{
+			"amazonec2credentialConfig-accessKey":     "access-key",
+			"amazonec2credentialConfig-secretKey":     "secret-key",
+			"amazonec2credentialConfig-defaultRegion": "us-east-1",
+		}
+		Expect(cl.Create(ctx, rancherSecret)).ToNot(HaveOccurred())
+
+		Eventually(ctx, func(g Gomega) {
+			res, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: rancherSecret.Namespace,
+					Name:      rancherSecret.Name,
+				},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(res.RequeueAfter).To(BeZero())
+
+			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
+				Name:      rancherSecret.GetName(),
+				Namespace: capaProviderNamespace,
+			}, translatedSecret))).To(BeTrue())
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+	})
+
+	It("Should translate existing Cloud Credentials after CAPA CAPIProvider is installed", func() {
+		// first we check that no translation happens when CAPA is not installed.
+		// then we install CAPA and expect existing Cloud Credentials to be translated.
+		capaProvider := &turtlesv1.CAPIProvider{}
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
+				Name:      capaProviderSpecName,
+				Namespace: capaProviderNamespace,
+			}, capaProvider))).To(BeTrue())
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+
+		rancherSecret.Annotations = map[string]string{
+			"field.cattle.io/name": "aws-cred",
+			driverNameAnnotation:   "aws",
+		}
+		rancherSecret.StringData = map[string]string{
+			"amazonec2credentialConfig-accessKey":     "access-key",
+			"amazonec2credentialConfig-secretKey":     "secret-key",
+			"amazonec2credentialConfig-defaultRegion": "us-east-1",
+		}
+		Expect(cl.Create(ctx, rancherSecret)).ToNot(HaveOccurred())
+
+		translatedSecret := &corev1.Secret{}
+
+		Eventually(ctx, func(g Gomega) {
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: rancherSecret.Namespace,
+					Name:      rancherSecret.Name,
+				},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
+				Name:      rancherSecret.GetName(),
+				Namespace: capaProviderNamespace,
+			}, translatedSecret))).To(BeTrue())
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+
+		Expect(cl.Create(ctx, provider)).ToNot(HaveOccurred())
+		patchBase := client.MergeFrom(provider.DeepCopy())
+		provider.Status = turtlesv1.CAPIProviderStatus{
+			Phase: turtlesv1.Ready,
+		}
+
+		err := cl.Status().Patch(ctx, provider, patchBase)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(ctx, func(g Gomega) {
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: rancherSecret.Namespace,
+					Name:      rancherSecret.Name,
+				},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(cl.Get(ctx, types.NamespacedName{
+				Name: rancherSecret.GetName(),
+			}, translatedIdentity)).ToNot(HaveOccurred())
+
+			g.Expect(cl.Get(ctx, types.NamespacedName{
+				Name:      rancherSecret.GetName(),
+				Namespace: capaProviderNamespace,
+			}, translatedSecret)).ToNot(HaveOccurred())
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+	})
+
+	It("Should not translate non-AWS Rancher Cloud Credential", func() {
+		Expect(cl.Create(ctx, provider)).ToNot(HaveOccurred())
+		patchBase := client.MergeFrom(provider.DeepCopy())
+		provider.Status = turtlesv1.CAPIProviderStatus{
+			Phase: turtlesv1.Ready,
+		}
+
+		err := cl.Status().Patch(ctx, provider, patchBase)
+		Expect(err).NotTo(HaveOccurred())
+
+		rancherSecret.Annotations = map[string]string{
+			"field.cattle.io/name": "azure-cred",
+			driverNameAnnotation:   "azure",
+		}
+		rancherSecret.StringData = map[string]string{
+			"sampleazure": "sample-azure-key",
+		}
+		Expect(cl.Create(ctx, rancherSecret)).ToNot(HaveOccurred())
+
+		Eventually(ctx, func(g Gomega) {
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: rancherSecret.Namespace,
+					Name:      rancherSecret.Name,
+				},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(apierrors.IsNotFound(cl.Get(ctx, types.NamespacedName{
+				Name: rancherSecret.GetName(),
+			}, translatedIdentity))).To(BeTrue())
+		}).WithTimeout(10 * time.Second).Should(Succeed())
+	})
+})

--- a/internal/controllers/helpers.go
+++ b/internal/controllers/helpers.go
@@ -54,6 +54,9 @@ const (
 	fleetNamespaceMigrated    = "cluster-api.cattle.io/fleet-namespace-migrated"
 	fleetDisabledLabel        = "cluster-api.cattle.io/disable-fleet-auto-import"
 
+	rancherCredentialsNamespace = "cattle-global-data"
+	driverNameAnnotation        = "provisioning.cattle.io/driver"
+
 	defaultRequeueDuration = 1 * time.Minute
 	trueValue              = "true"
 )

--- a/internal/controllers/helpers.go
+++ b/internal/controllers/helpers.go
@@ -55,7 +55,11 @@ const (
 	fleetDisabledLabel        = "cluster-api.cattle.io/disable-fleet-auto-import"
 
 	rancherCredentialsNamespace = "cattle-global-data"
-	driverNameAnnotation        = "provisioning.cattle.io/driver"
+
+	driverNameAnnotation = "provisioning.cattle.io/driver"
+
+	//nolint:gosec  // This is not a hardcoded credential, just an annotation key name.
+	cloudCredentialSecretAnnotation = "cluster-api.cattle.io/source-id"
 
 	defaultRequeueDuration = 1 * time.Minute
 	trueValue              = "true"
@@ -383,4 +387,30 @@ func getTrustedCAcert(ctx context.Context, cl client.Client, agentTLSModeFeature
 	default:
 		return nil, fmt.Errorf("invalid agent-tls-mode setting value: %s", agentTLSModeValue)
 	}
+}
+
+func verifySecretOwnership(obj client.Object, sourceSecret *corev1.Secret) error {
+	if obj.GetResourceVersion() != "" {
+		annots := obj.GetAnnotations()
+		if annots == nil || annots[cloudCredentialSecretAnnotation] != string(sourceSecret.UID) {
+			return fmt.Errorf("security collision detected: target %s %s/%s already exists and is not related to the cloud credential",
+				obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName())
+		}
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	annotations[cloudCredentialSecretAnnotation] = string(sourceSecret.UID)
+
+	obj.SetAnnotations(annotations)
+
+	return nil
+}
+
+func isObjectOwnedBySecret(obj client.Object, sourceSecret *corev1.Secret) bool {
+	annots := obj.GetAnnotations()
+	return annots != nil && annots[cloudCredentialSecretAnnotation] == string(sourceSecret.UID)
 }

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher/turtles/internal/test/helpers"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -51,6 +52,7 @@ var (
 )
 
 func setup() {
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(operatorv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(turtlesv1.AddToScheme(scheme.Scheme))

--- a/internal/controllers/sync_controller_test.go
+++ b/internal/controllers/sync_controller_test.go
@@ -25,6 +25,7 @@ import (
 	turtlesv1 "github.com/rancher/turtles/api/v1alpha1"
 	"github.com/rancher/turtles/internal/sync"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api-operator/controller"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -40,9 +41,7 @@ func objectFromKey(key client.ObjectKey, obj client.Object) client.Object {
 }
 
 var _ = Describe("Reconcile CAPIProvider", Ordered, func() {
-	var (
-		ns *corev1.Namespace
-	)
+	var ns *corev1.Namespace
 
 	BeforeAll(func() {
 		mgr := testEnv.Manager
@@ -130,11 +129,14 @@ var _ = Describe("Reconcile CAPIProvider", Ordered, func() {
 		doSecret := objectFromKey(client.ObjectKeyFromObject(provider), &corev1.Secret{})
 		Eventually(testEnv.GetAs(provider, doSecret)).ShouldNot(BeNil())
 
-		Expect(cl.Create(ctx, &corev1.Namespace{
+		globalDataNs := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: sync.RancherCredentialsNamespace,
 			},
-		})).To(Succeed())
+		}
+		if apierrors.IsNotFound(testEnv.Get(ctx, client.ObjectKeyFromObject(globalDataNs), &corev1.Namespace{})) {
+			Expect(testEnv.Create(ctx, globalDataNs)).ToNot(HaveOccurred())
+		}
 
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/provider/defaults.go
+++ b/internal/provider/defaults.go
@@ -73,7 +73,7 @@ func SetDefaultProviderSpec(o operatorv1.GenericProvider) {
 	providerSpec := o.GetSpec()
 	providerNamespace := o.GetNamespace()
 
-	if providerSpec.ConfigSecret != nil && providerSpec.ConfigSecret.Namespace == "" {
+	if providerSpec.ConfigSecret != nil {
 		providerSpec.ConfigSecret.Namespace = providerNamespace
 	}
 
@@ -87,10 +87,9 @@ func SetDefaultProviderSpec(o operatorv1.GenericProvider) {
 	}
 
 	providerSpec.ConfigSecret = cmp.Or(providerSpec.ConfigSecret, &operatorv1.SecretReference{
-		Name: o.GetName(),
+		Name:      o.GetName(),
+		Namespace: providerNamespace,
 	})
-
-	providerSpec.ConfigSecret.Namespace = cmp.Or(providerSpec.ConfigSecret.Namespace, providerNamespace)
 
 	o.SetSpec(providerSpec)
 }

--- a/main.go
+++ b/main.go
@@ -275,6 +275,9 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 		if err := (&controllers.RancherCredentialReconciler{
 			Client: mgr.GetClient(),
+			Translators: map[string]controllers.CredentialTranslator{
+				"aws": &controllers.AWSTranslator{},
+			},
 		}).SetupWithManager(ctx, mgr, controller.Options{
 			MaxConcurrentReconciles: concurrencyNumber,
 		}); err != nil {

--- a/main.go
+++ b/main.go
@@ -269,4 +269,17 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 			os.Exit(1)
 		}
 	}
+
+	if feature.Gates.Enabled(feature.RancherCCTranslation) {
+		setupLog.Info("enabling Rancher Credential translation controller")
+
+		if err := (&controllers.RancherCredentialReconciler{
+			Client: mgr.GetClient(),
+		}).SetupWithManager(ctx, mgr, controller.Options{
+			MaxConcurrentReconciles: concurrencyNumber,
+		}); err != nil {
+			setupLog.Error(err, "unable to create Rancher Credential translation controller")
+			os.Exit(1)
+		}
+	}
 }

--- a/test/e2e/data/cluster-templates/aws-ec2-rke2-topology.yaml
+++ b/test/e2e/data/cluster-templates/aws-ec2-rke2-topology.yaml
@@ -1,11 +1,3 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-kind: AWSClusterStaticIdentity
-metadata:
-  name: cluster-identity
-spec:
-  secretRef: cluster-identity
-  allowedNamespaces: {}
----
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
@@ -38,7 +30,7 @@ spec:
       - name: cni
         value: none
       - name: awsClusterIdentityName
-        value: cluster-identity
+        value: ${AWS_CLUSTER_IDENTITY_NAME}
     version: ${RKE2_KUBERNETES_VERSION}
     workers:
       machineDeployments:

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -55,13 +55,22 @@ type Setup struct {
 	RancherHostname string
 }
 
-func SetupSpecNamespace(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder string) (*corev1.Namespace, context.CancelFunc) {
+func SetupSpecNamespace(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder, clusterNs string) (*corev1.Namespace, context.CancelFunc) {
 	turtlesframework.Byf("Creating a namespace for hosting the %q test spec", specName)
+
+	var nsName string
+	if clusterNs != "" {
+		nsName = clusterNs
+	} else {
+		nsName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+	}
+
 	namespace, cancelWatches := framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
-		Creator:   clusterProxy.GetClient(),
-		ClientSet: clusterProxy.GetClientSet(),
-		Name:      fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
-		LogFolder: filepath.Join(artifactFolder, "clusters", clusterProxy.GetName()),
+		Creator:             clusterProxy.GetClient(),
+		ClientSet:           clusterProxy.GetClientSet(),
+		Name:                nsName,
+		LogFolder:           filepath.Join(artifactFolder, "clusters", clusterProxy.GetName()),
+		IgnoreAlreadyExists: true,
 	})
 
 	return namespace, cancelWatches

--- a/test/e2e/specs/import_gitops.go
+++ b/test/e2e/specs/import_gitops.go
@@ -64,6 +64,13 @@ type CreateUsingGitOpsSpecInput struct {
 	CAPIClusterCreateWaitName string
 	DeleteClusterWaitName     string
 
+	// Namespace defines the namespace where the test cluster will be created.
+	// If not specified, a random namespace will be created.
+	// This should only be used when the test case requires the cluster to be
+	// created in a know namespace, otherwise, it is recommended to let the test
+	// create a random namespace to avoid conflicts with other parallel tests.
+	Namespace string
+
 	// ControlPlaneMachineCount defines the number of control plane machines to be added to the workload cluster.
 	// If not specified, 1 will be used.
 	ControlPlaneMachineCount *int
@@ -140,7 +147,7 @@ func CreateUsingGitOpsSpec(ctx context.Context, inputGetter func() CreateUsingGi
 		Expect(os.MkdirAll(input.ArtifactFolder, 0o750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
 
 		Expect(input.E2EConfig.Variables).To(HaveKey(e2e.KubernetesManagementVersionVar))
-		namespace, cancelWatches = e2e.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
+		namespace, cancelWatches = e2e.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, input.Namespace)
 
 		capiClusterCreateWait = input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), input.CAPIClusterCreateWaitName)
 		Expect(capiClusterCreateWait).ToNot(BeNil(), "Failed to get wait intervals %s", input.CAPIClusterCreateWaitName)

--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -21,11 +21,13 @@ package import_gitops
 
 import (
 	"fmt"
+	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/rancher/turtles/test/e2e"
 	"github.com/rancher/turtles/test/e2e/specs"
 	turtlesframework "github.com/rancher/turtles/test/framework"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
@@ -259,7 +261,7 @@ var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionali
 			BootstrapClusterProxy:     bootstrapClusterProxy,
 			ClusterTemplate:           e2e.CAPIAwsKubeadmTopology,
 			ClusterName:               "cluster-aws-kubeadm",
-			ControlPlaneMachineCount:  ptr.To(3), //minimum 3 replicas for CSI controller
+			ControlPlaneMachineCount:  ptr.To(3), // minimum 3 replicas for CSI controller
 			WorkerMachineCount:        ptr.To(1),
 			SkipDeletionTest:          false,
 			LabelNamespace:            true,
@@ -299,13 +301,40 @@ var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionali
 })
 
 var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.FullTestLabel, e2e.Rke2TestLabel), func() {
-	var topologyNamespace string
+	var topologyNamespace, credentialName string
 
 	BeforeEach(func() {
 		komega.SetClient(bootstrapClusterProxy.GetClient())
 		komega.SetContext(ctx)
 
 		topologyNamespace = "creategitops-aws-rke2"
+		credentialName = "rancher-cloud-credential-aws"
+
+		By("Creating Rancher AWS Cloud Credential which will be translated into `AWSClusterStaticIdentity`")
+		lookupResult := &turtlesframework.RancherLookupUserResult{}
+		turtlesframework.RancherLookupUser(ctx, turtlesframework.RancherLookupUserInput{
+			Username:     "admin",
+			ClusterProxy: bootstrapClusterProxy,
+		}, lookupResult)
+
+		turtlesframework.CreateSecret(ctx, turtlesframework.CreateSecretInput{
+			Creator:   bootstrapClusterProxy.GetClient(),
+			Name:      credentialName,
+			Namespace: "cattle-global-data",
+			Type:      corev1.SecretTypeOpaque,
+			Data: map[string]string{
+				"amazonec2credentialConfig-accessKey": os.Getenv("AWS_ACCESS_KEY_ID"),
+				"amazonec2credentialConfig-secretKey": os.Getenv("AWS_SECRET_ACCESS_KEY"),
+			},
+			Annotations: map[string]string{
+				"field.cattle.io/name":          credentialName,
+				"provisioning.cattle.io/driver": "aws",
+				"field.cattle.io/creatorId":     lookupResult.User,
+			},
+			Labels: map[string]string{
+				"cattle.io/creator": "norman",
+			},
+		})
 	})
 
 	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
@@ -314,7 +343,7 @@ var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality 
 			BootstrapClusterProxy:     bootstrapClusterProxy,
 			ClusterTemplate:           e2e.CAPIAwsEC2RKE2Topology,
 			ClusterName:               "cluster-aws-rke2",
-			ControlPlaneMachineCount:  ptr.To(3), //minimum 3 replicas for CSI controller
+			ControlPlaneMachineCount:  ptr.To(3), // minimum 3 replicas for CSI controller
 			WorkerMachineCount:        ptr.To(1),
 			LabelNamespace:            true,
 			RancherServerURL:          hostName,
@@ -322,6 +351,9 @@ var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality 
 			DeleteClusterWaitName:     "wait-eks-delete",
 			TopologyNamespace:         topologyNamespace,
 			VerifyETCDSize:            true,
+			AdditionalTemplateVariables: map[string]string{
+				"AWS_CLUSTER_IDENTITY_NAME": credentialName,
+			},
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{
 					Name:            "aws-cluster-class-rke2",
@@ -461,7 +493,7 @@ var _ = Describe("[vSphere] [Kubeadm] Create and delete CAPI cluster from cluste
 			ClusterTemplate:           e2e.CAPIvSphereKubeadmTopology,
 			TopologyNamespace:         topologyNamespace,
 			ClusterName:               "cluster-vsphere-kubeadm",
-			ControlPlaneMachineCount:  ptr.To(3), //minimum 3 replicas for CSI controller
+			ControlPlaneMachineCount:  ptr.To(3), // minimum 3 replicas for CSI controller
 			WorkerMachineCount:        ptr.To(1),
 			LabelNamespace:            true,
 			RancherServerURL:          hostName,
@@ -517,7 +549,7 @@ var _ = Describe("[vSphere] [RKE2] Create and delete CAPI cluster functionality 
 			ClusterTemplate:           e2e.CAPIvSphereRKE2Topology,
 			TopologyNamespace:         topologyNamespace,
 			ClusterName:               "cluster-vsphere-rke2",
-			ControlPlaneMachineCount:  ptr.To(3), //minimum 3 replicas for CSI controller
+			ControlPlaneMachineCount:  ptr.To(3), // minimum 3 replicas for CSI controller
 			WorkerMachineCount:        ptr.To(1),
 			LabelNamespace:            true,
 			RancherServerURL:          hostName,

--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -301,13 +301,15 @@ var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionali
 })
 
 var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.FullTestLabel, e2e.Rke2TestLabel), func() {
-	var topologyNamespace, credentialName string
+	var topologyNamespace, capiClusterNamespace, credentialName string
 
 	BeforeEach(func() {
 		komega.SetClient(bootstrapClusterProxy.GetClient())
 		komega.SetContext(ctx)
 
 		topologyNamespace = "creategitops-aws-rke2"
+		// AWSClusterStaticIdentity only allows provisioning clusters in "fleet-default"
+		capiClusterNamespace = "fleet-default"
 		credentialName = "rancher-cloud-credential-aws"
 
 		By("Creating Rancher AWS Cloud Credential which will be translated into `AWSClusterStaticIdentity`")
@@ -343,6 +345,7 @@ var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality 
 			BootstrapClusterProxy:     bootstrapClusterProxy,
 			ClusterTemplate:           e2e.CAPIAwsEC2RKE2Topology,
 			ClusterName:               "cluster-aws-rke2",
+			Namespace:                 capiClusterNamespace,
 			ControlPlaneMachineCount:  ptr.To(3), // minimum 3 replicas for CSI controller
 			WorkerMachineCount:        ptr.To(1),
 			LabelNamespace:            true,
@@ -353,6 +356,7 @@ var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality 
 			VerifyETCDSize:            true,
 			AdditionalTemplateVariables: map[string]string{
 				"AWS_CLUSTER_IDENTITY_NAME": credentialName,
+				"NAMESPACE":                 capiClusterNamespace,
 			},
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{

--- a/test/e2e/suites/import-gitops/suite_test.go
+++ b/test/e2e/suites/import-gitops/suite_test.go
@@ -102,6 +102,13 @@ var _ = SynchronizedBeforeSuite(
 		By("Enable CAAPF")
 		testenv.EnableCAAPF(ctx, testenv.EnableCAAPFInput{BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy})
 
+		By("Enable Rancher Cloud Credential translation")
+		testenv.SetTurtlesFeatureGate(ctx, testenv.SetTurtlesFeatureGateInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+			FeatureName:           "rancher-credential-translation",
+			Enabled:               true,
+		})
+
 		By("Waiting for Rancher to be ready")
 		capiframework.WaitForDeploymentsAvailable(ctx, capiframework.WaitForDeploymentsAvailableInput{
 			Getter: setupClusterResult.BootstrapClusterProxy.GetClient(),

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -41,9 +41,9 @@ const (
 	ClusterDescriptionAnnotation = "cluster-api.cattle.io/cluster-description"
 	// ImportedClusterVersionManagementAnnotation is a Rancher management Cluster annotation that enables or disables version management for the Cluster.
 	ImportedClusterVersionManagementAnnotation = "rancher.io/imported-cluster-version-management"
-	// AWSClusterStaticIdentityRefAnnotation is the annotation added to a Rancher Cloud Credential
-	// to reference the translated AWSClusterStaticIdentity object name.
-	AWSClusterStaticIdentityRefAnnotation = "cluster-api.cattle.io/aws-static-identity-ref"
+	// CAPIIdentityRefAnnotation is the annotation added to a Rancher Cloud Credential
+	// to reference the translated CAPI identity object name.
+	CAPIIdentityRefAnnotation = "cluster-api.cattle.io/capi-static-identity-ref"
 )
 
 // HasClusterImportAnnotation returns true if the object has the `imported` annotation.

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -41,6 +41,9 @@ const (
 	ClusterDescriptionAnnotation = "cluster-api.cattle.io/cluster-description"
 	// ImportedClusterVersionManagementAnnotation is a Rancher management Cluster annotation that enables or disables version management for the Cluster.
 	ImportedClusterVersionManagementAnnotation = "rancher.io/imported-cluster-version-management"
+	// AWSClusterStaticIdentityRefAnnotation is the annotation added to a Rancher Cloud Credential
+	// to reference the translated AWSClusterStaticIdentity object name.
+	AWSClusterStaticIdentityRefAnnotation = "cluster-api.cattle.io/aws-static-identity-ref"
 )
 
 // HasClusterImportAnnotation returns true if the object has the `imported` annotation.


### PR DESCRIPTION
**What this PR does / why we need it**:

- :green_circle:  Successfull long end-to-end test execution: https://github.com/rancher/turtles/actions/runs/27346906885

The goal of this PR is to introduce logic that translates Rancher AWS Cloud Credentials into CAPA `AWSClusterStaticIdentity` (and underlying `Secret`) for enabling CAPI Plug and Play for AWS.

Translation is (for now) implemented for AWS and `AWSClusterStaticIdentity` only. Users can continue to use regular CAPI authentication mechanisms normally. This should only affect users of Rancher v2prov and Rancher Cloud Credentials.

For now, **this is behind a feature gate because it cannot be enabled until the second part of this feature (validation webhook) is implemented adding a security layer** that will prevent users that do not own a given Rancher Cloud Credential from using the translated AWS identity.

Some implementation details:
- A new controller will watch Rancher Cloud Credential `Secrets` in the `cattle-global-data` namespace. It will only trigger on `Secrets` that represent AWS credentials (only the AWS Translator exists).
- Even if there are Rancher AWS Cloud Credentials, the controller will perform a validation to check if the CAPA `CAPIProvider` object is installed and `Status.Phase=Ready`. Otherwise, translation won't happen.
- If the above conditions are met, a new `AWSClusterStaticIdentity` (global resource) and a `Secret` (with the corresponding AWS keys) will be created in `capa-system`.
- The original Rancher Cloud Credential `Secret` is annotated with a reference to the new `AWSClusterStaticIdentity`. This also serves as a way to identify which credentials have already been translated.
- A new finalizer is set on the Rancher Cloud Credential secret to cascade down the deletion of translated objects, namely `AWSClusterStaticIdentity` and `Secret`, before entirely removing the Cloud Credential.
- By default, the translated objects will use the same name as the Rancher Cloud Credential `Secret` object, which is automatically generated `cc-*`.
- The existing E2E test that provisions a AWS RKE2 cluster is updated to use a translated Rancher Cloud Credential. A new `Secret` that represents a Cloud Credential is created and Turtles is deployed with the translation feature gate enabled. The `AWSClusterStaticIdentity` is now embedded in the `AWSClusterTemplate` so that it uses it to authenticate against AWS. All other AWS-related tests continue to work with CAPI-specific authentication mechanisms (remain unchanged).
- A new set of Go tests is added to validate the reconciling logic: including standard translation, not erroring on missing CAPA `CAPIProvider`, translating older Cloud Credentials when CAPA is installed, not translating credentials other than AWS, etc.
- To prevent object name collisions, a reference (annotation) to the original Rancher Cloud Credential `Secret` UID is added to the translated resources (in AWS `Secret` and `AWSClusterStaticIdentity`. This allows the controller to **only** create/update these resources when there are no name collisions. If there's a `Secret` or `AWSClusterStaticIdentity` that exists with the same name as the generated credential, translation will fail and no resources will be created. The cleanup logic is also updated to **only** remove objects which are verified to be owned by a Rancher Cloud Credential that was translated.
- Translated `AWSClusterStaticIdentity` will only allow provisioning clusters to `fleet-default` namespace.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

We decided to have a first implementation that limits user configuration. CAPA `CAPIProvider` is expected to be installed in the default system namespace `capa-system` and with the default name `capa`. Both of these values are defaults in the `rancher-turtles-providers` Helm chart. If there's interest for more granular user configurations, it was agreed that we would study adding it in the future.

**Controller logic is agnostic and should be easily scalable to add more providers by implementing the `CredentialTranslator` interface.**

Additionally, Kubebuilder validation on `providerSpec.configSecret` prevents from populating either `configSecret` or `configSecret.namespace`. However this namespace is populated with a default (the provider's ns) and any update to the object after the default is set will fail because it is caught by the CEL rule.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
