### PR TITLE
fix: Migrate ClusterGroup objects

### DIFF
--- a/scripts/migrate-caapf.sh
+++ b/scripts/migrate-caapf.sh
@@ -35,6 +35,7 @@ MIGRATION_LABEL="migration.fleet.cattle.io/upgrade-2.14=true"
 CAAPF_MANAGED_LABEL="migration.fleet.cattle.io/caapf-managed=true"
 PAUSE_LABEL="migration.fleet.cattle.io/paused=true"
 MIGRATED_CG_LABEL="migration.fleet.cattle.io/from-caapf=true"
+KEEP_RESOURCES_LABEL="migration.fleet.cattle.io/keep-resources=true"
 
 # Rancher/Turtles labels on Management Clusters (v3)
 RANCHER_CAPI_OWNER="cluster-api.cattle.io/capi-cluster-owner"
@@ -307,7 +308,7 @@ if [ "$PHASE" == "pre" ]; then
     done
 
     log "Checking CAAPF ClusterGroups for collisions before replicating into fleet-default..."
-    declare -A CG_SELECTORS
+    declare -A CG_SELECTORS=()
     for CG_NS in "${!COLLISION_NAMESPACES[@]}"; do
         CG_ITEMS=$(kubectl get clustergroups.fleet.cattle.io -n "$CG_NS" -o json 2>/dev/null | jq -c '
             .items[]
@@ -405,7 +406,73 @@ EOF
     for NS in "${!CAPI_CLUSTER_NAMESPACES[@]}" "${!CLASS_NAMESPACES[@]}"; do
         ALL_MIGRATION_NAMESPACES["$NS"]=1
     done
-    
+
+    # keepResources protects the workloads deployed on downstream clusters from being garbage collected.
+    log "Setting keepResources=true on Fleet resources before pausing..."
+    RESOURCES=("gitrepos.fleet.cattle.io" "helmops.fleet.cattle.io" "bundles.fleet.cattle.io")
+    for RES in "${RESOURCES[@]}"; do
+        for NS in "${!ALL_MIGRATION_NAMESPACES[@]}"; do
+            ITEMS=$(kubectl get "$RES" -n "$NS" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+            for NAME in $ITEMS; do
+                if [[ "$RES" == "bundles.fleet.cattle.io" ]]; then
+                    # Skip fleet-agent-* system bundles entirely.
+                    if [[ "$NAME" == fleet-agent-* ]]; then continue; fi
+                    # Skip bundles derived from a GitRepo or HelmOp: they inherit keepResources from their parent resource.
+                    REPO_LABEL=$(kubectl get bundles.fleet.cattle.io "$NAME" -n "$NS" \
+                        -o jsonpath='{.metadata.labels.fleet\.cattle\.io/repo-name}' 2>/dev/null || true)
+                    if [ -n "$REPO_LABEL" ]; then continue; fi
+                    HELMOP_LABEL=$(kubectl get bundles.fleet.cattle.io "$NAME" -n "$NS" \
+                        -o jsonpath='{.metadata.labels.fleet\.cattle\.io/fleet-helm-name}' 2>/dev/null || true)
+                    if [ -n "$HELMOP_LABEL" ]; then continue; fi
+                fi
+
+                # Only set and label keepResources if the resource did not already have it.
+                IS_KEPT=$(kubectl get "$RES" "$NAME" -n "$NS" -o jsonpath='{.spec.keepResources}' 2>/dev/null || true)
+                if [ "$IS_KEPT" != "true" ]; then
+                    log "Setting keepResources=true on $RES $NS/$NAME..."
+                    run_cmd kubectl patch "$RES" "$NAME" -n "$NS" --type='merge' -p '{"spec":{"keepResources":true}}'
+                    run_cmd kubectl label "$RES" "$NAME" -n "$NS" "$KEEP_RESOURCES_LABEL" --overwrite
+                else
+                    log "Skipping keepResources for $NS/$NAME (already set)"
+                fi
+            done
+        done
+    done
+
+    # Wait for keepResources to propagate to the BundleDeployments that target the old Fleet clusters.
+    if [ "$DRY_RUN" != "true" ]; then
+        log "Waiting for keepResources to sync to BundleDeployments..."
+        KR_WAIT_RETRIES=0
+        while true; do
+            PENDING=0
+            for ITEM in "${CAAPF_CLUSTERS[@]}"; do
+                OLD_NS=$(echo "$ITEM" | cut -d'/' -f1)
+                OLD_NAME=$(echo "$ITEM" | cut -d'/' -f2)
+                BDNS=$(kubectl get clusters.fleet.cattle.io "$OLD_NAME" -n "$OLD_NS" -o jsonpath='{.status.namespace}' 2>/dev/null || true)
+                [ -z "$BDNS" ] && continue
+                # Count non-agent BundleDeployments that have not yet picked up keepResources=true.
+                NOT_SYNCED=$(kubectl get bundledeployments -n "$BDNS" -o json 2>/dev/null \
+                    | jq -r --arg agent "fleet-agent-$OLD_NAME" '
+                        [ .items[]
+                          | select(.metadata.labels["fleet.cattle.io/bundle-name"] != $agent)
+                          | select((.spec.options.keepResources // false) != true) ] | length' 2>/dev/null || echo 0)
+                PENDING=$((PENDING + NOT_SYNCED))
+            done
+            if [ "$PENDING" -eq 0 ]; then
+                log "keepResources synced to all BundleDeployments."
+                break
+            fi
+            KR_WAIT_RETRIES=$((KR_WAIT_RETRIES + 1))
+            if [ "$KR_WAIT_RETRIES" -ge 20 ]; then
+                log "ERROR: keepResources did not sync to $PENDING BundleDeployment(s) after 10 minutes."
+                log "Aborting pre-upgrade: deleting old clusters now would risk deleting downstream workloads."
+                exit 1
+            fi
+            log "Still waiting: $PENDING BundleDeployment(s) without keepResources=true..."
+            sleep 30
+        done
+    fi
+
     log "Add migration labels to Fleet resources that are located in CAPI cluster and class namespaces..."
     RESOURCES=("gitrepos.fleet.cattle.io" "helmops.fleet.cattle.io" "bundles.fleet.cattle.io")
     for RES in "${RESOURCES[@]}"; do
@@ -670,6 +737,27 @@ elif [ "$PHASE" == "post" ]; then
                 run_cmd kubectl delete bundlenamespacemappings.fleet.cattle.io "$OLD_NS" -n "$CLASS_NS"
             fi
         fi
+    done
+
+    # Remove keepResources from the resources this script has marked previously.
+    log "Removing keepResources from migrated Fleet resources in fully-migrated namespaces..."
+    KR_PENDING_NS=$(kubectl get clusters.fleet.cattle.io -A -l "$CAAPF_MANAGED_LABEL" \
+        -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' 2>/dev/null \
+        | sort -u || true)
+    RESOURCES=("gitrepos.fleet.cattle.io" "helmops.fleet.cattle.io" "bundles.fleet.cattle.io")
+    for RES in "${RESOURCES[@]}"; do
+        ITEMS=$(kubectl get "$RES" -A -l "${KEEP_RESOURCES_LABEL%=*}=true" -o json 2>/dev/null \
+            | jq -r '.items[] | "\(.metadata.namespace) \(.metadata.name)"' || true)
+        while read -r NS NAME; do
+            [ -z "$NS" ] && continue
+            if [ -n "$KR_PENDING_NS" ] && echo "$KR_PENDING_NS" | grep -qFx "$NS"; then
+                log "Skipping keepResources revert for $RES $NS/$NAME — namespace still has CAAPF-managed Fleet clusters."
+                continue
+            fi
+            log "Removing keepResources from $RES $NS/$NAME"
+            run_cmd kubectl patch "$RES" "$NAME" -n "$NS" --type='merge' -p '{"spec":{"keepResources":null}}'
+            run_cmd kubectl label "$RES" "$NAME" -n "$NS" "${KEEP_RESOURCES_LABEL%=*}"-
+        done <<< "$ITEMS"
     done
 
     log "Delete CAAPF-created ClusterGroups in CAPI and class namespaces..."

--- a/scripts/migrate-caapf.sh
+++ b/scripts/migrate-caapf.sh
@@ -34,6 +34,7 @@ CAAPF_NS="fleet-addon-system"
 MIGRATION_LABEL="migration.fleet.cattle.io/upgrade-2.14=true"
 CAAPF_MANAGED_LABEL="migration.fleet.cattle.io/caapf-managed=true"
 PAUSE_LABEL="migration.fleet.cattle.io/paused=true"
+MIGRATED_CG_LABEL="migration.fleet.cattle.io/from-caapf=true"
 
 # Rancher/Turtles labels on Management Clusters (v3)
 RANCHER_CAPI_OWNER="cluster-api.cattle.io/capi-cluster-owner"
@@ -89,7 +90,7 @@ discover_caapf_clusters() {
 }
 
 if [ "$PHASE" == "pre" ]; then
-    log "Starting pre-upgrade phase for Rancher 2.14.2..."
+    log "Starting pre-upgrade phase for Rancher 2.14..."
 
     log "Scaling down controllers..."
     for DEPLOY in "rancher-turtles-controller-manager:$TURTLES_NS" "caapf-controller-manager:$CAAPF_NS"; do
@@ -305,11 +306,88 @@ if [ "$PHASE" == "pre" ]; then
         fi
     done
 
+    log "Checking CAAPF ClusterGroups for collisions before replicating into fleet-default..."
+    declare -A CG_SELECTORS
+    for CG_NS in "${!COLLISION_NAMESPACES[@]}"; do
+        CG_ITEMS=$(kubectl get clustergroups.fleet.cattle.io -n "$CG_NS" -o json 2>/dev/null | jq -c '
+            .items[]
+            | select((.metadata.ownerReferences // []) | map(
+                select((.kind == "Cluster" or .kind == "ClusterClass")
+                       and (.apiVersion | startswith("cluster.x-k8s.io")))
+              ) | length > 0)
+            | {name: .metadata.name, selector: (.spec.selector // {})}
+        ' || true)
+        while IFS= read -r CG; do
+            [ -z "$CG" ] && continue
+            CG_NAME=$(echo "$CG" | jq -r '.name')
+            CG_SEL=$(echo "$CG" | jq -cS '.selector')
+            # Prevent empty selectors that would target all clusters in fleet-default.
+            IS_EMPTY=$(echo "$CG_SEL" | jq -r '
+                ((.matchLabels // {}) | length) as $ml |
+                ((.matchExpressions // []) | length) as $me |
+                if $ml == 0 and $me == 0 then "true" else "false" end
+            ')
+            if [ "$IS_EMPTY" = "true" ]; then
+                log "ERROR: ClusterGroup '$CG_NS/$CG_NAME' has an empty selector. Replicating it would match ALL clusters in fleet-default."
+                COLLISION_FOUND=true
+                continue
+            fi
+            # Same name across namespaces with different selectors can't merge into one
+            # ClusterGroup in fleet-default.
+            if [ -n "${CG_SELECTORS[$CG_NAME]+_}" ] && [ "${CG_SELECTORS[$CG_NAME]}" != "$CG_SEL" ]; then
+                log "ERROR: ClusterGroup '$CG_NAME' exists in multiple namespaces with different selectors; cannot merge into fleet-default."
+                COLLISION_FOUND=true
+            else
+                CG_SELECTORS["$CG_NAME"]="$CG_SEL"
+            fi
+        done <<< "$CG_ITEMS"
+    done
+
+    # Check for pre-existing ClusterGroups of the same name in fleet-default without the migration label.
+    # These are user-created and should not be overwritten.
+    for CG_NAME in "${!CG_SELECTORS[@]}"; do
+        if kubectl get clustergroups.fleet.cattle.io "$CG_NAME" -n fleet-default &>/dev/null; then
+            EXISTING_TAG=$(kubectl get clustergroups.fleet.cattle.io "$CG_NAME" -n fleet-default \
+                -o jsonpath='{.metadata.labels.migration\.fleet\.cattle\.io/from-caapf}' 2>/dev/null || true)
+            if [ "$EXISTING_TAG" != "true" ]; then
+                log "ERROR: ClusterGroup '$CG_NAME' already exists in fleet-default without the migration marker; cannot safely overwrite."
+                COLLISION_FOUND=true
+            fi
+        fi
+    done
+
     if [ "$COLLISION_FOUND" = "true" ]; then
         log "Aborting pre-upgrade: resolve the above collisions before proceeding."
         exit 1
     fi
     log "No collisions detected. Proceeding with migration."
+
+    # Copy CAAPF ClusterGroups into fleet-default.
+    if [ "${#CG_SELECTORS[@]}" -gt 0 ]; then
+        log "Replicating ${#CG_SELECTORS[@]} CAAPF ClusterGroup(s) into fleet-default..."
+        for CG_NAME in "${!CG_SELECTORS[@]}"; do
+            SEL="${CG_SELECTORS[$CG_NAME]}"
+            CG_JSON=$(cat <<EOF
+{
+  "apiVersion": "fleet.cattle.io/v1alpha1",
+  "kind": "ClusterGroup",
+  "metadata": {
+    "name": "$CG_NAME",
+    "namespace": "fleet-default",
+    "labels": { "${MIGRATED_CG_LABEL%=*}": "${MIGRATED_CG_LABEL#*=}" }
+  },
+  "spec": { "selector": $SEL }
+}
+EOF
+)
+            if [ "$DRY_RUN" = "true" ]; then
+                echo "[DRY-RUN] Would apply ClusterGroup $CG_NAME in fleet-default:"
+                echo "$CG_JSON"
+            else
+                echo "$CG_JSON" | kubectl apply -f -
+            fi
+        done
+    fi
 
     # Label Fleet clusters for post-phase discovery
     for ITEM in "${CAAPF_CLUSTERS[@]}"; do
@@ -593,6 +671,30 @@ elif [ "$PHASE" == "post" ]; then
             fi
         fi
     done
+
+    log "Delete CAAPF-created ClusterGroups in CAPI and class namespaces..."
+    # Skip any namespaces that still contain CAAPF-managed Fleet clusters that are not yet deleted.
+    PENDING_NS=$(kubectl get clusters.fleet.cattle.io -A -l "$CAAPF_MANAGED_LABEL" \
+        -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' 2>/dev/null \
+        | sort -u || true)
+    CG_TO_DELETE=$(kubectl get clustergroups.fleet.cattle.io -A -o json 2>/dev/null | jq -r '
+        .items[]
+        | select(.metadata.namespace != "fleet-default" and .metadata.namespace != "fleet-local")
+        | select((.metadata.ownerReferences // []) | map(
+            select((.kind == "Cluster" or .kind == "ClusterClass")
+                   and (.apiVersion | startswith("cluster.x-k8s.io")))
+          ) | length > 0)
+        | "\(.metadata.namespace) \(.metadata.name)"
+    ' || true)
+    while read -r NS NAME; do
+        [ -z "$NS" ] && continue
+        if [ -n "$PENDING_NS" ] && echo "$PENDING_NS" | grep -qFx "$NS"; then
+            log "Skipping CAAPF ClusterGroup $NS/$NAME — namespace still has CAAPF-managed Fleet clusters."
+            continue
+        fi
+        log "Deleting CAAPF ClusterGroup $NS/$NAME"
+        run_cmd kubectl delete clustergroups.fleet.cattle.io "$NAME" -n "$NS"
+    done <<< "$CG_TO_DELETE"
 
     log "Post-upgrade phase complete."
 else


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR updates the CAAPF migration script in two ways:

1. It migrates ClusterGroup objects that CAAPF originally created, from the CAPI namespaces to `fleet-default`, after verifying that they don't cause any name collisions.
2. It sets `keepResources: true` for any Fleet resources in CAPI/ClusterClass namespaces so that they don't get garbage collected when the new fleet-agent starts running on the downstream cluster, and removes it as part of the post phase. This was noticed when the migration happened without an upgrade taking place.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates to #2439 

**Special notes for your reviewer**:
It may be easier to follow the changes by reviewing each commit separately.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
