### PR TITLE
[release/v0.26] Bump dependencies to fix security issues and prepare providers chart for 0.26.3-rc.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Go",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:1.24",
+	"image": "mcr.microsoft.com/devcontainers/go:1.25",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},

--- a/charts/rancher-turtles-providers/Chart.yaml
+++ b/charts/rancher-turtles-providers/Chart.yaml
@@ -3,8 +3,8 @@ name: rancher-turtles-providers
 description: This chart installs the Rancher Turtles certified providers.
 home: https://turtles.docs.rancher.com/turtles/stable/en/overview/certified.html
 icon: https://raw.githubusercontent.com/rancher/turtles/main/logos/capi.svg
-version: 0.26.2
-appVersion: "0.26.2"
+version: 0.26.3-rc.0
+appVersion: "0.26.3-rc.0"
 keywords:
   - rancher
   - cluster-api

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -22,7 +22,7 @@ imagePullSecrets: []
 shellImage:
   image:
     repository: rancher/kuberlr-kubectl
-    tag: v7.0.3
+    tag: v7.1.0
 # features: Optional and experimental features.
 features:
   # agent-tls-mode: Beta feature for agent TLS.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/examples
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/agnivade/levenshtein v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/test
 
-go 1.25.10
+go 1.25.11
 
 replace github.com/rancher/turtles => ../
 

--- a/tilt/project/Tiltfile
+++ b/tilt/project/Tiltfile
@@ -295,7 +295,7 @@ def get_port_forwards(debug):
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.25.10 as tilt-helper
+FROM golang:1.25.11 as tilt-helper
 # Support live reloading with Tilt
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/restart.sh  && \


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/rancher/kuberlr-kubectl/releases/tag/v7.1.0

Related to: https://github.com/rancherlabs/image-scanning/issues/8193 and https://github.com/rancherlabs/image-scanning/issues/8244

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Once merged, I am planning to cut a new patch for the release/v0.26 branch


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
