### PR TITLE
[backport-release/v0.25] fix: use go generate for release against Rancher

### DIFF
--- a/.github/scripts/release-against-rancher.sh
+++ b/.github/scripts/release-against-rancher.sh
@@ -132,12 +132,7 @@ fi
 
 yq --inplace ".turtlesVersion = \"${NEW_CHART_VERSION}+up${NEW_TURTLES_VERSION_SHORT}\"" ./build.yaml
 
-# Downloads dapper
-make .dapper
-
-# DAPPER_MODE=bind will make sure we output everything that changed
-DAPPER_MODE=bind ./.dapper go generate ./... || true
-DAPPER_MODE=bind ./.dapper rm -rf go .config
+go generate ./...
 
 git add .
 git commit -m "$COMMIT_MSG"


### PR DESCRIPTION
**What this PR does / why we need it**:
manual backport of https://github.com/rancher/turtles/pull/2369

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
While releasing a new release from release/v0.25 branch: https://github.com/rancher/turtles/actions/runs/27266834439/job/80525941819 CI fails due to dapper being not found. Fix was backported to >=release/v0.26  branches and hence this is the reason of failure

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
