### PR TITLE
fix: avoid secondary envtest panic on startup failure

### DIFF
--- a/internal/test/helpers/envtest.go
+++ b/internal/test/helpers/envtest.go
@@ -164,7 +164,7 @@ func NewTestEnvironmentConfiguration(crdDirectoryPaths ...string) *TestEnvironme
 // usually the environment is initialized in a suite_test.go file within a `BeforeSuite` ginkgo block.
 func (t *TestEnvironmentConfiguration) Build() (*TestEnvironment, error) {
 	if _, err := t.env.Start(); err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	options := manager.Options{
@@ -206,7 +206,17 @@ func (t *TestEnvironment) StartManager(ctx context.Context) error {
 
 // Stop stops the test environment.
 func (t *TestEnvironment) Stop() error {
-	t.cancel()
+	if t == nil {
+		return nil
+	}
+
+	if t.cancel != nil {
+		t.cancel()
+	}
+
+	if t.env == nil {
+		return nil
+	}
 
 	return t.env.Stop()
 }

--- a/internal/test/helpers/envtest_test.go
+++ b/internal/test/helpers/envtest_test.go
@@ -1,0 +1,41 @@
+package helpers
+
+import (
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+func TestBuildReturnsEnvtestStartError(t *testing.T) {
+	t.Setenv("KUBEBUILDER_ASSETS", "")
+
+	cfg := &TestEnvironmentConfiguration{
+		env: &envtest.Environment{
+			BinaryAssetsDirectory: t.TempDir(),
+		},
+	}
+
+	env, err := cfg.Build()
+	if err == nil {
+		if env != nil {
+			_ = env.Stop()
+		}
+		t.Fatal("expected Build to return an error when envtest assets are missing")
+	}
+}
+
+func TestStopHandlesNilEnvironment(t *testing.T) {
+	var testEnv *TestEnvironment
+
+	if err := testEnv.Stop(); err != nil {
+		t.Fatalf("expected nil environment stop to succeed, got %v", err)
+	}
+}
+
+func TestStopHandlesPartiallyInitializedEnvironment(t *testing.T) {
+	testEnv := &TestEnvironment{}
+
+	if err := testEnv.Stop(); err != nil {
+		t.Fatalf("expected partially initialized environment stop to succeed, got %v", err)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
When envtest startup blows up, `Build()` panics before returning and teardown can hit a second nil panic in `Stop()`. That hides the real failure and makes the output kinda noisy.

This patch returns the startup error from `Build()`, makes `Stop()` safe for nil or partial envs, and adds unit tests for both paths.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**Special notes for your reviewer**:
Repro before fix:
1. Run `go test ./util/predicates -run TestClusterPredicates -count=1` in an env where envtest startup fails, for example missing `KUBEBUILDER_ASSETS`.
2. You get the real startup error, then a second nil pointer panic in teardown. not great

After this patch, you only get the real startup failure.

I also ran `make test` after the change.

**Checklist**:
- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests