### PR TITLE
chore: remove ghcr.io usage from dev-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,8 @@ vendor-clean:
 	rm -rf vendor
 
 .PHOHY: dev-env
-dev-env: kind build-local-rancher-charts ## Create a local development environment
+dev-env: kind ## Create a local development environment
+	REGISTRY=docker.io $(MAKE) build-local-rancher-charts
 	./scripts/turtles-dev.sh ${RANCHER_HOSTNAME}
 
 ## --------------------------------------

--- a/Tiltfile
+++ b/Tiltfile
@@ -40,7 +40,7 @@ always_enable_projects = ["turtles"]
 projects = {
     "turtles": {
         "context": ".",
-        "image": "ghcr.io/rancher/turtles:dev",
+        "image": "docker.io/rancher/turtles:dev",
         "live_reload_deps": [
             "main.go",
             "go.mod",

--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -30,7 +30,8 @@ RANCHER_IMAGE=${RANCHER_IMAGE:-rancher/rancher:$RANCHER_IMAGE_TAG}
 CLUSTER_NAME=${CLUSTER_NAME:-capi-test}
 USE_TILT_DEV=${USE_TILT_DEV:-true}
 TURTLES_VERSION=${TURTLES_VERSION:-dev}
-TURTLES_IMAGE=${TURTLES_IMAGE:-ghcr.io/rancher/turtles:$TURTLES_VERSION}
+TURTLES_REPO=${TURTLES_REPO:-docker.io}
+TURTLES_IMAGE=${TURTLES_IMAGE:-$TURTLES_REPO/rancher/turtles:$TURTLES_VERSION}
 KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.36.1}
 
 GITEA_PASSWORD=${GITEA_PASSWORD:-giteaadmin}
@@ -90,7 +91,7 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # Build and load the controller image
-make docker-build-prime
+REGISTRY="$TURTLES_REPO" make docker-build-prime
 kind load docker-image $TURTLES_IMAGE --name $CLUSTER_NAME
 
 # Deploy Gitea test Nodeport

--- a/tilt-settings.json.example
+++ b/tilt-settings.json.example
@@ -1,5 +1,5 @@
 {
-    "default_registry": "ghcr.io/test",
+    "default_registry": "docker.io/rancher",
     "debug": {
         "turtles": {
             "continue": true,

--- a/tilt/project/Tiltfile
+++ b/tilt/project/Tiltfile
@@ -130,8 +130,7 @@ def update_manager(yaml, containerName, debug, env, name, project):
             for c in containers:
                 if c["name"] != containerName:
                     continue
-                if name != "turtles":  # use custom image for projects except turtles
-                    c["image"] = project.get("image")
+                c["image"] = project.get("image")
                 if project.get("command"):
                     c["command"] = project.get("command")
                 # Append additional args from the main file to any existing container args


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aligns the dev-env with docker.io usage.
This is currently broken when tilt is not used, since it builds a docker.io image but uses a ghcr.io one by default.
It should now work consistently when dev-env is used with or without tilt.

Note that ghcr.io registry is still used for e2e tests (short and long)

Related to https://github.com/rancher/turtles/issues/2495

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
