### PR TITLE
[release/v0.27] Bump dependencies to fix security issues and prepare providers chart for 0.27.0-rc.3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.25"
+  go: "1.26"
   allow-parallel-runners: true
 linters:
   default: all

--- a/charts/rancher-turtles-providers/Chart.yaml
+++ b/charts/rancher-turtles-providers/Chart.yaml
@@ -3,8 +3,8 @@ name: rancher-turtles-providers
 description: This chart installs the Rancher Turtles certified providers.
 home: https://turtles.docs.rancher.com/turtles/stable/en/overview/certified.html
 icon: https://raw.githubusercontent.com/rancher/turtles/main/logos/capi.svg
-version: 0.27.0-rc.2
-appVersion: "0.27.0-rc.2"
+version: 0.27.0-rc.3
+appVersion: "0.27.0-rc.3"
 keywords:
   - rancher
   - cluster-api

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -22,7 +22,7 @@ imagePullSecrets: []
 shellImage:
   image:
     repository: rancher/kuberlr-kubectl
-    tag: v8.0.0
+    tag: v8.1.0
 # features: Optional and experimental features.
 features:
   # agent-tls-mode: Beta feature for agent TLS.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/examples
 
-go 1.25.10
+go 1.26.4
 
 require (
 	github.com/agnivade/levenshtein v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles
 
-go 1.26.3
+go 1.26.4
 
 ignore (
 	./hack/tools/krew

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/test
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/rancher/turtles => ../
 

--- a/tilt/project/Tiltfile
+++ b/tilt/project/Tiltfile
@@ -295,7 +295,7 @@ def get_port_forwards(debug):
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.25.10 as tilt-helper
+FROM golang:1.26.4 as tilt-helper
 # Support live reloading with Tilt
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/restart.sh  && \


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/rancher/kuberlr-kubectl/releases/tag/v8.1.0

Related to: https://github.com/rancherlabs/image-scanning/issues/10199

Also bumps golang to 1.26.4

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Once merged, I am planning to cut a new rc for release/v0.27 branch

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
