### PR TITLE
chore: refactor Docker/Kubeadm test to remove CAAPF

### DIFF
--- a/examples/applications/cni/calico/helm-chart.yaml
+++ b/examples/applications/cni/calico/helm-chart.yaml
@@ -43,9 +43,7 @@ spec:
         operator: In
         values:
           - azure-kubeadm-example
-          - docker-kubeadm-example
           - docker-rke2-example
-          - docker-rke2-v1beta1-example
           - etcd-snapshot-restore
           - vsphere-kubeadm-example
           - vsphere-rke2-example

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -102,6 +102,11 @@ var (
 	//go:embed data/cluster-templates/vsphere-rke2-topology.yaml
 	CAPIvSphereRKE2Topology []byte
 
+	// Downstream test manifests
+
+	//go:embed data/applications/calico.yaml
+	CalicoManifest []byte
+
 	// CAPIProvider test data
 
 	//go:embed data/test-providers/capv-provider-no-ver.yaml

--- a/test/e2e/data/applications/calico.yaml
+++ b/test/e2e/data/applications/calico.yaml
@@ -1,0 +1,7425 @@
+---
+# Source: https://raw.githubusercontent.com/projectcalico/calico/refs/tags/v3.31.5/manifests/calico.yaml
+# This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    k8s-app: calico-kube-controllers
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
+---
+# Source: calico/templates/calico-kube-controllers.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+---
+# Source: calico/templates/calico-node.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system
+---
+# Source: calico/templates/calico-node.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-cni-plugin
+  namespace: kube-system
+---
+# Source: calico/templates/calico-config.yaml
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # Typha is disabled.
+  typha_service_name: "none"
+  # Configure the backend to use.
+  calico_backend: "bird"
+
+  # Configure the MTU to use for workload interfaces and tunnels.
+  # By default, MTU is auto-detected, and explicitly setting this field should not be required.
+  # You can override auto-detection by providing a non-zero value.
+  veth_mtu: "0"
+
+  # The CNI network configuration to install on each node. The special
+  # values in this config will be automatically populated.
+  cni_network_config: |-
+    {
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "calico",
+          "log_level": "info",
+          "log_file_path": "/var/log/calico/cni/cni.log",
+          "datastore_type": "kubernetes",
+          "nodename": "__KUBERNETES_NODE_NAME__",
+          "mtu": __CNI_MTU__,
+          "ipam": {
+              "type": "calico-ipam"
+          },
+          "policy": {
+              "type": "k8s"
+          },
+          "kubernetes": {
+              "kubeconfig": "__KUBECONFIG_FILEPATH__"
+          }
+        },
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
+        }
+      ]
+    }
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPConfiguration
+    listKind: BGPConfigurationList
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                asNumber:
+                  format: int32
+                  type: integer
+                bindMode:
+                  type: string
+                communities:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                        type: string
+                    type: object
+                  type: array
+                ignoredInterfaces:
+                  items:
+                    type: string
+                  type: array
+                listenPort:
+                  maximum: 65535
+                  minimum: 1
+                  type: integer
+                localWorkloadPeeringIPV4:
+                  type: string
+                localWorkloadPeeringIPV6:
+                  type: string
+                logSeverityScreen:
+                  type: string
+                nodeMeshMaxRestartTime:
+                  type: string
+                nodeMeshPassword:
+                  properties:
+                    secretKeyRef:
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          default: ""
+                          type: string
+                        optional:
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                nodeToNodeMeshEnabled:
+                  type: boolean
+                prefixAdvertisements:
+                  items:
+                    properties:
+                      cidr:
+                        type: string
+                      communities:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                serviceClusterIPs:
+                  items:
+                    properties:
+                      cidr:
+                        type: string
+                    type: object
+                  type: array
+                serviceExternalIPs:
+                  items:
+                    properties:
+                      cidr:
+                        type: string
+                    type: object
+                  type: array
+                serviceLoadBalancerAggregation:
+                  default: Enabled
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                serviceLoadBalancerIPs:
+                  items:
+                    properties:
+                      cidr:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: bgpfilters.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPFilter
+    listKind: BGPFilterList
+    plural: bgpfilters
+    singular: bgpfilter
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                exportV4:
+                  items:
+                    properties:
+                      action:
+                        type: string
+                      cidr:
+                        type: string
+                      interface:
+                        type: string
+                      matchOperator:
+                        type: string
+                      prefixLength:
+                        properties:
+                          max:
+                            format: int32
+                            maximum: 32
+                            minimum: 0
+                            type: integer
+                          min:
+                            format: int32
+                            maximum: 32
+                            minimum: 0
+                            type: integer
+                        type: object
+                      source:
+                        type: string
+                    required:
+                      - action
+                    type: object
+                  type: array
+                exportV6:
+                  items:
+                    properties:
+                      action:
+                        type: string
+                      cidr:
+                        type: string
+                      interface:
+                        type: string
+                      matchOperator:
+                        type: string
+                      prefixLength:
+                        properties:
+                          max:
+                            format: int32
+                            maximum: 128
+                            minimum: 0
+                            type: integer
+                          min:
+                            format: int32
+                            maximum: 128
+                            minimum: 0
+                            type: integer
+                        type: object
+                      source:
+                        type: string
+                    required:
+                      - action
+                    type: object
+                  type: array
+                importV4:
+                  items:
+                    properties:
+                      action:
+                        type: string
+                      cidr:
+                        type: string
+                      interface:
+                        type: string
+                      matchOperator:
+                        type: string
+                      prefixLength:
+                        properties:
+                          max:
+                            format: int32
+                            maximum: 32
+                            minimum: 0
+                            type: integer
+                          min:
+                            format: int32
+                            maximum: 32
+                            minimum: 0
+                            type: integer
+                        type: object
+                      source:
+                        type: string
+                    required:
+                      - action
+                    type: object
+                  type: array
+                importV6:
+                  items:
+                    properties:
+                      action:
+                        type: string
+                      cidr:
+                        type: string
+                      interface:
+                        type: string
+                      matchOperator:
+                        type: string
+                      prefixLength:
+                        properties:
+                          max:
+                            format: int32
+                            maximum: 128
+                            minimum: 0
+                            type: integer
+                          min:
+                            format: int32
+                            maximum: 128
+                            minimum: 0
+                            type: integer
+                        type: object
+                      source:
+                        type: string
+                    required:
+                      - action
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: bgppeers.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPPeer
+    listKind: BGPPeerList
+    plural: bgppeers
+    singular: bgppeer
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                asNumber:
+                  format: int32
+                  type: integer
+                filters:
+                  items:
+                    type: string
+                  type: array
+                keepOriginalNextHop:
+                  type: boolean
+                localASNumber:
+                  format: int32
+                  type: integer
+                localWorkloadSelector:
+                  type: string
+                maxRestartTime:
+                  type: string
+                nextHopMode:
+                  allOf:
+                    - enum:
+                        - Auto
+                        - Self
+                        - Keep
+                    - enum:
+                        - Auto
+                        - Self
+                        - Keep
+                  type: string
+                node:
+                  type: string
+                nodeSelector:
+                  type: string
+                numAllowedLocalASNumbers:
+                  format: int32
+                  type: integer
+                password:
+                  properties:
+                    secretKeyRef:
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          default: ""
+                          type: string
+                        optional:
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                peerIP:
+                  type: string
+                peerSelector:
+                  type: string
+                reachableBy:
+                  type: string
+                reversePeering:
+                  enum:
+                    - Auto
+                    - Manual
+                  type: string
+                sourceAddress:
+                  type: string
+                ttlSecurity:
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: blockaffinities.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BlockAffinity
+    listKind: BlockAffinityList
+    plural: blockaffinities
+    singular: blockaffinity
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                cidr:
+                  type: string
+                deleted:
+                  type: string
+                node:
+                  type: string
+                state:
+                  type: string
+                type:
+                  type: string
+              required:
+                - cidr
+                - deleted
+                - node
+                - state
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: caliconodestatuses.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: CalicoNodeStatus
+    listKind: CalicoNodeStatusList
+    plural: caliconodestatuses
+    singular: caliconodestatus
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                classes:
+                  items:
+                    type: string
+                  type: array
+                node:
+                  type: string
+                updatePeriodSeconds:
+                  format: int32
+                  type: integer
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    birdV4:
+                      properties:
+                        lastBootTime:
+                          type: string
+                        lastReconfigurationTime:
+                          type: string
+                        routerID:
+                          type: string
+                        state:
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                    birdV6:
+                      properties:
+                        lastBootTime:
+                          type: string
+                        lastReconfigurationTime:
+                          type: string
+                        routerID:
+                          type: string
+                        state:
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                  type: object
+                bgp:
+                  properties:
+                    numberEstablishedV4:
+                      type: integer
+                    numberEstablishedV6:
+                      type: integer
+                    numberNotEstablishedV4:
+                      type: integer
+                    numberNotEstablishedV6:
+                      type: integer
+                    peersV4:
+                      items:
+                        properties:
+                          peerIP:
+                            type: string
+                          since:
+                            type: string
+                          state:
+                            type: string
+                          type:
+                            type: string
+                        type: object
+                      type: array
+                    peersV6:
+                      items:
+                        properties:
+                          peerIP:
+                            type: string
+                          since:
+                            type: string
+                          state:
+                            type: string
+                          type:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                    - numberEstablishedV4
+                    - numberEstablishedV6
+                    - numberNotEstablishedV4
+                    - numberNotEstablishedV6
+                  type: object
+                lastUpdated:
+                  format: date-time
+                  nullable: true
+                  type: string
+                routes:
+                  properties:
+                    routesV4:
+                      items:
+                        properties:
+                          destination:
+                            type: string
+                          gateway:
+                            type: string
+                          interface:
+                            type: string
+                          learnedFrom:
+                            properties:
+                              peerIP:
+                                type: string
+                              sourceType:
+                                type: string
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      type: array
+                    routesV6:
+                      items:
+                        properties:
+                          destination:
+                            type: string
+                          gateway:
+                            type: string
+                          interface:
+                            type: string
+                          learnedFrom:
+                            properties:
+                              peerIP:
+                                type: string
+                              sourceType:
+                                type: string
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: ClusterInformation
+    listKind: ClusterInformationList
+    plural: clusterinformations
+    singular: clusterinformation
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                calicoVersion:
+                  type: string
+                clusterGUID:
+                  type: string
+                clusterType:
+                  type: string
+                datastoreReady:
+                  type: boolean
+                variant:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: FelixConfiguration
+    listKind: FelixConfigurationList
+    plural: felixconfigurations
+    singular: felixconfiguration
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: Felix Configuration contains the configuration for Felix.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: FelixConfigurationSpec contains the values of the Felix configuration.
+              properties:
+                allowIPIPPacketsFromWorkloads:
+                  description: |-
+                    AllowIPIPPacketsFromWorkloads controls whether Felix will add a rule to drop IPIP encapsulated traffic
+                    from workloads. [Default: false]
+                  type: boolean
+                allowVXLANPacketsFromWorkloads:
+                  description: |-
+                    AllowVXLANPacketsFromWorkloads controls whether Felix will add a rule to drop VXLAN encapsulated traffic
+                    from workloads. [Default: false]
+                  type: boolean
+                awsSrcDstCheck:
+                  description: |-
+                    AWSSrcDstCheck controls whether Felix will try to change the "source/dest check" setting on the EC2 instance
+                    on which it is running. A value of "Disable" will try to disable the source/dest check. Disabling the check
+                    allows for sending workload traffic without encapsulation within the same AWS subnet.
+                    [Default: DoNothing]
+                  enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                  type: string
+                bpfAttachType:
+                  description: |-
+                    BPFAttachType controls how are the BPF programs at the network interfaces attached.
+                    By default `TCX` is used where available to enable easier coexistence with 3rd party programs.
+                    `TC` can force the legacy method of attaching via a qdisc. `TCX` falls back to `TC` if `TCX` is not available.
+                    [Default: TCX]
+                  enum:
+                    - TC
+                    - TCX
+                  type: string
+                bpfCTLBLogFilter:
+                  description: |-
+                    BPFCTLBLogFilter specifies, what is logged by connect time load balancer when BPFLogLevel is
+                    debug. Currently has to be specified as 'all' when BPFLogFilters is set
+                    to see CTLB logs.
+                    [Default: unset - means logs are emitted when BPFLogLevel id debug and BPFLogFilters not set.]
+                  type: string
+                bpfConnectTimeLoadBalancing:
+                  description: |-
+                    BPFConnectTimeLoadBalancing when in BPF mode, controls whether Felix installs the connect-time load
+                    balancer. The connect-time load balancer is required for the host to be able to reach Kubernetes services
+                    and it improves the performance of pod-to-service connections.When set to TCP, connect time load balancing
+                    is available only for services with TCP ports. [Default: TCP]
+                  enum:
+                    - TCP
+                    - Enabled
+                    - Disabled
+                  type: string
+                bpfConnectTimeLoadBalancingEnabled:
+                  description: |-
+                    BPFConnectTimeLoadBalancingEnabled when in BPF mode, controls whether Felix installs the connection-time load
+                    balancer.  The connect-time load balancer is required for the host to be able to reach Kubernetes services
+                    and it improves the performance of pod-to-service connections.  The only reason to disable it is for debugging
+                    purposes.
+
+                    Deprecated: Use BPFConnectTimeLoadBalancing [Default: true]
+                  type: boolean
+                bpfConntrackLogLevel:
+                  description: |-
+                    BPFConntrackLogLevel controls the log level of the BPF conntrack cleanup program, which runs periodically
+                    to clean up expired BPF conntrack entries.
+                    [Default: Off].
+                  enum:
+                    - "Off"
+                    - Debug
+                  type: string
+                bpfConntrackMode:
+                  description: |-
+                    BPFConntrackCleanupMode controls how BPF conntrack entries are cleaned up.  `Auto` will use a BPF program if supported,
+                    falling back to userspace if not.  `Userspace` will always use the userspace cleanup code.  `BPFProgram` will
+                    always use the BPF program (failing if not supported).
+
+                    /To be deprecated in future versions as conntrack map type changed to
+                    lru_hash and userspace cleanup is the only mode that is supported.
+                    [Default: Userspace]
+                  enum:
+                    - Auto
+                    - Userspace
+                    - BPFProgram
+                  type: string
+                bpfConntrackTimeouts:
+                  description: |-
+                    BPFConntrackTimers overrides the default values for the specified conntrack timer if
+                    set. Each value can be either a duration or `Auto` to pick the value from
+                    a Linux conntrack timeout.
+
+                    Configurable timers are: CreationGracePeriod, TCPSynSent,
+                    TCPEstablished, TCPFinsSeen, TCPResetSeen, UDPTimeout, GenericTimeout,
+                    ICMPTimeout.
+
+                    Unset values are replaced by the default values with a warning log for
+                    incorrect values.
+                  properties:
+                    creationGracePeriod:
+                      description: |-
+                        CreationGracePeriod gives a generic grace period to new connections
+                        before they are considered for cleanup [Default: 10s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    genericTimeout:
+                      description: |-
+                        GenericTimeout controls how long it takes before considering this
+                        entry for cleanup after the connection became idle. If set to 'Auto', the
+                        value from nf_conntrack_generic_timeout is used. If nil, Calico uses its
+                        own default value. [Default: 10m].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    icmpTimeout:
+                      description: |-
+                        ICMPTimeout controls how long it takes before considering this
+                        entry for cleanup after the connection became idle. If set to 'Auto', the
+                        value from nf_conntrack_icmp_timeout is used. If nil, Calico uses its
+                        own default value. [Default: 5s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    tcpEstablished:
+                      description: |-
+                        TCPEstablished controls how long it takes before considering this entry for
+                        cleanup after the connection became idle. If set to 'Auto', the
+                        value from nf_conntrack_tcp_timeout_established is used. If nil, Calico uses
+                        its own default value. [Default: 1h].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    tcpFinsSeen:
+                      description: |-
+                        TCPFinsSeen controls how long it takes before considering this entry for
+                        cleanup after the connection was closed gracefully. If set to 'Auto', the
+                        value from nf_conntrack_tcp_timeout_time_wait is used. If nil, Calico uses
+                        its own default value. [Default: Auto].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    tcpResetSeen:
+                      description: |-
+                        TCPResetSeen controls how long it takes before considering this entry for
+                        cleanup after the connection was aborted. If nil, Calico uses its own
+                        default value. [Default: 40s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    tcpSynSent:
+                      description: |-
+                        TCPSynSent controls how long it takes before considering this entry for
+                        cleanup after the last SYN without a response. If set to 'Auto', the
+                        value from nf_conntrack_tcp_timeout_syn_sent is used. If nil, Calico uses
+                        its own default value. [Default: 20s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    udpTimeout:
+                      description: |-
+                        UDPTimeout controls how long it takes before considering this entry for
+                        cleanup after the connection became idle. If nil, Calico uses its own
+                        default value. [Default: 60s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                  type: object
+                bpfDSROptoutCIDRs:
+                  description: |-
+                    BPFDSROptoutCIDRs is a list of CIDRs which are excluded from DSR. That is, clients
+                    in those CIDRs will access service node ports as if BPFExternalServiceMode was set to
+                    Tunnel.
+                  items:
+                    type: string
+                  type: array
+                bpfDataIfacePattern:
+                  description: |-
+                    BPFDataIfacePattern is a regular expression that controls which interfaces Felix should attach BPF programs to
+                    in order to catch traffic to/from the network.  This needs to match the interfaces that Calico workload traffic
+                    flows over as well as any interfaces that handle incoming traffic to nodeports and services from outside the
+                    cluster.  It should not match the workload interfaces (usually named cali...) or any other special device managed
+                    by Calico itself (e.g., tunnels).
+                  type: string
+                bpfDisableGROForIfaces:
+                  description: |-
+                    BPFDisableGROForIfaces is a regular expression that controls which interfaces Felix should disable the
+                    Generic Receive Offload [GRO] option.  It should not match the workload interfaces (usually named cali...).
+                  type: string
+                bpfDisableUnprivileged:
+                  description: |-
+                    BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled sysctl to disable
+                    unprivileged use of BPF.  This ensures that unprivileged users cannot access Calico's BPF maps and
+                    cannot insert their own BPF programs to interfere with Calico's. [Default: true]
+                  type: boolean
+                bpfEnabled:
+                  description:
+                    "BPFEnabled, if enabled Felix will use the BPF dataplane.
+                    [Default: false]"
+                  type: boolean
+                bpfEnforceRPF:
+                  description: |-
+                    BPFEnforceRPF enforce strict RPF on all host interfaces with BPF programs regardless of
+                    what is the per-interfaces or global setting. Possible values are Disabled, Strict
+                    or Loose. [Default: Loose]
+                  pattern: ^(?i)(Disabled|Strict|Loose)?$
+                  type: string
+                bpfExcludeCIDRsFromNAT:
+                  description: |-
+                    BPFExcludeCIDRsFromNAT is a list of CIDRs that are to be excluded from NAT
+                    resolution so that host can handle them. A typical usecase is node local
+                    DNS cache.
+                  items:
+                    type: string
+                  type: array
+                bpfExportBufferSizeMB:
+                  description: |-
+                    BPFExportBufferSizeMB in BPF mode, controls the buffer size used for sending BPF events to felix.
+                    [Default: 1]
+                  type: integer
+                bpfExtToServiceConnmark:
+                  description: |-
+                    BPFExtToServiceConnmark in BPF mode, controls a 32bit mark that is set on connections from an
+                    external client to a local service. This mark allows us to control how packets of that
+                    connection are routed within the host and how is routing interpreted by RPF check. [Default: 0]
+                  type: integer
+                bpfExternalServiceMode:
+                  description: |-
+                    BPFExternalServiceMode in BPF mode, controls how connections from outside the cluster to services (node ports
+                    and cluster IPs) are forwarded to remote workloads.  If set to "Tunnel" then both request and response traffic
+                    is tunneled to the remote node.  If set to "DSR", the request traffic is tunneled but the response traffic
+                    is sent directly from the remote node.  In "DSR" mode, the remote node appears to use the IP of the ingress
+                    node; this requires a permissive L2 network.  [Default: Tunnel]
+                  pattern: ^(?i)(Tunnel|DSR)?$
+                  type: string
+                bpfForceTrackPacketsFromIfaces:
+                  description: |-
+                    BPFForceTrackPacketsFromIfaces in BPF mode, forces traffic from these interfaces
+                    to skip Calico's iptables NOTRACK rule, allowing traffic from those interfaces to be
+                    tracked by Linux conntrack.  Should only be used for interfaces that are not used for
+                    the Calico fabric.  For example, a docker bridge device for non-Calico-networked
+                    containers. [Default: docker+]
+                  items:
+                    type: string
+                  type: array
+                bpfHostConntrackBypass:
+                  description: |-
+                    BPFHostConntrackBypass Controls whether to bypass Linux conntrack in BPF mode for
+                    workloads and services. [Default: true - bypass Linux conntrack]
+                  type: boolean
+                bpfHostNetworkedNATWithoutCTLB:
+                  description: |-
+                    BPFHostNetworkedNATWithoutCTLB when in BPF mode, controls whether Felix does a NAT without CTLB. This along with BPFConnectTimeLoadBalancing
+                    determines the CTLB behavior. [Default: Enabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                bpfJITHardening:
+                  allOf:
+                    - enum:
+                        - Auto
+                        - Strict
+                    - enum:
+                        - Auto
+                        - Strict
+                  description: |-
+                    BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
+                    if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
+                    Felix will not modify the JIT hardening setting. [Default: Auto]
+                  type: string
+                bpfKubeProxyEndpointSlicesEnabled:
+                  description: |-
+                    BPFKubeProxyEndpointSlicesEnabled is deprecated and has no effect. BPF
+                    kube-proxy always accepts endpoint slices. This option will be removed in
+                    the next release.
+                  type: boolean
+                bpfKubeProxyHealthzPort:
+                  description: |-
+                    BPFKubeProxyHealthzPort, in BPF mode, controls the port that Felix's embedded kube-proxy health check server binds to.
+                    The health check server is used by external load balancers to determine if this node should receive traffic.  [Default: 10256]
+                  type: integer
+                bpfKubeProxyIptablesCleanupEnabled:
+                  description: |-
+                    BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF mode, Felix will proactively clean up the upstream
+                    Kubernetes kube-proxy's iptables chains.  Should only be enabled if kube-proxy is not running.  [Default: true]
+                  type: boolean
+                bpfKubeProxyMinSyncPeriod:
+                  description: |-
+                    BPFKubeProxyMinSyncPeriod, in BPF mode, controls the minimum time between updates to the dataplane for Felix's
+                    embedded kube-proxy.  Lower values give reduced set-up latency.  Higher values reduce Felix CPU usage by
+                    batching up more work.  [Default: 1s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                bpfL3IfacePattern:
+                  description: |-
+                    BPFL3IfacePattern is a regular expression that allows to list tunnel devices like wireguard or vxlan (i.e., L3 devices)
+                    in addition to BPFDataIfacePattern. That is, tunnel interfaces not created by Calico, that Calico workload traffic flows
+                    over as well as any interfaces that handle incoming traffic to nodeports and services from outside the cluster.
+                  type: string
+                bpfLogFilters:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    BPFLogFilters is a map of key=values where the value is
+                    a pcap filter expression and the key is an interface name with 'all'
+                    denoting all interfaces, 'weps' all workload endpoints and 'heps' all host
+                    endpoints.
+
+                    When specified as an env var, it accepts a comma-separated list of
+                    key=values.
+                    [Default: unset - means all debug logs are emitted]
+                  type: object
+                bpfLogLevel:
+                  description: |-
+                    BPFLogLevel controls the log level of the BPF programs when in BPF dataplane mode.  One of "Off", "Info", or
+                    "Debug".  The logs are emitted to the BPF trace pipe, accessible with the command `tc exec bpf debug`.
+                    [Default: Off].
+                  pattern: ^(?i)(Off|Info|Debug)?$
+                  type: string
+                bpfMapSizeConntrack:
+                  description: |-
+                    BPFMapSizeConntrack sets the size for the conntrack map.  This map must be large enough to hold
+                    an entry for each active connection.  Warning: changing the size of the conntrack map can cause disruption.
+                  type: integer
+                bpfMapSizeConntrackCleanupQueue:
+                  description: |-
+                    BPFMapSizeConntrackCleanupQueue sets the size for the map used to hold NAT conntrack entries that are queued
+                    for cleanup.  This should be big enough to hold all the NAT entries that expire within one cleanup interval.
+                  minimum: 1
+                  type: integer
+                bpfMapSizeConntrackScaling:
+                  description: |-
+                    BPFMapSizeConntrackScaling controls whether and how we scale the conntrack map size depending
+                    on its usage. 'Disabled' make the size stay at the default or whatever is set by
+                    BPFMapSizeConntrack*. 'DoubleIfFull' doubles the size when the map is pretty much full even
+                    after cleanups. [Default: DoubleIfFull]
+                  pattern: ^(?i)(Disabled|DoubleIfFull)?$
+                  type: string
+                bpfMapSizeIPSets:
+                  description: |-
+                    BPFMapSizeIPSets sets the size for ipsets map.  The IP sets map must be large enough to hold an entry
+                    for each endpoint matched by every selector in the source/destination matches in network policy.  Selectors
+                    such as "all()" can result in large numbers of entries (one entry per endpoint in that case).
+                  type: integer
+                bpfMapSizeIfState:
+                  description: |-
+                    BPFMapSizeIfState sets the size for ifstate map.  The ifstate map must be large enough to hold an entry
+                    for each device (host + workloads) on a host.
+                  type: integer
+                bpfMapSizeNATAffinity:
+                  description: |-
+                    BPFMapSizeNATAffinity sets the size of the BPF map that stores the affinity of a connection (for services that
+                    enable that feature.
+                  type: integer
+                bpfMapSizeNATBackend:
+                  description: |-
+                    BPFMapSizeNATBackend sets the size for NAT back end map.
+                    This is the total number of endpoints. This is mostly
+                    more than the size of the number of services.
+                  type: integer
+                bpfMapSizeNATFrontend:
+                  description: |-
+                    BPFMapSizeNATFrontend sets the size for NAT front end map.
+                    FrontendMap should be large enough to hold an entry for each nodeport,
+                    external IP and each port in each service.
+                  type: integer
+                bpfMapSizePerCpuConntrack:
+                  description: |-
+                    BPFMapSizePerCPUConntrack determines the size of conntrack map based on the number of CPUs. If set to a
+                    non-zero value, overrides BPFMapSizeConntrack with `BPFMapSizePerCPUConntrack * (Number of CPUs)`.
+                    This map must be large enough to hold an entry for each active connection.  Warning: changing the size of the
+                    conntrack map can cause disruption.
+                  type: integer
+                bpfMapSizeRoute:
+                  description: |-
+                    BPFMapSizeRoute sets the size for the routes map.  The routes map should be large enough
+                    to hold one entry per workload and a handful of entries per host (enough to cover its own IPs and
+                    tunnel IPs).
+                  type: integer
+                bpfPSNATPorts:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: |-
+                    BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
+                    collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
+                    preferably outside the  ephemeral ranges used by common operating systems. Linux uses
+                    32768–60999, while others mostly use the IANA defined range 49152–65535. It is not necessarily
+                    a problem if this range overlaps with the operating systems. Both ends of the range are
+                    inclusive. [Default: 20000:29999]
+                  pattern: ^.*
+                  x-kubernetes-int-or-string: true
+                bpfPolicyDebugEnabled:
+                  description: |-
+                    BPFPolicyDebugEnabled when true, Felix records detailed information
+                    about the BPF policy programs, which can be examined with the calico-bpf command-line tool.
+                  type: boolean
+                bpfProfiling:
+                  description: |-
+                    BPFProfiling controls profiling of BPF programs. At the monent, it can be
+                    Disabled or Enabled. [Default: Disabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                bpfRedirectToPeer:
+                  description: |-
+                    BPFRedirectToPeer controls which whether it is allowed to forward straight to the
+                    peer side of the workload devices. It is allowed for any host L2 devices by default
+                    (L2Only), but it breaks TCP dump on the host side of workload device as it bypasses
+                    it on ingress. Value of Enabled also allows redirection from L3 host devices like
+                    IPIP tunnel or Wireguard directly to the peer side of the workload's device. This
+                    makes redirection faster, however, it breaks tools like tcpdump on the peer side.
+                    Use Enabled with caution. [Default: L2Only]
+                  enum:
+                    - Enabled
+                    - Disabled
+                    - L2Only
+                  type: string
+                cgroupV2Path:
+                  description:
+                    CgroupV2Path overrides the default location where to
+                    find the cgroup hierarchy.
+                  type: string
+                chainInsertMode:
+                  description: |-
+                    ChainInsertMode controls whether Felix hooks the kernel's top-level iptables chains by inserting a rule
+                    at the top of the chain or by appending a rule at the bottom. insert is the safe default since it prevents
+                    Calico's rules from being bypassed. If you switch to append mode, be sure that the other rules in the chains
+                    signal acceptance by falling through to the Calico rules, otherwise the Calico policy will be bypassed.
+                    [Default: insert]
+                  pattern: ^(?i)(Insert|Append)?$
+                  type: string
+                dataplaneDriver:
+                  description: |-
+                    DataplaneDriver filename of the external dataplane driver to use.  Only used if UseInternalDataplaneDriver
+                    is set to false.
+                  type: string
+                dataplaneWatchdogTimeout:
+                  description: |-
+                    DataplaneWatchdogTimeout is the readiness/liveness timeout used for Felix's (internal) dataplane driver.
+                    Deprecated: replaced by the generic HealthTimeoutOverrides.
+                  type: string
+                debugDisableLogDropping:
+                  description: |-
+                    DebugDisableLogDropping disables the dropping of log messages when the log buffer is full.  This can
+                    significantly impact performance if log write-out is a bottleneck. [Default: false]
+                  type: boolean
+                debugHost:
+                  description: |-
+                    DebugHost is the host IP or hostname to bind the debug port to.  Only used
+                    if DebugPort is set. [Default:localhost]
+                  type: string
+                debugMemoryProfilePath:
+                  description:
+                    DebugMemoryProfilePath is the path to write the memory
+                    profile to when triggered by signal.
+                  type: string
+                debugPort:
+                  description: |-
+                    DebugPort if set, enables Felix's debug HTTP port, which allows memory and CPU profiles
+                    to be retrieved.  The debug port is not secure, it should not be exposed to the internet.
+                  type: integer
+                debugSimulateCalcGraphHangAfter:
+                  description: |-
+                    DebugSimulateCalcGraphHangAfter is used to simulate a hang in the calculation graph after the specified duration.
+                    This is useful in tests of the watchdog system only!
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                debugSimulateDataplaneApplyDelay:
+                  description: |-
+                    DebugSimulateDataplaneApplyDelay adds an artificial delay to every dataplane operation.  This is useful for
+                    simulating a heavily loaded system for test purposes only.
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                debugSimulateDataplaneHangAfter:
+                  description: |-
+                    DebugSimulateDataplaneHangAfter is used to simulate a hang in the dataplane after the specified duration.
+                    This is useful in tests of the watchdog system only!
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                defaultEndpointToHostAction:
+                  description: |-
+                    DefaultEndpointToHostAction controls what happens to traffic that goes from a workload endpoint to the host
+                    itself (after the endpoint's egress policy is applied). By default, Calico blocks traffic from workload
+                    endpoints to the host itself with an iptables "DROP" action. If you want to allow some or all traffic from
+                    endpoint to host, set this parameter to RETURN or ACCEPT. Use RETURN if you have your own rules in the iptables
+                    "INPUT" chain; Calico will insert its rules at the top of that chain, then "RETURN" packets to the "INPUT" chain
+                    once it has completed processing workload endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                    from workloads after processing workload endpoint egress policy. [Default: Drop]
+                  pattern: ^(?i)(Drop|Accept|Return)?$
+                  type: string
+                deviceRouteProtocol:
+                  description: |-
+                    DeviceRouteProtocol controls the protocol to set on routes programmed by Felix. The protocol is an 8-bit label
+                    used to identify the owner of the route.
+                  type: integer
+                deviceRouteSourceAddress:
+                  description: |-
+                    DeviceRouteSourceAddress IPv4 address to set as the source hint for routes programmed by Felix. When not set
+                    the source address for local traffic from host to workload will be determined by the kernel.
+                  type: string
+                deviceRouteSourceAddressIPv6:
+                  description: |-
+                    DeviceRouteSourceAddressIPv6 IPv6 address to set as the source hint for routes programmed by Felix. When not set
+                    the source address for local traffic from host to workload will be determined by the kernel.
+                  type: string
+                disableConntrackInvalidCheck:
+                  description: |-
+                    DisableConntrackInvalidCheck disables the check for invalid connections in conntrack. While the conntrack
+                    invalid check helps to detect malicious traffic, it can also cause issues with certain multi-NIC scenarios.
+                  type: boolean
+                endpointReportingDelay:
+                  description: |-
+                    EndpointReportingDelay is the delay before Felix reports endpoint status to the datastore. This is only used
+                    by the OpenStack integration. [Default: 1s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                endpointReportingEnabled:
+                  description: |-
+                    EndpointReportingEnabled controls whether Felix reports endpoint status to the datastore. This is only used
+                    by the OpenStack integration. [Default: false]
+                  type: boolean
+                endpointStatusPathPrefix:
+                  description: |-
+                    EndpointStatusPathPrefix is the path to the directory where endpoint status will be written. Endpoint status
+                    file reporting is disabled if field is left empty.
+
+                    Chosen directory should match the directory used by the CNI plugin for PodStartupDelay.
+                    [Default: /var/run/calico]
+                  type: string
+                externalNodesList:
+                  description: |-
+                    ExternalNodesCIDRList is a list of CIDR's of external, non-Calico nodes from which VXLAN/IPIP overlay traffic
+                    will be allowed.  By default, external tunneled traffic is blocked to reduce attack surface.
+                  items:
+                    type: string
+                  type: array
+                failsafeInboundHostPorts:
+                  description: |-
+                    FailsafeInboundHostPorts is a list of ProtoPort struct objects including UDP/TCP/SCTP ports and CIDRs that Felix will
+                    allow incoming traffic to host endpoints on irrespective of the security policy. This is useful to avoid accidentally
+                    cutting off a host with incorrect configuration. For backwards compatibility, if the protocol is not specified,
+                    it defaults to "tcp". If a CIDR is not specified, it will allow traffic from all addresses. To disable all inbound host ports,
+                    use the value "[]". The default value allows ssh access, DHCP, BGP, etcd and the Kubernetes API.
+                    [Default: tcp:22, udp:68, tcp:179, tcp:2379, tcp:2380, tcp:5473, tcp:6443, tcp:6666, tcp:6667 ]
+                  items:
+                    description:
+                      ProtoPort is combination of protocol, port, and CIDR.
+                      Protocol and port must be specified.
+                    properties:
+                      net:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        type: string
+                    required:
+                      - port
+                    type: object
+                  type: array
+                failsafeOutboundHostPorts:
+                  description: |-
+                    FailsafeOutboundHostPorts is a list of PortProto struct objects including UDP/TCP/SCTP ports and CIDRs that Felix
+                    will allow outgoing traffic from host endpoints to irrespective of the security policy. This is useful to avoid accidentally
+                    cutting off a host with incorrect configuration. For backwards compatibility, if the protocol is not specified, it defaults
+                    to "tcp". If a CIDR is not specified, it will allow traffic from all addresses. To disable all outbound host ports,
+                    use the value "[]". The default value opens etcd's standard ports to ensure that Felix does not get cut off from etcd
+                    as well as allowing DHCP, DNS, BGP and the Kubernetes API.
+                    [Default: udp:53, udp:67, tcp:179, tcp:2379, tcp:2380, tcp:5473, tcp:6443, tcp:6666, tcp:6667 ]
+                  items:
+                    description:
+                      ProtoPort is combination of protocol, port, and CIDR.
+                      Protocol and port must be specified.
+                    properties:
+                      net:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        type: string
+                    required:
+                      - port
+                    type: object
+                  type: array
+                featureDetectOverride:
+                  description: |-
+                    FeatureDetectOverride is used to override feature detection based on auto-detected platform
+                    capabilities.  Values are specified in a comma separated list with no spaces, example;
+                    "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=". A value of "true" or "false" will
+                    force enable/disable feature, empty or omitted values fall back to auto-detection.
+                  pattern: ^([a-zA-Z0-9-_]+=(true|false|),)*([a-zA-Z0-9-_]+=(true|false|))?$
+                  type: string
+                featureGates:
+                  description: |-
+                    FeatureGates is used to enable or disable tech-preview Calico features.
+                    Values are specified in a comma separated list with no spaces, example;
+                    "BPFConnectTimeLoadBalancingWorkaround=enabled,XyZ=false". This is
+                    used to enable features that are not fully production ready.
+                  pattern: ^([a-zA-Z0-9-_]+=([^=]+),)*([a-zA-Z0-9-_]+=([^=]+))?$
+                  type: string
+                floatingIPs:
+                  description: |-
+                    FloatingIPs configures whether or not Felix will program non-OpenStack floating IP addresses.  (OpenStack-derived
+                    floating IPs are always programmed, regardless of this setting.)
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                flowLogsCollectorDebugTrace:
+                  description: |-
+                    When FlowLogsCollectorDebugTrace is set to true, enables the logs in the collector to be
+                    printed in their entirety.
+                  type: boolean
+                flowLogsFlushInterval:
+                  description:
+                    FlowLogsFlushInterval configures the interval at which
+                    Felix exports flow logs.
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                flowLogsGoldmaneServer:
+                  description:
+                    FlowLogGoldmaneServer is the flow server endpoint to
+                    which flow data should be published.
+                  type: string
+                flowLogsLocalReporter:
+                  description:
+                    "FlowLogsLocalReporter configures local unix socket for
+                    reporting flow data from each node. [Default: Disabled]"
+                  enum:
+                    - Disabled
+                    - Enabled
+                  type: string
+                flowLogsPolicyEvaluationMode:
+                  description: |-
+                    Continuous - Felix evaluates active flows on a regular basis to determine the rule
+                    traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+                    pending_policies field, offering a near-real-time view of policy changes across flows.
+                    None - Felix stops evaluating pending traces.
+                    [Default: Continuous]
+                  enum:
+                    - None
+                    - Continuous
+                  type: string
+                genericXDPEnabled:
+                  description: |-
+                    GenericXDPEnabled enables Generic XDP so network cards that don't support XDP offload or driver
+                    modes can use XDP. This is not recommended since it doesn't provide better performance than
+                    iptables. [Default: false]
+                  type: boolean
+                goGCThreshold:
+                  description: |-
+                    GoGCThreshold Sets the Go runtime's garbage collection threshold.  I.e. the percentage that the heap is
+                    allowed to grow before garbage collection is triggered.  In general, doubling the value halves the CPU time
+                    spent doing GC, but it also doubles peak GC memory overhead.  A special value of -1 can be used
+                    to disable GC entirely; this should only be used in conjunction with the GoMemoryLimitMB setting.
+
+                    This setting is overridden by the GOGC environment variable.
+
+                    [Default: 40]
+                  type: integer
+                goMaxProcs:
+                  description: |-
+                    GoMaxProcs sets the maximum number of CPUs that the Go runtime will use concurrently.  A value of -1 means
+                    "use the system default"; typically the number of real CPUs on the system.
+
+                    this setting is overridden by the GOMAXPROCS environment variable.
+
+                    [Default: -1]
+                  type: integer
+                goMemoryLimitMB:
+                  description: |-
+                    GoMemoryLimitMB sets a (soft) memory limit for the Go runtime in MB.  The Go runtime will try to keep its memory
+                    usage under the limit by triggering GC as needed.  To avoid thrashing, it will exceed the limit if GC starts to
+                    take more than 50% of the process's CPU time.  A value of -1 disables the memory limit.
+
+                    Note that the memory limit, if used, must be considerably less than any hard resource limit set at the container
+                    or pod level.  This is because felix is not the only process that must run in the container or pod.
+
+                    This setting is overridden by the GOMEMLIMIT environment variable.
+
+                    [Default: -1]
+                  type: integer
+                healthEnabled:
+                  description: |-
+                    HealthEnabled if set to true, enables Felix's health port, which provides readiness and liveness endpoints.
+                    [Default: false]
+                  type: boolean
+                healthHost:
+                  description:
+                    "HealthHost is the host that the health server should
+                    bind to. [Default: localhost]"
+                  type: string
+                healthPort:
+                  description:
+                    "HealthPort is the TCP port that the health server should
+                    bind to. [Default: 9099]"
+                  type: integer
+                healthTimeoutOverrides:
+                  description: |-
+                    HealthTimeoutOverrides allows the internal watchdog timeouts of individual subcomponents to be
+                    overridden.  This is useful for working around "false positive" liveness timeouts that can occur
+                    in particularly stressful workloads or if CPU is constrained.  For a list of active
+                    subcomponents, see Felix's logs.
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      timeout:
+                        type: string
+                    required:
+                      - name
+                      - timeout
+                    type: object
+                  type: array
+                interfaceExclude:
+                  description: |-
+                    InterfaceExclude A comma-separated list of interface names that should be excluded when Felix is resolving
+                    host endpoints. The default value ensures that Felix ignores Kubernetes' internal `kube-ipvs0` device. If you
+                    want to exclude multiple interface names using a single value, the list supports regular expressions. For
+                    regular expressions you must wrap the value with `/`. For example having values `/^kube/,veth1` will exclude
+                    all interfaces that begin with `kube` and also the interface `veth1`. [Default: kube-ipvs0]
+                  type: string
+                interfacePrefix:
+                  description: |-
+                    InterfacePrefix is the interface name prefix that identifies workload endpoints and so distinguishes
+                    them from host endpoint interfaces. Note: in environments other than bare metal, the orchestrators
+                    configure this appropriately. For example our Kubernetes and Docker integrations set the 'cali' value,
+                    and our OpenStack integration sets the 'tap' value. [Default: cali]
+                  type: string
+                interfaceRefreshInterval:
+                  description: |-
+                    InterfaceRefreshInterval is the period at which Felix rescans local interfaces to verify their state.
+                    The rescan can be disabled by setting the interval to 0.
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                ipForwarding:
+                  description: |-
+                    IPForwarding controls whether Felix sets the host sysctls to enable IP forwarding.  IP forwarding is required
+                    when using Calico for workload networking.  This should be disabled only on hosts where Calico is used solely for
+                    host protection. In BPF mode, due to a kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                    must be disabled. [Default: Enabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                ipipEnabled:
+                  description: |-
+                    IPIPEnabled overrides whether Felix should configure an IPIP interface on the host. Optional as Felix
+                    determines this based on the existing IP pools. [Default: nil (unset)]
+                  type: boolean
+                ipipMTU:
+                  description: |-
+                    IPIPMTU controls the MTU to set on the IPIP tunnel device.  Optional as Felix auto-detects the MTU based on the
+                    MTU of the host's interfaces. [Default: 0 (auto-detect)]
+                  type: integer
+                ipsetsRefreshInterval:
+                  description: |-
+                    IpsetsRefreshInterval controls the period at which Felix re-checks all IP sets to look for discrepancies.
+                    Set to 0 to disable the periodic refresh. [Default: 90s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                iptablesBackend:
+                  description: |-
+                    IptablesBackend controls which backend of iptables will be used. The default is `Auto`.
+
+                    Warning: changing this on a running system can leave "orphaned" rules in the "other" backend. These
+                    should be cleaned up to avoid confusing interactions.
+                  pattern: ^(?i)(Auto|Legacy|NFT)?$
+                  type: string
+                iptablesFilterAllowAction:
+                  description: |-
+                    IptablesFilterAllowAction controls what happens to traffic that is accepted by a Felix policy chain in the
+                    iptables filter table (which is used for "normal" policy). The default will immediately `Accept` the traffic. Use
+                    `Return` to send the traffic back up to the system chains for further processing.
+                  pattern: ^(?i)(Accept|Return)?$
+                  type: string
+                iptablesFilterDenyAction:
+                  description: |-
+                    IptablesFilterDenyAction controls what happens to traffic that is denied by network policy. By default Calico blocks traffic
+                    with an iptables "DROP" action. If you want to use "REJECT" action instead you can configure it in here.
+                  pattern: ^(?i)(Drop|Reject)?$
+                  type: string
+                iptablesLockFilePath:
+                  description: |-
+                    IptablesLockFilePath is the location of the iptables lock file. You may need to change this
+                    if the lock file is not in its standard location (for example if you have mapped it into Felix's
+                    container at a different path). [Default: /run/xtables.lock]
+                  type: string
+                iptablesLockProbeInterval:
+                  description: |-
+                    IptablesLockProbeInterval when IptablesLockTimeout is enabled: the time that Felix will wait between
+                    attempts to acquire the iptables lock if it is not available. Lower values make Felix more
+                    responsive when the lock is contended, but use more CPU. [Default: 50ms]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                iptablesLockTimeout:
+                  description: |-
+                    IptablesLockTimeout is the time that Felix itself will wait for the iptables lock (rather than delegating the
+                    lock handling to the `iptables` command).
+
+                    Deprecated: `iptables-restore` v1.8+ always takes the lock, so enabling this feature results in deadlock.
+                    [Default: 0s disabled]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                iptablesMangleAllowAction:
+                  description: |-
+                    IptablesMangleAllowAction controls what happens to traffic that is accepted by a Felix policy chain in the
+                    iptables mangle table (which is used for "pre-DNAT" policy). The default will immediately `Accept` the traffic.
+                    Use `Return` to send the traffic back up to the system chains for further processing.
+                  pattern: ^(?i)(Accept|Return)?$
+                  type: string
+                iptablesMarkMask:
+                  description: |-
+                    IptablesMarkMask is the mask that Felix selects its IPTables Mark bits from. Should be a 32 bit hexadecimal
+                    number with at least 8 bits set, none of which clash with any other mark bits in use on the system.
+                    [Default: 0xffff0000]
+                  format: int32
+                  type: integer
+                iptablesNATOutgoingInterfaceFilter:
+                  description: |-
+                    This parameter can be used to limit the host interfaces on which Calico will apply SNAT to traffic leaving a
+                    Calico IPAM pool with "NAT outgoing" enabled. This can be useful if you have a main data interface, where
+                    traffic should be SNATted and a secondary device (such as the docker bridge) which is local to the host and
+                    doesn't require SNAT. This parameter uses the iptables interface matching syntax, which allows + as a
+                    wildcard. Most users will not need to set this. Example: if your data interfaces are eth0 and eth1 and you
+                    want to exclude the docker bridge, you could set this to eth+
+                  type: string
+                iptablesPostWriteCheckInterval:
+                  description: |-
+                    IptablesPostWriteCheckInterval is the period after Felix has done a write
+                    to the dataplane that it schedules an extra read back in order to check the write was not
+                    clobbered by another process. This should only occur if another application on the system
+                    doesn't respect the iptables lock. [Default: 1s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                iptablesRefreshInterval:
+                  description: |-
+                    IptablesRefreshInterval is the period at which Felix re-checks the IP sets
+                    in the dataplane to ensure that no other process has accidentally broken Calico's rules.
+                    Set to 0 to disable IP sets refresh. Note: the default for this value is lower than the
+                    other refresh intervals as a workaround for a Linux kernel bug that was fixed in kernel
+                    version 4.11. If you are using v4.11 or greater you may want to set this to, a higher value
+                    to reduce Felix CPU usage. [Default: 10s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                ipv6Support:
+                  description:
+                    IPv6Support controls whether Felix enables support for
+                    IPv6 (if supported by the in-use dataplane).
+                  type: boolean
+                kubeNodePortRanges:
+                  description: |-
+                    KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
+                    Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
+                  items:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  type: array
+                logActionRateLimit:
+                  description: |-
+                    LogActionRateLimit sets the rate of hitting a Log action. The value must be in the format "N/unit",
+                    where N is a number and unit is one of: second, minute, hour, or day. For example: "10/second" or "100/hour".
+                  pattern: ^[1-9]\d{0,3}/(?:second|minute|hour|day)$
+                  type: string
+                logActionRateLimitBurst:
+                  description:
+                    LogActionRateLimitBurst sets the rate limit burst of
+                    hitting a Log action when LogActionRateLimit is enabled.
+                  maximum: 9999
+                  minimum: 0
+                  type: integer
+                logDebugFilenameRegex:
+                  description: |-
+                    LogDebugFilenameRegex controls which source code files have their Debug log output included in the logs.
+                    Only logs from files with names that match the given regular expression are included.  The filter only applies
+                    to Debug level logs.
+                  type: string
+                logFilePath:
+                  description:
+                    "LogFilePath is the full path to the Felix log. Set to
+                    none to disable file logging. [Default: /var/log/calico/felix.log]"
+                  type: string
+                logPrefix:
+                  description: |-
+                    LogPrefix is the log prefix that Felix uses when rendering LOG rules. It is possible to use the following specifiers
+                    to include extra information in the log prefix.
+                    - %t: Tier name.
+                    - %k: Kind (short names).
+                    - %n: Policy or profile name.
+                    - %p: Policy or profile name (namespace/name for namespaced kinds or just name for non namespaced kinds).
+                    Calico includes ": " characters at the end of the generated log prefix.
+                    Note that iptables shows up to 29 characters for the log prefix and nftables up to 127 characters. Extra characters are truncated.
+                    [Default: calico-packet]
+                  pattern: "^([a-zA-Z0-9%: /_-])*$"
+                  type: string
+                logSeverityFile:
+                  description:
+                    "LogSeverityFile is the log severity above which logs
+                    are sent to the log file. [Default: Info]"
+                  pattern: ^(?i)(Trace|Debug|Info|Warning|Error|Fatal)?$
+                  type: string
+                logSeverityScreen:
+                  description:
+                    "LogSeverityScreen is the log severity above which logs
+                    are sent to the stdout. [Default: Info]"
+                  pattern: ^(?i)(Trace|Debug|Info|Warning|Error|Fatal)?$
+                  type: string
+                logSeveritySys:
+                  description: |-
+                    LogSeveritySys is the log severity above which logs are sent to the syslog. Set to None for no logging to syslog.
+                    [Default: Info]
+                  pattern: ^(?i)(Trace|Debug|Info|Warning|Error|Fatal)?$
+                  type: string
+                maxIpsetSize:
+                  description: |-
+                    MaxIpsetSize is the maximum number of IP addresses that can be stored in an IP set. Not applicable
+                    if using the nftables backend.
+                  type: integer
+                metadataAddr:
+                  description: |-
+                    MetadataAddr is the IP address or domain name of the server that can answer VM queries for
+                    cloud-init metadata. In OpenStack, this corresponds to the machine running nova-api (or in
+                    Ubuntu, nova-api-metadata). A value of none (case-insensitive) means that Felix should not
+                    set up any NAT rule for the metadata path. [Default: 127.0.0.1]
+                  type: string
+                metadataPort:
+                  description: |-
+                    MetadataPort is the port of the metadata server. This, combined with global.MetadataAddr (if
+                    not 'None'), is used to set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                    In most cases this should not need to be changed [Default: 8775].
+                  type: integer
+                mtuIfacePattern:
+                  description: |-
+                    MTUIfacePattern is a regular expression that controls which interfaces Felix should scan in order
+                    to calculate the host's MTU.
+                    This should not match workload interfaces (usually named cali...).
+                  type: string
+                natOutgoingAddress:
+                  description: |-
+                    NATOutgoingAddress specifies an address to use when performing source NAT for traffic in a natOutgoing pool that
+                    is leaving the network. By default the address used is an address on the interface the traffic is leaving on
+                    (i.e. it uses the iptables MASQUERADE target).
+                  type: string
+                natOutgoingExclusions:
+                  description: |-
+                    When a IP pool setting `natOutgoing` is true, packets sent from Calico networked containers in this IP pool to destinations will be masqueraded.
+                    Configure which type of destinations is excluded from being masqueraded.
+                    - IPPoolsOnly: destinations outside of this IP pool will be masqueraded.
+                    - IPPoolsAndHostIPs: destinations outside of this IP pool and all hosts will be masqueraded.
+                    [Default: IPPoolsOnly]
+                  enum:
+                    - IPPoolsOnly
+                    - IPPoolsAndHostIPs
+                  type: string
+                natPortRange:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: |-
+                    NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
+                    network stack is used.
+                  pattern: ^.*
+                  x-kubernetes-int-or-string: true
+                netlinkTimeout:
+                  description: |-
+                    NetlinkTimeout is the timeout when talking to the kernel over the netlink protocol, used for programming
+                    routes, rules, and other kernel objects. [Default: 10s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                nftablesFilterAllowAction:
+                  description: |-
+                    NftablesFilterAllowAction controls the nftables action that Felix uses to represent the "allow" policy verdict
+                    in the filter table. The default is to `ACCEPT` the traffic, which is a terminal action.  Alternatively,
+                    `RETURN` can be used to return the traffic back to the top-level chain for further processing by your rules.
+                  pattern: ^(?i)(Accept|Return)?$
+                  type: string
+                nftablesFilterDenyAction:
+                  description: |-
+                    NftablesFilterDenyAction controls what happens to traffic that is denied by network policy. By default, Calico
+                    blocks traffic with a "drop" action. If you want to use a "reject" action instead you can configure it here.
+                  pattern: ^(?i)(Drop|Reject)?$
+                  type: string
+                nftablesMangleAllowAction:
+                  description: |-
+                    NftablesMangleAllowAction controls the nftables action that Felix uses to represent the "allow" policy verdict
+                    in the mangle table. The default is to `ACCEPT` the traffic, which is a terminal action.  Alternatively,
+                    `RETURN` can be used to return the traffic back to the top-level chain for further processing by your rules.
+                  pattern: ^(?i)(Accept|Return)?$
+                  type: string
+                nftablesMarkMask:
+                  description: |-
+                    NftablesMarkMask is the mask that Felix selects its nftables Mark bits from. Should be a 32 bit hexadecimal
+                    number with at least 8 bits set, none of which clash with any other mark bits in use on the system.
+                    [Default: 0xffff0000]
+                  format: int32
+                  type: integer
+                nftablesMode:
+                  description:
+                    "NFTablesMode configures nftables support in Felix. [Default:
+                    Disabled]"
+                  enum:
+                    - Disabled
+                    - Enabled
+                    - Auto
+                  type: string
+                nftablesRefreshInterval:
+                  description:
+                    "NftablesRefreshInterval controls the interval at which
+                    Felix periodically refreshes the nftables rules. [Default: 90s]"
+                  type: string
+                openstackRegion:
+                  description: |-
+                    OpenstackRegion is the name of the region that a particular Felix belongs to. In a multi-region
+                    Calico/OpenStack deployment, this must be configured somehow for each Felix (here in the datamodel,
+                    or in felix.cfg or the environment on each compute node), and must match the [calico]
+                    openstack_region value configured in neutron.conf on each node. [Default: Empty]
+                  type: string
+                policySyncPathPrefix:
+                  description: |-
+                    PolicySyncPathPrefix is used to by Felix to communicate policy changes to external services,
+                    like Application layer policy. [Default: Empty]
+                  type: string
+                programClusterRoutes:
+                  description: |-
+                    ProgramClusterRoutes specifies whether Felix should program IPIP routes instead of BIRD.
+                    Felix always programs VXLAN routes. [Default: Disabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                prometheusGoMetricsEnabled:
+                  description: |-
+                    PrometheusGoMetricsEnabled disables Go runtime metrics collection, which the Prometheus client does by default, when
+                    set to false. This reduces the number of metrics reported, reducing Prometheus load. [Default: true]
+                  type: boolean
+                prometheusMetricsEnabled:
+                  description:
+                    "PrometheusMetricsEnabled enables the Prometheus metrics
+                    server in Felix if set to true. [Default: false]"
+                  type: boolean
+                prometheusMetricsHost:
+                  description:
+                    "PrometheusMetricsHost is the host that the Prometheus
+                    metrics server should bind to. [Default: empty]"
+                  type: string
+                prometheusMetricsPort:
+                  description:
+                    "PrometheusMetricsPort is the TCP port that the Prometheus
+                    metrics server should bind to. [Default: 9091]"
+                  type: integer
+                prometheusProcessMetricsEnabled:
+                  description: |-
+                    PrometheusProcessMetricsEnabled disables process metrics collection, which the Prometheus client does by default, when
+                    set to false. This reduces the number of metrics reported, reducing Prometheus load. [Default: true]
+                  type: boolean
+                prometheusWireGuardMetricsEnabled:
+                  description: |-
+                    PrometheusWireGuardMetricsEnabled disables wireguard metrics collection, which the Prometheus client does by default, when
+                    set to false. This reduces the number of metrics reported, reducing Prometheus load. [Default: true]
+                  type: boolean
+                removeExternalRoutes:
+                  description: |-
+                    RemoveExternalRoutes Controls whether Felix will remove unexpected routes to workload interfaces. Felix will
+                    always clean up expected routes that use the configured DeviceRouteProtocol.  To add your own routes, you must
+                    use a distinct protocol (in addition to setting this field to false).
+                  type: boolean
+                reportingInterval:
+                  description: |-
+                    ReportingInterval is the interval at which Felix reports its status into the datastore or 0 to disable.
+                    Must be non-zero in OpenStack deployments. [Default: 30s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                reportingTTL:
+                  description:
+                    "ReportingTTL is the time-to-live setting for process-wide
+                    status reports. [Default: 90s]"
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                requireMTUFile:
+                  description: |-
+                    RequireMTUFile specifies whether mtu file is required to start the felix.
+                    Optional as to keep the same as previous behavior. [Default: false]
+                  type: boolean
+                routeRefreshInterval:
+                  description: |-
+                    RouteRefreshInterval is the period at which Felix re-checks the routes
+                    in the dataplane to ensure that no other process has accidentally broken Calico's rules.
+                    Set to 0 to disable route refresh. [Default: 90s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                routeSource:
+                  description: |-
+                    RouteSource configures where Felix gets its routing information.
+                    - WorkloadIPs: use workload endpoints to construct routes.
+                    - CalicoIPAM: the default - use IPAM data to construct routes.
+                  pattern: ^(?i)(WorkloadIPs|CalicoIPAM)?$
+                  type: string
+                routeSyncDisabled:
+                  description: |-
+                    RouteSyncDisabled will disable all operations performed on the route table. Set to true to
+                    run in network-policy mode only.
+                  type: boolean
+                routeTableRange:
+                  description: |-
+                    Deprecated in favor of RouteTableRanges.
+                    Calico programs additional Linux route tables for various purposes.
+                    RouteTableRange specifies the indices of the route tables that Calico should use.
+                  properties:
+                    max:
+                      type: integer
+                    min:
+                      type: integer
+                  required:
+                    - max
+                    - min
+                  type: object
+                routeTableRanges:
+                  description: |-
+                    Calico programs additional Linux route tables for various purposes.
+                    RouteTableRanges specifies a set of table index ranges that Calico should use.
+                    Deprecates`RouteTableRange`, overrides `RouteTableRange`.
+                  items:
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                      - max
+                      - min
+                    type: object
+                  type: array
+                serviceLoopPrevention:
+                  description: |-
+                    When service IP advertisement is enabled, prevent routing loops to service IPs that are
+                    not in use, by dropping or rejecting packets that do not get DNAT'd by kube-proxy.
+                    Unless set to "Disabled", in which case such routing loops continue to be allowed.
+                    [Default: Drop]
+                  pattern: ^(?i)(Drop|Reject|Disabled)?$
+                  type: string
+                sidecarAccelerationEnabled:
+                  description:
+                    "SidecarAccelerationEnabled enables experimental sidecar
+                    acceleration [Default: false]"
+                  type: boolean
+                usageReportingEnabled:
+                  description: |-
+                    UsageReportingEnabled reports anonymous Calico version number and cluster size to projectcalico.org. Logs warnings returned by the usage
+                    server. For example, if a significant security vulnerability has been discovered in the version of Calico being used. [Default: true]
+                  type: boolean
+                usageReportingInitialDelay:
+                  description:
+                    "UsageReportingInitialDelay controls the minimum delay
+                    before Felix makes a report. [Default: 300s]"
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                usageReportingInterval:
+                  description:
+                    "UsageReportingInterval controls the interval at which
+                    Felix makes reports. [Default: 86400s]"
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                useInternalDataplaneDriver:
+                  description: |-
+                    UseInternalDataplaneDriver, if true, Felix will use its internal dataplane programming logic.  If false, it
+                    will launch an external dataplane driver and communicate with it over protobuf.
+                  type: boolean
+                vxlanEnabled:
+                  description: |-
+                    VXLANEnabled overrides whether Felix should create the VXLAN tunnel device for IPv4 VXLAN networking.
+                    Optional as Felix determines this based on the existing IP pools. [Default: nil (unset)]
+                  type: boolean
+                vxlanMTU:
+                  description: |-
+                    VXLANMTU is the MTU to set on the IPv4 VXLAN tunnel device.  Optional as Felix auto-detects the MTU based on the
+                    MTU of the host's interfaces. [Default: 0 (auto-detect)]
+                  type: integer
+                vxlanMTUV6:
+                  description: |-
+                    VXLANMTUV6 is the MTU to set on the IPv6 VXLAN tunnel device. Optional as Felix auto-detects the MTU based on the
+                    MTU of the host's interfaces. [Default: 0 (auto-detect)]
+                  type: integer
+                vxlanPort:
+                  description:
+                    "VXLANPort is the UDP port number to use for VXLAN traffic.
+                    [Default: 4789]"
+                  type: integer
+                vxlanVNI:
+                  description: |-
+                    VXLANVNI is the VXLAN VNI to use for VXLAN traffic.  You may need to change this if the default value is
+                    in use on your system. [Default: 4096]
+                  type: integer
+                windowsManageFirewallRules:
+                  description:
+                    "WindowsManageFirewallRules configures whether or not
+                    Felix will program Windows Firewall rules (to allow inbound access
+                    to its own metrics ports). [Default: Disabled]"
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                wireguardEnabled:
+                  description:
+                    "WireguardEnabled controls whether Wireguard is enabled
+                    for IPv4 (encapsulating IPv4 traffic over an IPv4 underlay network).
+                    [Default: false]"
+                  type: boolean
+                wireguardEnabledV6:
+                  description:
+                    "WireguardEnabledV6 controls whether Wireguard is enabled
+                    for IPv6 (encapsulating IPv6 traffic over an IPv6 underlay network).
+                    [Default: false]"
+                  type: boolean
+                wireguardHostEncryptionEnabled:
+                  description:
+                    "WireguardHostEncryptionEnabled controls whether Wireguard
+                    host-to-host encryption is enabled. [Default: false]"
+                  type: boolean
+                wireguardInterfaceName:
+                  description:
+                    "WireguardInterfaceName specifies the name to use for
+                    the IPv4 Wireguard interface. [Default: wireguard.cali]"
+                  type: string
+                wireguardInterfaceNameV6:
+                  description:
+                    "WireguardInterfaceNameV6 specifies the name to use for
+                    the IPv6 Wireguard interface. [Default: wg-v6.cali]"
+                  type: string
+                wireguardKeepAlive:
+                  description:
+                    "WireguardPersistentKeepAlive controls Wireguard PersistentKeepalive
+                    option. Set 0 to disable. [Default: 0]"
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                wireguardListeningPort:
+                  description:
+                    "WireguardListeningPort controls the listening port used
+                    by IPv4 Wireguard. [Default: 51820]"
+                  type: integer
+                wireguardListeningPortV6:
+                  description:
+                    "WireguardListeningPortV6 controls the listening port
+                    used by IPv6 Wireguard. [Default: 51821]"
+                  type: integer
+                wireguardMTU:
+                  description:
+                    "WireguardMTU controls the MTU on the IPv4 Wireguard
+                    interface. See Configuring MTU [Default: 1440]"
+                  type: integer
+                wireguardMTUV6:
+                  description:
+                    "WireguardMTUV6 controls the MTU on the IPv6 Wireguard
+                    interface. See Configuring MTU [Default: 1420]"
+                  type: integer
+                wireguardRoutingRulePriority:
+                  description:
+                    "WireguardRoutingRulePriority controls the priority value
+                    to use for the Wireguard routing rule. [Default: 99]"
+                  type: integer
+                wireguardThreadingEnabled:
+                  description: |-
+                    WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false]
+                    This increases the maximum number of packets a Wireguard interface can process.
+                    Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+                    There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+                    that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+                    Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
+                  type: boolean
+                workloadSourceSpoofing:
+                  description: |-
+                    WorkloadSourceSpoofing controls whether pods can use the allowedSourcePrefixes annotation to send traffic with a source IP
+                    address that is not theirs. This is disabled by default. When set to "Any", pods can request any prefix.
+                  pattern: ^(?i)(Disabled|Any)?$
+                  type: string
+                xdpEnabled:
+                  description:
+                    "XDPEnabled enables XDP acceleration for suitable untracked
+                    incoming deny rules. [Default: true]"
+                  type: boolean
+                xdpRefreshInterval:
+                  description: |-
+                    XDPRefreshInterval is the period at which Felix re-checks all XDP state to ensure that no
+                    other process has accidentally broken Calico's BPF maps or attached programs. Set to 0 to
+                    disable XDP refresh. [Default: 90s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkPolicy
+    listKind: GlobalNetworkPolicyList
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                applyOnForward:
+                  type: boolean
+                doNotTrack:
+                  type: boolean
+                egress:
+                  items:
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      ipVersion:
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                ingress:
+                  items:
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      ipVersion:
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                namespaceSelector:
+                  type: string
+                order:
+                  type: number
+                performanceHints:
+                  items:
+                    type: string
+                  type: array
+                preDNAT:
+                  type: boolean
+                selector:
+                  type: string
+                serviceAccountSelector:
+                  type: string
+                tier:
+                  type: string
+                types:
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkSet
+    listKind: GlobalNetworkSetList
+    plural: globalnetworksets
+    singular: globalnetworkset
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                nets:
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: HostEndpoint
+    listKind: HostEndpointList
+    plural: hostendpoints
+    singular: hostendpoint
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                expectedIPs:
+                  items:
+                    type: string
+                  type: array
+                interfaceName:
+                  type: string
+                node:
+                  type: string
+                ports:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                    required:
+                      - name
+                      - port
+                      - protocol
+                    type: object
+                  type: array
+                profiles:
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMBlock
+    listKind: IPAMBlockList
+    plural: ipamblocks
+    singular: ipamblock
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                affinity:
+                  type: string
+                allocations:
+                  items:
+                    type: integer
+                    # TODO: This nullable is manually added in. We should update controller-gen
+                    # to handle []*int properly itself.
+                    nullable: true
+                  type: array
+                attributes:
+                  items:
+                    properties:
+                      handle_id:
+                        type: string
+                      secondary:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  type: array
+                cidr:
+                  type: string
+                deleted:
+                  type: boolean
+                sequenceNumber:
+                  default: 0
+                  format: int64
+                  type: integer
+                sequenceNumberForAllocation:
+                  additionalProperties:
+                    format: int64
+                    type: integer
+                  type: object
+                strictAffinity:
+                  type: boolean
+                unallocated:
+                  items:
+                    type: integer
+                  type: array
+              required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ipamconfigs.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMConfig
+    listKind: IPAMConfigList
+    plural: ipamconfigs
+    singular: ipamconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                autoAllocateBlocks:
+                  type: boolean
+                maxBlocksPerHost:
+                  maximum: 2147483647
+                  minimum: 0
+                  type: integer
+                strictAffinity:
+                  type: boolean
+              required:
+                - autoAllocateBlocks
+                - strictAffinity
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ipamhandles.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMHandle
+    listKind: IPAMHandleList
+    plural: ipamhandles
+    singular: ipamhandle
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                block:
+                  additionalProperties:
+                    type: integer
+                  type: object
+                deleted:
+                  type: boolean
+                handleID:
+                  type: string
+              required:
+                - block
+                - handleID
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ippools.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPPool
+    listKind: IPPoolList
+    plural: ippools
+    singular: ippool
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                allowedUses:
+                  items:
+                    type: string
+                  type: array
+                assignmentMode:
+                  enum:
+                    - Automatic
+                    - Manual
+                  type: string
+                blockSize:
+                  type: integer
+                cidr:
+                  type: string
+                disableBGPExport:
+                  type: boolean
+                disabled:
+                  type: boolean
+                ipip:
+                  properties:
+                    enabled:
+                      type: boolean
+                    mode:
+                      type: string
+                  type: object
+                ipipMode:
+                  type: string
+                namespaceSelector:
+                  type: string
+                nat-outgoing:
+                  type: boolean
+                natOutgoing:
+                  type: boolean
+                nodeSelector:
+                  type: string
+                vxlanMode:
+                  type: string
+              required:
+                - cidr
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ipreservations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPReservation
+    listKind: IPReservationList
+    plural: ipreservations
+    singular: ipreservation
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                reservedCIDRs:
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: kubecontrollersconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: KubeControllersConfiguration
+    listKind: KubeControllersConfigurationList
+    plural: kubecontrollersconfigurations
+    singular: kubecontrollersconfiguration
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllers:
+                  properties:
+                    loadBalancer:
+                      properties:
+                        assignIPs:
+                          default: AllServices
+                          type: string
+                      type: object
+                    namespace:
+                      properties:
+                        reconcilerPeriod:
+                          type: string
+                      type: object
+                    node:
+                      properties:
+                        hostEndpoint:
+                          properties:
+                            autoCreate:
+                              type: string
+                            createDefaultHostEndpoint:
+                              type: string
+                            templates:
+                              items:
+                                properties:
+                                  generateName:
+                                    maxLength: 253
+                                    type: string
+                                  interfaceCIDRs:
+                                    items:
+                                      type: string
+                                    type: array
+                                  interfacePattern:
+                                    type: string
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  nodeSelector:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        leakGracePeriod:
+                          type: string
+                        reconcilerPeriod:
+                          type: string
+                        syncLabels:
+                          type: string
+                      type: object
+                    policy:
+                      properties:
+                        reconcilerPeriod:
+                          type: string
+                      type: object
+                    serviceAccount:
+                      properties:
+                        reconcilerPeriod:
+                          type: string
+                      type: object
+                    workloadEndpoint:
+                      properties:
+                        reconcilerPeriod:
+                          type: string
+                      type: object
+                  type: object
+                debugProfilePort:
+                  format: int32
+                  type: integer
+                etcdV3CompactionPeriod:
+                  type: string
+                healthChecks:
+                  type: string
+                logSeverityScreen:
+                  type: string
+                prometheusMetricsPort:
+                  type: integer
+              required:
+                - controllers
+              type: object
+            status:
+              properties:
+                environmentVars:
+                  additionalProperties:
+                    type: string
+                  type: object
+                runningConfig:
+                  properties:
+                    controllers:
+                      properties:
+                        loadBalancer:
+                          properties:
+                            assignIPs:
+                              default: AllServices
+                              type: string
+                          type: object
+                        namespace:
+                          properties:
+                            reconcilerPeriod:
+                              type: string
+                          type: object
+                        node:
+                          properties:
+                            hostEndpoint:
+                              properties:
+                                autoCreate:
+                                  type: string
+                                createDefaultHostEndpoint:
+                                  type: string
+                                templates:
+                                  items:
+                                    properties:
+                                      generateName:
+                                        maxLength: 253
+                                        type: string
+                                      interfaceCIDRs:
+                                        items:
+                                          type: string
+                                        type: array
+                                      interfacePattern:
+                                        type: string
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      nodeSelector:
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            leakGracePeriod:
+                              type: string
+                            reconcilerPeriod:
+                              type: string
+                            syncLabels:
+                              type: string
+                          type: object
+                        policy:
+                          properties:
+                            reconcilerPeriod:
+                              type: string
+                          type: object
+                        serviceAccount:
+                          properties:
+                            reconcilerPeriod:
+                              type: string
+                          type: object
+                        workloadEndpoint:
+                          properties:
+                            reconcilerPeriod:
+                              type: string
+                          type: object
+                      type: object
+                    debugProfilePort:
+                      format: int32
+                      type: integer
+                    etcdV3CompactionPeriod:
+                      type: string
+                    healthChecks:
+                      type: string
+                    logSeverityScreen:
+                      type: string
+                    prometheusMetricsPort:
+                      type: integer
+                  required:
+                    - controllers
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                egress:
+                  items:
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      ipVersion:
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                ingress:
+                  items:
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      ipVersion:
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                order:
+                  type: number
+                performanceHints:
+                  items:
+                    type: string
+                  type: array
+                selector:
+                  type: string
+                serviceAccountSelector:
+                  type: string
+                tier:
+                  type: string
+                types:
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: networksets.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkSet
+    listKind: NetworkSetList
+    plural: networksets
+    singular: networkset
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                nets:
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: stagedglobalnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: StagedGlobalNetworkPolicy
+    listKind: StagedGlobalNetworkPolicyList
+    plural: stagedglobalnetworkpolicies
+    singular: stagedglobalnetworkpolicy
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                applyOnForward:
+                  type: boolean
+                doNotTrack:
+                  type: boolean
+                egress:
+                  items:
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      ipVersion:
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                ingress:
+                  items:
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      ipVersion:
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                namespaceSelector:
+                  type: string
+                order:
+                  type: number
+                performanceHints:
+                  items:
+                    type: string
+                  type: array
+                preDNAT:
+                  type: boolean
+                selector:
+                  type: string
+                serviceAccountSelector:
+                  type: string
+                stagedAction:
+                  type: string
+                tier:
+                  type: string
+                types:
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: stagedkubernetesnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: StagedKubernetesNetworkPolicy
+    listKind: StagedKubernetesNetworkPolicyList
+    plural: stagedkubernetesnetworkpolicies
+    singular: stagedkubernetesnetworkpolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                egress:
+                  items:
+                    properties:
+                      ports:
+                        items:
+                          properties:
+                            endPort:
+                              format: int32
+                              type: integer
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            protocol:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      to:
+                        items:
+                          properties:
+                            ipBlock:
+                              properties:
+                                cidr:
+                                  type: string
+                                except:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - cidr
+                              type: object
+                            namespaceSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            podSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  type: array
+                ingress:
+                  items:
+                    properties:
+                      from:
+                        items:
+                          properties:
+                            ipBlock:
+                              properties:
+                                cidr:
+                                  type: string
+                                except:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - cidr
+                              type: object
+                            namespaceSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            podSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ports:
+                        items:
+                          properties:
+                            endPort:
+                              format: int32
+                              type: integer
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            protocol:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  type: array
+                podSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                policyTypes:
+                  items:
+                    type: string
+                  type: array
+                stagedAction:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: stagednetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: StagedNetworkPolicy
+    listKind: StagedNetworkPolicyList
+    plural: stagednetworkpolicies
+    singular: stagednetworkpolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                egress:
+                  items:
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      ipVersion:
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                ingress:
+                  items:
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      ipVersion:
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            type: integer
+                          type:
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                order:
+                  type: number
+                performanceHints:
+                  items:
+                    type: string
+                  type: array
+                selector:
+                  type: string
+                serviceAccountSelector:
+                  type: string
+                stagedAction:
+                  type: string
+                tier:
+                  type: string
+                types:
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tiers.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: Tier
+    listKind: TierList
+    plural: tiers
+    singular: tier
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                defaultAction:
+                  enum:
+                    - Pass
+                    - Deny
+                  type: string
+                order:
+                  type: number
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
+    policy.networking.k8s.io/bundle-version: v0.1.1
+    policy.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: adminnetworkpolicies.policy.networking.k8s.io
+spec:
+  group: policy.networking.k8s.io
+  names:
+    kind: AdminNetworkPolicy
+    listKind: AdminNetworkPolicyList
+    plural: adminnetworkpolicies
+    shortNames:
+      - anp
+    singular: adminnetworkpolicy
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.priority
+          name: Priority
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            AdminNetworkPolicy is  a cluster level resource that is part of the
+            AdminNetworkPolicy API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Specification of the desired behavior of AdminNetworkPolicy.
+              properties:
+                egress:
+                  description: |-
+                    Egress is the list of Egress rules to be applied to the selected pods.
+                    A total of 100 rules will be allowed in each ANP instance.
+                    The relative precedence of egress rules within a single ANP object (all of
+                    which share the priority) will be determined by the order in which the rule
+                    is written. Thus, a rule that appears at the top of the egress rules
+                    would take the highest precedence.
+                    ANPs with no egress rules do not affect egress traffic.
+
+
+                    Support: Core
+                  items:
+                    description: |-
+                      AdminNetworkPolicyEgressRule describes an action to take on a particular
+                      set of traffic originating from pods selected by a AdminNetworkPolicy's
+                      Subject field.
+                      <network-policy-api:experimental:validation>
+                    properties:
+                      action:
+                        description: |-
+                          Action specifies the effect this rule will have on matching traffic.
+                          Currently the following actions are supported:
+                          Allow: allows the selected traffic (even if it would otherwise have been denied by NetworkPolicy)
+                          Deny: denies the selected traffic
+                          Pass: instructs the selected traffic to skip any remaining ANP rules, and
+                          then pass execution to any NetworkPolicies that select the pod.
+                          If the pod is not selected by any NetworkPolicies then execution
+                          is passed to any BaselineAdminNetworkPolicies that select the pod.
+
+
+                          Support: Core
+                        enum:
+                          - Allow
+                          - Deny
+                          - Pass
+                        type: string
+                      name:
+                        description: |-
+                          Name is an identifier for this rule, that may be no more than 100 characters
+                          in length. This field should be used by the implementation to help
+                          improve observability, readability and error-reporting for any applied
+                          AdminNetworkPolicies.
+
+
+                          Support: Core
+                        maxLength: 100
+                        type: string
+                      ports:
+                        description: |-
+                          Ports allows for matching traffic based on port and protocols.
+                          This field is a list of destination ports for the outgoing egress traffic.
+                          If Ports is not set then the rule does not filter traffic via port.
+
+
+                          Support: Core
+                        items:
+                          description: |-
+                            AdminNetworkPolicyPort describes how to select network ports on pod(s).
+                            Exactly one field must be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            namedPort:
+                              description: |-
+                                NamedPort selects a port on a pod(s) based on name.
+
+
+                                Support: Extended
+
+
+                                <network-policy-api:experimental>
+                              type: string
+                            portNumber:
+                              description: |-
+                                Port selects a port on a pod(s) based on number.
+
+
+                                Support: Core
+                              properties:
+                                port:
+                                  description: |-
+                                    Number defines a network port value.
+
+
+                                    Support: Core
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol is the network protocol (TCP, UDP, or SCTP) which traffic must
+                                    match. If not specified, this field defaults to TCP.
+
+
+                                    Support: Core
+                                  type: string
+                              required:
+                                - port
+                                - protocol
+                              type: object
+                            portRange:
+                              description: |-
+                                PortRange selects a port range on a pod(s) based on provided start and end
+                                values.
+
+
+                                Support: Core
+                              properties:
+                                end:
+                                  description: |-
+                                    End defines a network port that is the end of a port range, the End value
+                                    must be greater than Start.
+
+
+                                    Support: Core
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol is the network protocol (TCP, UDP, or SCTP) which traffic must
+                                    match. If not specified, this field defaults to TCP.
+
+
+                                    Support: Core
+                                  type: string
+                                start:
+                                  description: |-
+                                    Start defines a network port that is the start of a port range, the Start
+                                    value must be less than End.
+
+
+                                    Support: Core
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                              required:
+                                - end
+                                - start
+                              type: object
+                          type: object
+                        maxItems: 100
+                        type: array
+                      to:
+                        description: |-
+                          To is the List of destinations whose traffic this rule applies to.
+                          If any AdminNetworkPolicyEgressPeer matches the destination of outgoing
+                          traffic then the specified action is applied.
+                          This field must be defined and contain at least one item.
+
+
+                          Support: Core
+                        items:
+                          description: |-
+                            AdminNetworkPolicyEgressPeer defines a peer to allow traffic to.
+                            Exactly one of the selector pointers must be set for a given peer. If a
+                            consumer observes none of its fields are set, they must assume an unknown
+                            option has been specified and fail closed.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            namespaces:
+                              description: |-
+                                Namespaces defines a way to select all pods within a set of Namespaces.
+                                Note that host-networked pods are not included in this type of peer.
+
+
+                                Support: Core
+                              properties:
+                                matchExpressions:
+                                  description:
+                                    matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description:
+                                          key is the label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            networks:
+                              description: |-
+                                Networks defines a way to select peers via CIDR blocks.
+                                This is intended for representing entities that live outside the cluster,
+                                which can't be selected by pods, namespaces and nodes peers, but note
+                                that cluster-internal traffic will be checked against the rule as
+                                well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                                or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                                add a rule that Passes all pod traffic before the Networks rule.
+
+
+                                Each item in Networks should be provided in the CIDR format and should be
+                                IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                                Networks can have upto 25 CIDRs specified.
+
+
+                                Support: Extended
+
+
+                                <network-policy-api:experimental>
+                              items:
+                                description: |-
+                                  CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  This string must be validated by implementations using net.ParseCIDR
+                                  TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                                maxLength: 43
+                                type: string
+                                x-kubernetes-validations:
+                                  - message:
+                                      CIDR must be either an IPv4 or IPv6 address.
+                                      IPv4 address embedded in IPv6 addresses are not
+                                      supported
+                                    rule: self.contains(':') != self.contains('.')
+                              maxItems: 25
+                              minItems: 1
+                              type: array
+                              x-kubernetes-list-type: set
+                            nodes:
+                              description: |-
+                                Nodes defines a way to select a set of nodes in
+                                the cluster. This field follows standard label selector
+                                semantics; if present but empty, it selects all Nodes.
+
+
+                                Support: Extended
+
+
+                                <network-policy-api:experimental>
+                              properties:
+                                matchExpressions:
+                                  description:
+                                    matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description:
+                                          key is the label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            pods:
+                              description: |-
+                                Pods defines a way to select a set of pods in
+                                a set of namespaces. Note that host-networked pods
+                                are not included in this type of peer.
+
+
+                                Support: Core
+                              properties:
+                                namespaceSelector:
+                                  description: |-
+                                    NamespaceSelector follows standard label selector semantics; if empty,
+                                    it selects all Namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                podSelector:
+                                  description: |-
+                                    PodSelector is used to explicitly select pods within a namespace; if empty,
+                                    it selects all Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - namespaceSelector
+                                - podSelector
+                              type: object
+                          type: object
+                        maxItems: 100
+                        minItems: 1
+                        type: array
+                    required:
+                      - action
+                      - to
+                    type: object
+                    x-kubernetes-validations:
+                      - message:
+                          networks/nodes peer cannot be set with namedPorts since
+                          there are no namedPorts for networks/nodes
+                        rule:
+                          "!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                          && has(self.ports) && self.ports.exists(port, has(port.namedPort)))"
+                  maxItems: 100
+                  type: array
+                ingress:
+                  description: |-
+                    Ingress is the list of Ingress rules to be applied to the selected pods.
+                    A total of 100 rules will be allowed in each ANP instance.
+                    The relative precedence of ingress rules within a single ANP object (all of
+                    which share the priority) will be determined by the order in which the rule
+                    is written. Thus, a rule that appears at the top of the ingress rules
+                    would take the highest precedence.
+                    ANPs with no ingress rules do not affect ingress traffic.
+
+
+                    Support: Core
+                  items:
+                    description: |-
+                      AdminNetworkPolicyIngressRule describes an action to take on a particular
+                      set of traffic destined for pods selected by an AdminNetworkPolicy's
+                      Subject field.
+                    properties:
+                      action:
+                        description: |-
+                          Action specifies the effect this rule will have on matching traffic.
+                          Currently the following actions are supported:
+                          Allow: allows the selected traffic (even if it would otherwise have been denied by NetworkPolicy)
+                          Deny: denies the selected traffic
+                          Pass: instructs the selected traffic to skip any remaining ANP rules, and
+                          then pass execution to any NetworkPolicies that select the pod.
+                          If the pod is not selected by any NetworkPolicies then execution
+                          is passed to any BaselineAdminNetworkPolicies that select the pod.
+
+
+                          Support: Core
+                        enum:
+                          - Allow
+                          - Deny
+                          - Pass
+                        type: string
+                      from:
+                        description: |-
+                          From is the list of sources whose traffic this rule applies to.
+                          If any AdminNetworkPolicyIngressPeer matches the source of incoming
+                          traffic then the specified action is applied.
+                          This field must be defined and contain at least one item.
+
+
+                          Support: Core
+                        items:
+                          description: |-
+                            AdminNetworkPolicyIngressPeer defines an in-cluster peer to allow traffic from.
+                            Exactly one of the selector pointers must be set for a given peer. If a
+                            consumer observes none of its fields are set, they must assume an unknown
+                            option has been specified and fail closed.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            namespaces:
+                              description: |-
+                                Namespaces defines a way to select all pods within a set of Namespaces.
+                                Note that host-networked pods are not included in this type of peer.
+
+
+                                Support: Core
+                              properties:
+                                matchExpressions:
+                                  description:
+                                    matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description:
+                                          key is the label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            pods:
+                              description: |-
+                                Pods defines a way to select a set of pods in
+                                a set of namespaces. Note that host-networked pods
+                                are not included in this type of peer.
+
+
+                                Support: Core
+                              properties:
+                                namespaceSelector:
+                                  description: |-
+                                    NamespaceSelector follows standard label selector semantics; if empty,
+                                    it selects all Namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                podSelector:
+                                  description: |-
+                                    PodSelector is used to explicitly select pods within a namespace; if empty,
+                                    it selects all Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - namespaceSelector
+                                - podSelector
+                              type: object
+                          type: object
+                        maxItems: 100
+                        minItems: 1
+                        type: array
+                      name:
+                        description: |-
+                          Name is an identifier for this rule, that may be no more than 100 characters
+                          in length. This field should be used by the implementation to help
+                          improve observability, readability and error-reporting for any applied
+                          AdminNetworkPolicies.
+
+
+                          Support: Core
+                        maxLength: 100
+                        type: string
+                      ports:
+                        description: |-
+                          Ports allows for matching traffic based on port and protocols.
+                          This field is a list of ports which should be matched on
+                          the pods selected for this policy i.e the subject of the policy.
+                          So it matches on the destination port for the ingress traffic.
+                          If Ports is not set then the rule does not filter traffic via port.
+
+
+                          Support: Core
+                        items:
+                          description: |-
+                            AdminNetworkPolicyPort describes how to select network ports on pod(s).
+                            Exactly one field must be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            namedPort:
+                              description: |-
+                                NamedPort selects a port on a pod(s) based on name.
+
+
+                                Support: Extended
+
+
+                                <network-policy-api:experimental>
+                              type: string
+                            portNumber:
+                              description: |-
+                                Port selects a port on a pod(s) based on number.
+
+
+                                Support: Core
+                              properties:
+                                port:
+                                  description: |-
+                                    Number defines a network port value.
+
+
+                                    Support: Core
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol is the network protocol (TCP, UDP, or SCTP) which traffic must
+                                    match. If not specified, this field defaults to TCP.
+
+
+                                    Support: Core
+                                  type: string
+                              required:
+                                - port
+                                - protocol
+                              type: object
+                            portRange:
+                              description: |-
+                                PortRange selects a port range on a pod(s) based on provided start and end
+                                values.
+
+
+                                Support: Core
+                              properties:
+                                end:
+                                  description: |-
+                                    End defines a network port that is the end of a port range, the End value
+                                    must be greater than Start.
+
+
+                                    Support: Core
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol is the network protocol (TCP, UDP, or SCTP) which traffic must
+                                    match. If not specified, this field defaults to TCP.
+
+
+                                    Support: Core
+                                  type: string
+                                start:
+                                  description: |-
+                                    Start defines a network port that is the start of a port range, the Start
+                                    value must be less than End.
+
+
+                                    Support: Core
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                              required:
+                                - end
+                                - start
+                              type: object
+                          type: object
+                        maxItems: 100
+                        type: array
+                    required:
+                      - action
+                      - from
+                    type: object
+                  maxItems: 100
+                  type: array
+                priority:
+                  description: |-
+                    Priority is a value from 0 to 1000. Rules with lower priority values have
+                    higher precedence, and are checked before rules with higher priority values.
+                    All AdminNetworkPolicy rules have higher precedence than NetworkPolicy or
+                    BaselineAdminNetworkPolicy rules
+                    The behavior is undefined if two ANP objects have same priority.
+
+
+                    Support: Core
+                  format: int32
+                  maximum: 1000
+                  minimum: 0
+                  type: integer
+                subject:
+                  description: |-
+                    Subject defines the pods to which this AdminNetworkPolicy applies.
+                    Note that host-networked pods are not included in subject selection.
+
+
+                    Support: Core
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    namespaces:
+                      description: Namespaces is used to select pods via namespace selectors.
+                      properties:
+                        matchExpressions:
+                          description:
+                            matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description:
+                                  key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    pods:
+                      description:
+                        Pods is used to select pods via namespace AND pod
+                        selectors.
+                      properties:
+                        namespaceSelector:
+                          description: |-
+                            NamespaceSelector follows standard label selector semantics; if empty,
+                            it selects all Namespaces.
+                          properties:
+                            matchExpressions:
+                              description:
+                                matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description:
+                                      key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        podSelector:
+                          description: |-
+                            PodSelector is used to explicitly select pods within a namespace; if empty,
+                            it selects all Pods.
+                          properties:
+                            matchExpressions:
+                              description:
+                                matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description:
+                                      key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                        - namespaceSelector
+                        - podSelector
+                      type: object
+                  type: object
+              required:
+                - priority
+                - subject
+              type: object
+            status:
+              description: Status is the status to be reported by the implementation.
+              properties:
+                conditions:
+                  items:
+                    description:
+                      "Condition contains details for one aspect of the current
+                      state of this API Resource.\n---\nThis struct is intended for
+                      direct use as an array at the field path .status.conditions.  For
+                      example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                      observations of a foo's current state.\n\t    // Known .status.conditions.type
+                      are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                      +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                      \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                      patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                      \   // other fields\n\t}"
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              required:
+                - conditions
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
+    policy.networking.k8s.io/bundle-version: v0.1.1
+    policy.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: baselineadminnetworkpolicies.policy.networking.k8s.io
+spec:
+  group: policy.networking.k8s.io
+  names:
+    kind: BaselineAdminNetworkPolicy
+    listKind: BaselineAdminNetworkPolicyList
+    plural: baselineadminnetworkpolicies
+    shortNames:
+      - banp
+    singular: baselineadminnetworkpolicy
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            BaselineAdminNetworkPolicy is a cluster level resource that is part of the
+            AdminNetworkPolicy API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Specification of the desired behavior of BaselineAdminNetworkPolicy.
+              properties:
+                egress:
+                  description: |-
+                    Egress is the list of Egress rules to be applied to the selected pods if
+                    they are not matched by any AdminNetworkPolicy or NetworkPolicy rules.
+                    A total of 100 Egress rules will be allowed in each BANP instance.
+                    The relative precedence of egress rules within a single BANP object
+                    will be determined by the order in which the rule is written.
+                    Thus, a rule that appears at the top of the egress rules
+                    would take the highest precedence.
+                    BANPs with no egress rules do not affect egress traffic.
+
+
+                    Support: Core
+                  items:
+                    description: |-
+                      BaselineAdminNetworkPolicyEgressRule describes an action to take on a particular
+                      set of traffic originating from pods selected by a BaselineAdminNetworkPolicy's
+                      Subject field.
+                      <network-policy-api:experimental:validation>
+                    properties:
+                      action:
+                        description: |-
+                          Action specifies the effect this rule will have on matching traffic.
+                          Currently the following actions are supported:
+                          Allow: allows the selected traffic
+                          Deny: denies the selected traffic
+
+
+                          Support: Core
+                        enum:
+                          - Allow
+                          - Deny
+                        type: string
+                      name:
+                        description: |-
+                          Name is an identifier for this rule, that may be no more than 100 characters
+                          in length. This field should be used by the implementation to help
+                          improve observability, readability and error-reporting for any applied
+                          BaselineAdminNetworkPolicies.
+
+
+                          Support: Core
+                        maxLength: 100
+                        type: string
+                      ports:
+                        description: |-
+                          Ports allows for matching traffic based on port and protocols.
+                          This field is a list of destination ports for the outgoing egress traffic.
+                          If Ports is not set then the rule does not filter traffic via port.
+                        items:
+                          description: |-
+                            AdminNetworkPolicyPort describes how to select network ports on pod(s).
+                            Exactly one field must be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            namedPort:
+                              description: |-
+                                NamedPort selects a port on a pod(s) based on name.
+
+
+                                Support: Extended
+
+
+                                <network-policy-api:experimental>
+                              type: string
+                            portNumber:
+                              description: |-
+                                Port selects a port on a pod(s) based on number.
+
+
+                                Support: Core
+                              properties:
+                                port:
+                                  description: |-
+                                    Number defines a network port value.
+
+
+                                    Support: Core
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol is the network protocol (TCP, UDP, or SCTP) which traffic must
+                                    match. If not specified, this field defaults to TCP.
+
+
+                                    Support: Core
+                                  type: string
+                              required:
+                                - port
+                                - protocol
+                              type: object
+                            portRange:
+                              description: |-
+                                PortRange selects a port range on a pod(s) based on provided start and end
+                                values.
+
+
+                                Support: Core
+                              properties:
+                                end:
+                                  description: |-
+                                    End defines a network port that is the end of a port range, the End value
+                                    must be greater than Start.
+
+
+                                    Support: Core
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol is the network protocol (TCP, UDP, or SCTP) which traffic must
+                                    match. If not specified, this field defaults to TCP.
+
+
+                                    Support: Core
+                                  type: string
+                                start:
+                                  description: |-
+                                    Start defines a network port that is the start of a port range, the Start
+                                    value must be less than End.
+
+
+                                    Support: Core
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                              required:
+                                - end
+                                - start
+                              type: object
+                          type: object
+                        maxItems: 100
+                        type: array
+                      to:
+                        description: |-
+                          To is the list of destinations whose traffic this rule applies to.
+                          If any AdminNetworkPolicyEgressPeer matches the destination of outgoing
+                          traffic then the specified action is applied.
+                          This field must be defined and contain at least one item.
+
+
+                          Support: Core
+                        items:
+                          description: |-
+                            AdminNetworkPolicyEgressPeer defines a peer to allow traffic to.
+                            Exactly one of the selector pointers must be set for a given peer. If a
+                            consumer observes none of its fields are set, they must assume an unknown
+                            option has been specified and fail closed.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            namespaces:
+                              description: |-
+                                Namespaces defines a way to select all pods within a set of Namespaces.
+                                Note that host-networked pods are not included in this type of peer.
+
+
+                                Support: Core
+                              properties:
+                                matchExpressions:
+                                  description:
+                                    matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description:
+                                          key is the label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            networks:
+                              description: |-
+                                Networks defines a way to select peers via CIDR blocks.
+                                This is intended for representing entities that live outside the cluster,
+                                which can't be selected by pods, namespaces and nodes peers, but note
+                                that cluster-internal traffic will be checked against the rule as
+                                well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                                or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                                add a rule that Passes all pod traffic before the Networks rule.
+
+
+                                Each item in Networks should be provided in the CIDR format and should be
+                                IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                                Networks can have upto 25 CIDRs specified.
+
+
+                                Support: Extended
+
+
+                                <network-policy-api:experimental>
+                              items:
+                                description: |-
+                                  CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  This string must be validated by implementations using net.ParseCIDR
+                                  TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                                maxLength: 43
+                                type: string
+                                x-kubernetes-validations:
+                                  - message:
+                                      CIDR must be either an IPv4 or IPv6 address.
+                                      IPv4 address embedded in IPv6 addresses are not
+                                      supported
+                                    rule: self.contains(':') != self.contains('.')
+                              maxItems: 25
+                              minItems: 1
+                              type: array
+                              x-kubernetes-list-type: set
+                            nodes:
+                              description: |-
+                                Nodes defines a way to select a set of nodes in
+                                the cluster. This field follows standard label selector
+                                semantics; if present but empty, it selects all Nodes.
+
+
+                                Support: Extended
+
+
+                                <network-policy-api:experimental>
+                              properties:
+                                matchExpressions:
+                                  description:
+                                    matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description:
+                                          key is the label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            pods:
+                              description: |-
+                                Pods defines a way to select a set of pods in
+                                a set of namespaces. Note that host-networked pods
+                                are not included in this type of peer.
+
+
+                                Support: Core
+                              properties:
+                                namespaceSelector:
+                                  description: |-
+                                    NamespaceSelector follows standard label selector semantics; if empty,
+                                    it selects all Namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                podSelector:
+                                  description: |-
+                                    PodSelector is used to explicitly select pods within a namespace; if empty,
+                                    it selects all Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - namespaceSelector
+                                - podSelector
+                              type: object
+                          type: object
+                        maxItems: 100
+                        minItems: 1
+                        type: array
+                    required:
+                      - action
+                      - to
+                    type: object
+                    x-kubernetes-validations:
+                      - message:
+                          networks/nodes peer cannot be set with namedPorts since
+                          there are no namedPorts for networks/nodes
+                        rule:
+                          "!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                          && has(self.ports) && self.ports.exists(port, has(port.namedPort)))"
+                  maxItems: 100
+                  type: array
+                ingress:
+                  description: |-
+                    Ingress is the list of Ingress rules to be applied to the selected pods
+                    if they are not matched by any AdminNetworkPolicy or NetworkPolicy rules.
+                    A total of 100 Ingress rules will be allowed in each BANP instance.
+                    The relative precedence of ingress rules within a single BANP object
+                    will be determined by the order in which the rule is written.
+                    Thus, a rule that appears at the top of the ingress rules
+                    would take the highest precedence.
+                    BANPs with no ingress rules do not affect ingress traffic.
+
+
+                    Support: Core
+                  items:
+                    description: |-
+                      BaselineAdminNetworkPolicyIngressRule describes an action to take on a particular
+                      set of traffic destined for pods selected by a BaselineAdminNetworkPolicy's
+                      Subject field.
+                    properties:
+                      action:
+                        description: |-
+                          Action specifies the effect this rule will have on matching traffic.
+                          Currently the following actions are supported:
+                          Allow: allows the selected traffic
+                          Deny: denies the selected traffic
+
+
+                          Support: Core
+                        enum:
+                          - Allow
+                          - Deny
+                        type: string
+                      from:
+                        description: |-
+                          From is the list of sources whose traffic this rule applies to.
+                          If any AdminNetworkPolicyIngressPeer matches the source of incoming
+                          traffic then the specified action is applied.
+                          This field must be defined and contain at least one item.
+
+
+                          Support: Core
+                        items:
+                          description: |-
+                            AdminNetworkPolicyIngressPeer defines an in-cluster peer to allow traffic from.
+                            Exactly one of the selector pointers must be set for a given peer. If a
+                            consumer observes none of its fields are set, they must assume an unknown
+                            option has been specified and fail closed.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            namespaces:
+                              description: |-
+                                Namespaces defines a way to select all pods within a set of Namespaces.
+                                Note that host-networked pods are not included in this type of peer.
+
+
+                                Support: Core
+                              properties:
+                                matchExpressions:
+                                  description:
+                                    matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description:
+                                          key is the label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            pods:
+                              description: |-
+                                Pods defines a way to select a set of pods in
+                                a set of namespaces. Note that host-networked pods
+                                are not included in this type of peer.
+
+
+                                Support: Core
+                              properties:
+                                namespaceSelector:
+                                  description: |-
+                                    NamespaceSelector follows standard label selector semantics; if empty,
+                                    it selects all Namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                podSelector:
+                                  description: |-
+                                    PodSelector is used to explicitly select pods within a namespace; if empty,
+                                    it selects all Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - namespaceSelector
+                                - podSelector
+                              type: object
+                          type: object
+                        maxItems: 100
+                        minItems: 1
+                        type: array
+                      name:
+                        description: |-
+                          Name is an identifier for this rule, that may be no more than 100 characters
+                          in length. This field should be used by the implementation to help
+                          improve observability, readability and error-reporting for any applied
+                          BaselineAdminNetworkPolicies.
+
+
+                          Support: Core
+                        maxLength: 100
+                        type: string
+                      ports:
+                        description: |-
+                          Ports allows for matching traffic based on port and protocols.
+                          This field is a list of ports which should be matched on
+                          the pods selected for this policy i.e the subject of the policy.
+                          So it matches on the destination port for the ingress traffic.
+                          If Ports is not set then the rule does not filter traffic via port.
+
+
+                          Support: Core
+                        items:
+                          description: |-
+                            AdminNetworkPolicyPort describes how to select network ports on pod(s).
+                            Exactly one field must be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            namedPort:
+                              description: |-
+                                NamedPort selects a port on a pod(s) based on name.
+
+
+                                Support: Extended
+
+
+                                <network-policy-api:experimental>
+                              type: string
+                            portNumber:
+                              description: |-
+                                Port selects a port on a pod(s) based on number.
+
+
+                                Support: Core
+                              properties:
+                                port:
+                                  description: |-
+                                    Number defines a network port value.
+
+
+                                    Support: Core
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol is the network protocol (TCP, UDP, or SCTP) which traffic must
+                                    match. If not specified, this field defaults to TCP.
+
+
+                                    Support: Core
+                                  type: string
+                              required:
+                                - port
+                                - protocol
+                              type: object
+                            portRange:
+                              description: |-
+                                PortRange selects a port range on a pod(s) based on provided start and end
+                                values.
+
+
+                                Support: Core
+                              properties:
+                                end:
+                                  description: |-
+                                    End defines a network port that is the end of a port range, the End value
+                                    must be greater than Start.
+
+
+                                    Support: Core
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol is the network protocol (TCP, UDP, or SCTP) which traffic must
+                                    match. If not specified, this field defaults to TCP.
+
+
+                                    Support: Core
+                                  type: string
+                                start:
+                                  description: |-
+                                    Start defines a network port that is the start of a port range, the Start
+                                    value must be less than End.
+
+
+                                    Support: Core
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                              required:
+                                - end
+                                - start
+                              type: object
+                          type: object
+                        maxItems: 100
+                        type: array
+                    required:
+                      - action
+                      - from
+                    type: object
+                  maxItems: 100
+                  type: array
+                subject:
+                  description: |-
+                    Subject defines the pods to which this BaselineAdminNetworkPolicy applies.
+                    Note that host-networked pods are not included in subject selection.
+
+
+                    Support: Core
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    namespaces:
+                      description: Namespaces is used to select pods via namespace selectors.
+                      properties:
+                        matchExpressions:
+                          description:
+                            matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description:
+                                  key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    pods:
+                      description:
+                        Pods is used to select pods via namespace AND pod
+                        selectors.
+                      properties:
+                        namespaceSelector:
+                          description: |-
+                            NamespaceSelector follows standard label selector semantics; if empty,
+                            it selects all Namespaces.
+                          properties:
+                            matchExpressions:
+                              description:
+                                matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description:
+                                      key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        podSelector:
+                          description: |-
+                            PodSelector is used to explicitly select pods within a namespace; if empty,
+                            it selects all Pods.
+                          properties:
+                            matchExpressions:
+                              description:
+                                matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description:
+                                      key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                        - namespaceSelector
+                        - podSelector
+                      type: object
+                  type: object
+              required:
+                - subject
+              type: object
+            status:
+              description: Status is the status to be reported by the implementation.
+              properties:
+                conditions:
+                  items:
+                    description:
+                      "Condition contains details for one aspect of the current
+                      state of this API Resource.\n---\nThis struct is intended for
+                      direct use as an array at the field path .status.conditions.  For
+                      example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                      observations of a foo's current state.\n\t    // Known .status.conditions.type
+                      are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                      +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                      \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                      patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                      \   // other fields\n\t}"
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              required:
+                - conditions
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+          x-kubernetes-validations:
+            - message:
+                Only one baseline admin network policy with metadata.name="default"
+                can be created in the cluster
+              rule: self.metadata.name == 'default'
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+# Source: calico/templates/calico-kube-controllers-rbac.yaml
+# Include a clusterrole for the kube-controllers component,
+# and bind it to the calico-kube-controllers serviceaccount.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-kube-controllers
+rules:
+  # Nodes are watched to monitor for deletions.
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - watch
+      - list
+      - get
+  # Pods are watched to check for existence as part of IPAM controller.
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  # Namespaces are watched for LoadBalancer IP allocation with namespace selector support
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  # Services are monitored for service LoadBalancer IP allocation
+  - apiGroups: [""]
+    resources:
+      - services
+      - services/status
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  # IPAM resources are manipulated in response to node and block updates, as well as periodic triggers.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ipreservations
+    verbs:
+      - list
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      - ipamconfigs
+      - tiers
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+  # Pools are watched to maintain a mapping of blocks to IP pools.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ippools
+    verbs:
+      - list
+      - watch
+  # kube-controllers manages hostendpoints.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - hostendpoints
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+  # Needs access to update clusterinformations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - clusterinformations
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - watch
+  # KubeControllersConfiguration is where it gets its config
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - kubecontrollersconfigurations
+    verbs:
+      # read its own config
+      - get
+      - list
+      # create a default if none exists
+      - create
+      # update status
+      - update
+      # watch for changes
+      - watch
+---
+# Source: calico/templates/calico-node-rbac.yaml
+# Include a clusterrole for the calico-node DaemonSet,
+# and bind it to the calico-node serviceaccount.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-node
+rules:
+  # Used for creating service account tokens to be used by the CNI plugin
+  - apiGroups: [""]
+    resources:
+      - serviceaccounts/token
+    resourceNames:
+      - calico-cni-plugin
+    verbs:
+      - create
+  # The CNI plugin needs to get pods, nodes, and namespaces.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs:
+      - get
+  # EndpointSlices are used for Service-based network policy rule
+  # enforcement.
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs:
+      - watch
+      - list
+  - apiGroups: [""]
+    resources:
+      - endpoints
+      - services
+    verbs:
+      # Used to discover service IPs for advertisement.
+      - watch
+      - list
+      # Used to discover Typhas.
+      - get
+  # Pod CIDR auto-detection on kubeadm needs access to config maps.
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
+  # Watch for changes to Kubernetes NetworkPolicies.
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+  # Watch for changes to Kubernetes (Baseline)AdminNetworkPolicies.
+  - apiGroups: ["policy.networking.k8s.io"]
+    resources:
+      - adminnetworkpolicies
+      - baselineadminnetworkpolicies
+    verbs:
+      - watch
+      - list
+  # Used by Calico for policy information.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+    verbs:
+      - list
+      - watch
+  # The CNI plugin patches pods/status.
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - patch
+  # Calico monitors various CRDs for config.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - bgpfilters
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipreservations
+      - ipamblocks
+      - globalnetworkpolicies
+      - stagedglobalnetworkpolicies
+      - networkpolicies
+      - stagednetworkpolicies
+      - stagedkubernetesnetworkpolicies
+      - globalnetworksets
+      - networksets
+      - clusterinformations
+      - hostendpoints
+      - blockaffinities
+      - caliconodestatuses
+      - tiers
+    verbs:
+      - get
+      - list
+      - watch
+  # Calico creates some tiers on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - tiers
+    verbs:
+      - create
+  # Calico must create and update some CRDs on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+    verbs:
+      - create
+      - update
+  # Calico must update some CRDs.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - caliconodestatuses
+    verbs:
+      - update
+  # Calico stores some configuration information on the node.
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  # These permissions are only required for upgrade from v2.6, and can
+  # be removed after upgrade or on fresh installations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - bgpconfigurations
+      - bgppeers
+    verbs:
+      - create
+      - update
+  # These permissions are required for Calico CNI to perform IPAM allocations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+  # The CNI plugin and calico/node need to be able to create a default
+  # IPAMConfiguration
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ipamconfigs
+    verbs:
+      - get
+      - create
+  # Block affinities must also be watchable by confd for route aggregation.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+    verbs:
+      - watch
+  # The Calico IPAM migration needs to get daemonsets. These permissions can be
+  # removed if not upgrading from an installation using host-local IPAM.
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+    verbs:
+      - get
+---
+# Source: calico/templates/calico-node-rbac.yaml
+# CNI cluster role
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-cni-plugin
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - patch
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      - clusterinformations
+      - ippools
+      - ipreservations
+      - ipamconfigs
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+---
+# Source: calico/templates/tier-getter.yaml
+# Implements the necessary permissions for the kube-controller-manager to interact with
+# Tiers and Tiered Policies for GC.
+#
+# https://github.com/tigera/operator/blob/v1.37.0/pkg/render/apiserver.go#L1505-L1545
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-tier-getter
+rules:
+  - apiGroups:
+      - "projectcalico.org"
+    resources:
+      - "tiers"
+    verbs:
+      - "get"
+---
+# Source: calico/templates/calico-kube-controllers-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-kube-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-kube-controllers
+subjects:
+  - kind: ServiceAccount
+    name: calico-kube-controllers
+    namespace: kube-system
+---
+# Source: calico/templates/calico-node-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+  - kind: ServiceAccount
+    name: calico-node
+    namespace: kube-system
+---
+# Source: calico/templates/calico-node-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-cni-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-cni-plugin
+subjects:
+  - kind: ServiceAccount
+    name: calico-cni-plugin
+    namespace: kube-system
+---
+# Source: calico/templates/tier-getter.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-tier-getter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-tier-getter
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: system:kube-controller-manager
+---
+# Source: calico/templates/calico-node.yaml
+# This manifest installs the calico-node container, as well
+# as the CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      hostNetwork: true
+      tolerations:
+        # Make sure calico-node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      serviceAccountName: calico-node
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 0
+      priorityClassName: system-node-critical
+      initContainers:
+        # This container performs upgrade from host-local IPAM to calico-ipam.
+        # It can be deleted if this is a fresh installation, or if you have already
+        # upgraded to use calico-ipam.
+        - name: upgrade-ipam
+          image: quay.io/calico/cni:v3.31.5
+          imagePullPolicy: IfNotPresent
+          command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
+          envFrom:
+            - configMapRef:
+                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
+                name: kubernetes-services-endpoint
+                optional: true
+          env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+          volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+          securityContext:
+            privileged: true
+        # This container installs the CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: quay.io/calico/cni:v3.31.5
+          imagePullPolicy: IfNotPresent
+          command: ["/opt/cni/bin/install"]
+          envFrom:
+            - configMapRef:
+                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
+                name: kubernetes-services-endpoint
+                optional: true
+          env:
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+            # Set the hostname based on the k8s node name.
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # CNI MTU Config variable
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # Prevents the container from sleeping forever.
+            - name: SLEEP
+              value: "false"
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+          securityContext:
+            privileged: true
+        # This init container mounts the necessary filesystems needed by the BPF data plane
+        # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. It also configures the initial
+        # networking to allow communication with the API Server. Calico-node initialization is executed
+        # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptables mode.
+        - name: "ebpf-bootstrap"
+          image: quay.io/calico/node:v3.31.5
+          imagePullPolicy: IfNotPresent
+          command: ["calico-node", "-init", "-best-effort"]
+          volumeMounts:
+            - mountPath: /sys/fs
+              name: sys-fs
+              # Bidirectional is required to ensure that the new mount we make at /sys/fs/bpf propagates to the host
+              # so that it outlives the init container.
+              mountPropagation: Bidirectional
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              # Bidirectional is required to ensure that the new mount we make at /run/calico/cgroup propagates to the host
+              # so that it outlives the init container.
+              mountPropagation: Bidirectional
+            # Mount /proc/ from host which usually is an init program at /nodeproc. It's needed by mountns binary,
+            # executed by calico-node, to mount root cgroup2 fs at /run/calico/cgroup to attach CTLB programs correctly.
+            - mountPath: /nodeproc
+              name: nodeproc
+              readOnly: true
+          securityContext:
+            privileged: true
+      containers:
+        # Runs calico-node container on each Kubernetes node. This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:v3.31.5
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
+                name: kubernetes-services-endpoint
+                optional: true
+          env:
+            # Use Kubernetes API as the backing datastore.
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            # Wait for the datastore.
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            # Set based on the k8s node name.
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Choose the backend to use.
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+            # Cluster type to identify the deployment type
+            - name: CLUSTER_TYPE
+              value: "k8s,bgp"
+            # Auto-detect the BGP IP address.
+            - name: IP
+              value: "autodetect"
+            # Enable IPIP
+            - name: CALICO_IPV4POOL_IPIP
+              value: "Always"
+            # Enable or Disable VXLAN on the default IP pool.
+            - name: CALICO_IPV4POOL_VXLAN
+              value: "Never"
+            # Enable or Disable VXLAN on the default IPv6 IP pool.
+            - name: CALICO_IPV6POOL_VXLAN
+              value: "Never"
+            # Set MTU for tunnel device used if ipip is enabled
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # Set MTU for the VXLAN tunnel device.
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # Set MTU for the Wireguard tunnel device.
+            - name: FELIX_WIREGUARDMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+            # chosen from this range. Changing this value after installation will have
+            # no effect. This should fall within `--cluster-cidr`.
+            # - name: CALICO_IPV4POOL_CIDR
+            #   value: "192.168.0.0/16"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/calico-node
+                  - -shutdown
+          livenessProbe:
+            exec:
+              command:
+                - /bin/calico-node
+                - -felix-live
+                - -bird-live
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+            timeoutSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - /bin/calico-node
+                - -felix-ready
+                - -bird-ready
+            periodSeconds: 10
+            timeoutSeconds: 10
+          volumeMounts:
+            # For maintaining CNI plugin API credentials.
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - name: policysync
+              mountPath: /var/run/nodeagent
+            # For eBPF mode, we need to be able to mount the BPF filesystem at /sys/fs/bpf so we mount in the
+            # parent directory.
+            - name: bpffs
+              mountPath: /sys/fs/bpf
+            - name: cni-log-dir
+              mountPath: /var/log/calico/cni
+              readOnly: true
+      volumes:
+        # Used by calico-node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+            type: DirectoryOrCreate
+        - name: var-lib-calico
+          hostPath:
+            path: /var/lib/calico
+            type: DirectoryOrCreate
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+        - name: sys-fs
+          hostPath:
+            path: /sys/fs/
+            type: DirectoryOrCreate
+        - name: bpffs
+          hostPath:
+            path: /sys/fs/bpf
+            type: Directory
+        # mount /proc at /nodeproc to be used by ebpf-bootstrap initContainer to mount root cgroup2 fs.
+        - name: nodeproc
+          hostPath:
+            path: /proc
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+            type: DirectoryOrCreate
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        # Used to access CNI logs.
+        - name: cni-log-dir
+          hostPath:
+            path: /var/log/calico/cni
+        # Mount in the directory for host-local IPAM allocations. This is
+        # used when upgrading from host-local to calico-ipam, and can be removed
+        # if not using the upgrade-ipam init container.
+        - name: host-local-net-dir
+          hostPath:
+            path: /var/lib/cni/networks
+        # Used to create per-pod Unix Domain Sockets
+        - name: policysync
+          hostPath:
+            type: DirectoryOrCreate
+            path: /var/run/nodeagent
+---
+# Source: calico/templates/calico-kube-controllers.yaml
+# See https://github.com/projectcalico/kube-controllers
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    k8s-app: calico-kube-controllers
+spec:
+  # The controllers can only have a single active instance.
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+      labels:
+        k8s-app: calico-kube-controllers
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+      serviceAccountName: calico-kube-controllers
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: calico-kube-controllers
+          image: quay.io/calico/kube-controllers:v3.31.5
+          imagePullPolicy: IfNotPresent
+          env:
+            # Choose which controllers to run.
+            - name: ENABLED_CONTROLLERS
+              value: node,loadbalancer
+            - name: DATASTORE_TYPE
+              value: kubernetes
+          livenessProbe:
+            exec:
+              command:
+                - /usr/bin/check-status
+                - -l
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+            timeoutSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - /usr/bin/check-status
+                - -r
+            periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true

--- a/test/e2e/data/cluster-templates/docker-kubeadm-topology.yaml
+++ b/test/e2e/data/cluster-templates/docker-kubeadm-topology.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: ${NAMESPACE}
   annotations:
     cluster-api.cattle.io/cluster-description: "This is a custom cluster description"
-  labels:
-    cni: calico
 spec:
   clusterNetwork:
     pods:

--- a/test/e2e/specs/import_gitops.go
+++ b/test/e2e/specs/import_gitops.go
@@ -117,6 +117,10 @@ type CreateUsingGitOpsSpecInput struct {
 	// ValidateFleetAgentWasInstalled is used to indicate whether the test should also check that
 	// the fleet-agent has been installed on the downstream cluster.
 	ValidateFleetAgentWasInstalled bool
+
+	// AdditionalDownstreamTemplates contains a list of manifests that will be applied to the downstream Cluster
+	// as soon as the ControlPlane is initialized.
+	AdditionalDownstreamTemplates [][]byte
 }
 
 // CreateUsingGitOpsSpec implements a spec that will create a cluster via Fleet and test that it
@@ -277,6 +281,14 @@ func CreateUsingGitOpsSpec(ctx context.Context, inputGetter func() CreateUsingGi
 			return ptr.Deref(capiCluster.Status.Initialization.ControlPlaneInitialized, false)
 		}, capiClusterCreateWait...).Should(BeTrue())
 
+		By("Applying downstream manifests")
+		for _, template := range input.AdditionalDownstreamTemplates {
+			Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+				Template: template,
+				Proxy:    input.BootstrapClusterProxy.GetWorkloadCluster(ctx, capiCluster.Namespace, capiCluster.Name),
+			})).To(Succeed())
+		}
+
 		// Validate Rancher importing
 		rancherCluster = turtlesframework.ValidateRancherCluster(ctx, turtlesframework.ValidateRancherClusterInput{
 			BootstrapClusterProxy:   input.BootstrapClusterProxy,
@@ -390,6 +402,7 @@ func CreateUsingGitOpsSpec(ctx context.Context, inputGetter func() CreateUsingGi
 				RancherServerURL:        input.RancherServerURL,
 				WaitRancherIntervals:    input.E2EConfig.GetIntervals(input.BootstrapClusterProxy.GetName(), "wait-rancher"),
 				SkipLatestFeatureChecks: input.SkipLatestFeatureChecks,
+				RancherManagedFleet:     input.RancherManagedFleet,
 			})
 		}
 

--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -32,49 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
-var _ = Describe("[Docker] [Kubeadm]  Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.ShortTestLabel, e2e.KubeadmTestLabel), func() {
-	var topologyNamespace string
-
-	BeforeEach(func() {
-		komega.SetClient(bootstrapClusterProxy.GetClient())
-		komega.SetContext(ctx)
-
-		topologyNamespace = "creategitops-docker-kubeadm"
-	})
-
-	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
-		return specs.CreateUsingGitOpsSpecInput{
-			E2EConfig:                 e2e.LoadE2EConfig(),
-			BootstrapClusterProxy:     bootstrapClusterProxy,
-			ClusterTemplate:           e2e.CAPIDockerKubeadmTopology,
-			ClusterName:               "cluster-docker-kubeadm",
-			ControlPlaneMachineCount:  ptr.To(1),
-			WorkerMachineCount:        ptr.To(1),
-			LabelNamespace:            true,
-			TestClusterReimport:       true,
-			RancherServerURL:          hostName,
-			CAPIClusterCreateWaitName: "wait-rancher",
-			DeleteClusterWaitName:     "wait-controllers",
-			TopologyNamespace:         topologyNamespace,
-			VerifyETCDSize:            true,
-			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
-				{
-					Name:            "docker-cluster-classes-regular",
-					Paths:           []string{"examples/clusterclasses/docker/kubeadm"},
-					ClusterProxy:    bootstrapClusterProxy,
-					TargetNamespace: topologyNamespace,
-				},
-				{
-					Name:            "docker-cni",
-					Paths:           []string{"examples/applications/cni/calico"},
-					ClusterProxy:    bootstrapClusterProxy,
-					TargetNamespace: topologyNamespace,
-				},
-			},
-		}
-	})
-})
-
 var _ = Describe("[Azure] [AKS] Create and delete CAPI cluster from cluster class", Label(e2e.FullTestLabel), func() {
 	var topologyNamespace string
 

--- a/test/e2e/suites/rancher-managed-fleet/rancher_managed_fleet_test.go
+++ b/test/e2e/suites/rancher-managed-fleet/rancher_managed_fleet_test.go
@@ -113,3 +113,45 @@ var _ = Describe("[RancherManagedFleet] [Azure] [RKE2] Create and delete CAPI cl
 		}
 	})
 })
+
+var _ = Describe("[RancherManagedFleet] [Docker] [Kubeadm]  Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.ShortTestLabel, e2e.KubeadmTestLabel, e2e.RancherManagedFleetLabel), func() {
+	var topologyNamespace string
+
+	BeforeEach(func() {
+		komega.SetClient(bootstrapClusterProxy.GetClient())
+		komega.SetContext(ctx)
+
+		topologyNamespace = "creategitops-docker-kubeadm"
+	})
+
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
+		return specs.CreateUsingGitOpsSpecInput{
+			E2EConfig:                      e2e.LoadE2EConfig(),
+			BootstrapClusterProxy:          bootstrapClusterProxy,
+			ClusterTemplate:                e2e.CAPIDockerKubeadmTopology,
+			ClusterName:                    "cluster-docker-kubeadm",
+			ControlPlaneMachineCount:       new(1),
+			WorkerMachineCount:             new(1),
+			LabelNamespace:                 true,
+			TestClusterReimport:            true,
+			RancherManagedFleet:            true,
+			ValidateFleetAgentWasInstalled: true,
+			RancherServerURL:               hostName,
+			CAPIClusterCreateWaitName:      "wait-rancher",
+			DeleteClusterWaitName:          "wait-controllers",
+			TopologyNamespace:              topologyNamespace,
+			VerifyETCDSize:                 true,
+			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
+				{
+					Name:            "docker-cluster-classes-regular",
+					Paths:           []string{"examples/clusterclasses/docker/kubeadm"},
+					ClusterProxy:    bootstrapClusterProxy,
+					TargetNamespace: topologyNamespace,
+				},
+			},
+			AdditionalDownstreamTemplates: [][]byte{
+				e2e.CalicoManifest,
+			},
+		}
+	})
+})

--- a/test/e2e/suites/rancher-managed-fleet/suite_test.go
+++ b/test/e2e/suites/rancher-managed-fleet/suite_test.go
@@ -120,7 +120,7 @@ var _ = SynchronizedBeforeSuite(
 		testenv.DeployRancherTurtlesProviders(ctx, testenv.DeployRancherTurtlesProvidersInput{
 			BootstrapClusterProxy:   setupClusterResult.BootstrapClusterProxy,
 			RancherTurtlesNamespace: e2e.RancherTurtlesNamespace,
-			ProviderList:            "docker,rke2,azure",
+			ProviderList:            "docker,rke2,azure,kubeadm",
 		})
 
 		data, err := json.Marshal(e2e.Setup{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements https://github.com/rancher/turtles/issues/2496

The Docker/Kubeadm e2e test Cluster no longer uses CAAPF to install Calico.
Instead, the test framework now is able to apply templates downstream, if needed.
This is now the case for the Calico CNI manifest, which is applied as soon as the downstream Cluster has an initialized control plane.

For reference, this is also what the upstream documentation suggests: https://cluster-api.sigs.k8s.io/user/quick-start#deploy-a-cni-solution

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
