### PR TITLE
ci: clean kind build node-image cache on failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,8 +162,8 @@ GOLANGCI_LINT_PKG := github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
 CHART_TESTING_VER := v3.14.0
 
-KIND_VER := v0.31.0
-KIND_VER_SHA256 := eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa
+KIND_VER := v0.32.0
+KIND_VER_SHA256 := 50030de23cf40a18505f20426f6a8506bedf13c6e509244bd1fa9463721b0f54
 
 # Registry / images
 TAG ?= dev

--- a/test/go.mod
+++ b/test/go.mod
@@ -26,7 +26,7 @@ require (
 	sigs.k8s.io/cluster-api-operator/test v0.27.0
 	sigs.k8s.io/cluster-api/test v1.13.2
 	sigs.k8s.io/controller-runtime v0.23.3
-	sigs.k8s.io/kind v0.31.0
+	sigs.k8s.io/kind v0.32.0
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/test/go.sum
+++ b/test/go.sum
@@ -400,8 +400,8 @@ sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4i
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/kind v0.31.0 h1:UcT4nzm+YM7YEbqiAKECk+b6dsvc/HRZZu9U0FolL1g=
-sigs.k8s.io/kind v0.31.0/go.mod h1:FSqriGaoTPruiXWfRnUXNykF8r2t+fHtK0P0m1AbGF8=
+sigs.k8s.io/kind v0.32.0 h1:p9hscbj98u/qyrjVpjId86LI70nQmbSsipV7wCG10Xk=
+sigs.k8s.io/kind v0.32.0/go.mod h1:FSqriGaoTPruiXWfRnUXNykF8r2t+fHtK0P0m1AbGF8=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=

--- a/test/testenv/bootstrapclusterproviders.go
+++ b/test/testenv/bootstrapclusterproviders.go
@@ -19,6 +19,8 @@ package testenv
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -84,7 +86,6 @@ func KindWithExtraPortMappingsBootstrapCluster(ctx context.Context, config *clus
 }
 
 // BuildKindImage is a function that builds a local kindest/node image for an arbitrary k8s version.
-// FIXME: https://github.com/rancher/turtles/issues/2449
 func BuildKindImage(ctx context.Context, version string) {
 	Eventually(func() error {
 		kindBuildImage := turtlesframework.RunCommand(ctx, turtlesframework.RunCommandInput{
@@ -98,12 +99,28 @@ func BuildKindImage(ctx context.Context, version string) {
 			},
 		})
 		if kindBuildImage.Error != nil || kindBuildImage.ExitCode != 0 {
-			GinkgoWriter.Printf("\n\n!!! FIXME: Failed to build kindest/node image !!!")
+			// FIXME: https://github.com/rancher/turtles/issues/2449
+			GinkgoWriter.Printf("\nFailed to build kindest/node image\n")
 			GinkgoWriter.Printf("kind build stdout: \n%s\n", string(kindBuildImage.Stdout))
 			GinkgoWriter.Printf("kind build stderr: \n%s\n", string(kindBuildImage.Stderr))
+			cleanBuildKindImageCache()
 			return fmt.Errorf("Failed to build kindest/node image. Exit Code: %d. Error: %w",
 				kindBuildImage.ExitCode, kindBuildImage.Error)
 		}
 		return nil
 	}).WithPolling(5 * time.Minute).WithTimeout(30 * time.Minute).ShouldNot(HaveOccurred())
+}
+
+// cleanBuildKindImageCache is a helper function that deletes '/tmp/k8s-tar-extract-*' folders.
+// These are created by kind when downloading the k8s tarball that can be ~350MB in size.
+func cleanBuildKindImageCache() {
+	const cleanTarget = "/tmp/k8s-tar-extract-*"
+
+	matches, err := filepath.Glob(cleanTarget)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	for _, match := range matches {
+		GinkgoWriter.Printf("Cleaning kind build image cache %s\n", match)
+		Expect(os.RemoveAll(match)).Should(Succeed())
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds more mitigation for #2449
We observed kind failing to download the k8s tarball:

```txt
Failed to build Kubernetes: error downloading file: error downloading HTTP content from "https://dl.k8s.io/v1.36.1/kubernetes-server-linux-amd64.tar.gz": write /tmp/k8s-tar-extract-1669232424/kubernetes-v1.36.1-server-linux-amd64.tar.gz: no space left on device
```

This happened on the vSphere runner that seems to clean /tmp daily, see:

```txt
> systemctl status systemd-tmpfiles-clean.timer 
● systemd-tmpfiles-clean.timer - Daily Cleanup of Temporary Directories
     Loaded: loaded (/usr/lib/systemd/system/systemd-tmpfiles-clean.timer; static)
     Active: active (waiting) since Wed 2026-06-03 04:29:48 UTC; 1 day 3h ago
 Invocation: ee66df19a8f84891bf4671bfe9f9cbb2
    Trigger: Fri 2026-06-05 04:45:13 UTC; 20h left
   Triggers: ● systemd-tmpfiles-clean.service
       Docs: man:tmpfiles.d(5)
             man:systemd-tmpfiles(8)

Jun 03 04:29:48 ***** systemd[1]: Started Daily Cleanup of Temporary Directories.
```

runner seems to have plenty of space available as well:

```txt
> df -h /tmp
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           7.9G  2.7G  5.2G  35% /tmp
```

So I am not sure this is going to fix the problem. However the run that failed managed to build the first image for the management Cluster, which means clearing these cache folders may work if we have space to at least build one:

```txt
STEP: Building kindest/node:v1.36.1 for management Cluster @ 06/01/26 00:30:21.44 --> Succeeded
STEP: Building kindest/node:v1.36.1 for downstream Clusters @ 06/01/26 00:31:29.117 --> Failed
```

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
