### PR TITLE
ci: add renovate workflow and config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>rancher/renovate-config//rancher-main#release"
+  ],
+  "devbox": {
+    "enabled": false
+  },
+  "baseBranchPatterns": [
+    "release/v0.26"
+  ],
+  "packageRules": [
+    {
+      "description": "Disable rancher/turtles updates on dockerfiles. This avoids PRs that bump the version tag in Turtles Helm chart.",
+      "matchPackageNames": ["rancher/turtles"],
+      "matchDatasources": ["docker"],
+      "enabled": false
+    },
+    {
+      "description": "Align with core CAPI v1.12 dependencies",
+      "matchBaseBranches": ["release/v0.26"],
+      "matchPackageNames": [
+        "sigs.k8s.io/controller-runtime"
+      ],
+      "allowedVersions": "<0.23.0"
+    },
+    {
+      "description": "Align with core CAPI v1.12 dependencies",
+      "matchBaseBranches": ["release/v0.26"],
+      "matchPackageNames": [
+        "k8s.io/**"
+      ],
+      "allowedVersions": "<0.35.0"
+    },
+    {
+      "description": "Pin rancher/kuberlr-kubectl to version 7 (v7.x.x)",
+      "matchBaseBranches": ["release/v0.26"],
+      "matchPackageNames": ["rancher/kuberlr-kubectl"],
+      "allowedVersions": "^7.0.0"
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,7 +36,7 @@
       "description": "Pin rancher/kuberlr-kubectl to version 7 (v7.x.x)",
       "matchBaseBranches": ["release/v0.26"],
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
-      "allowedVersions": "^7.0.0"
+      "allowedVersions": "<8.0.0"
     }
   ]
 }

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,43 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Override default log level"
+        required: false
+        default: info
+        type: choice
+        options:
+          - info
+          - debug
+      overrideSchedule:
+        description: "Override all schedules"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      dryRun:
+        description: "Set dry-run type (null, full)"
+        required: false
+        default: "null"
+        type: string
+  schedule:
+    # Run at 06:30 on every day-of-week from Monday through Friday.
+    - cron: '30 6 * * 1-5'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  call-workflow:
+    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@a9fa41f899dfd0b3f211f7a897ec19ec7c4462c4 # v1.0.3
+    with:
+      logLevel: ${{ inputs.logLevel || 'info' }}
+      overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
+      dryRun: ${{ github.event.inputs.dryRun || 'null' }}
+    secrets: 
+      override-token: ${{ secrets.RENOVATE_FORK_GH_TOKEN || '' }}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR introduces a CI workflow that runs Renovate daily as well as a Renovate config file that constraints the versions of some of the dependencies to better align them with upstream CAPI. For now only `release/v0.26` will receive dependency bump PRs, this was intentional to avoid flooding us with PRs until we fine-tune the config further.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #2363 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
