### PR TITLE
fix: replace cr upload with gh CLI to fix asset upload on re-run and unblock immutable releases

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -58,34 +58,44 @@ jobs:
           rm -rf .cr-index
           mkdir -p .cr-index
 
-      - name: Run chart-releaser upload
-        run: cr upload --skip-existing -c "$(git rev-parse HEAD)" --generate-release-notes --release-name-template "${{ inputs.tag }}" --make-release-latest=false
+      - name: Create draft release
+        run: |
+          if gh release view "${{ inputs.tag }}" &>/dev/null; then
+            echo "Release '${{ inputs.tag }}' already exists, reusing."
+          else
+            gh release create "${{ inputs.tag }}" \
+              --draft \
+              --latest=false \
+              --generate-notes \
+              --title "${{ inputs.tag }}" \
+              --target "$(git rev-parse HEAD)"
+          fi
 
-      - name: Verify chart asset present (recover if missing)
+      - name: Upload chart asset
         run: |
           CHART_FILE=$(ls ${{ inputs.release_dir }}/*.tgz 2>/dev/null | head -1)
           if [ -z "${CHART_FILE}" ]; then
             echo "ERROR: No .tgz chart package found in ${{ inputs.release_dir }}"
             exit 1
           fi
+          gh release upload "${{ inputs.tag }}" "${CHART_FILE}" --clobber
+          echo "Uploaded $(basename ${CHART_FILE})"
+
+      - name: Verify chart asset present
+        run: |
+          CHART_FILE=$(ls ${{ inputs.release_dir }}/*.tgz | head -1)
           ASSET_NAME=$(basename "${CHART_FILE}")
-
-          if ! gh release view "${{ inputs.tag }}" > /dev/null 2>&1; then
-            echo "ERROR: Release '${{ inputs.tag }}' not found."
-            exit 1
-          fi
-
           FOUND=$(gh release view "${{ inputs.tag }}" \
             --json assets \
             --jq ".assets[] | select(.name == \"${ASSET_NAME}\") | .name")
-
           if [ -z "${FOUND}" ]; then
-            echo "Chart asset '${ASSET_NAME}' missing — uploading now..."
-            gh release upload "${{ inputs.tag }}" "${CHART_FILE}" --clobber
-            echo "Upload complete."
-          else
-            echo "Chart asset '${ASSET_NAME}' confirmed present."
+            echo "ERROR: Asset '${ASSET_NAME}' still missing after upload. Failing."
+            exit 1
           fi
+          echo "Asset '${ASSET_NAME}' confirmed present."
+
+      - name: Publish release
+        run: gh release edit "${{ inputs.tag }}" --draft=false --latest=false
 
       - name: Run chart-releaser index
         run: cr index --push --release-name-template "${{ inputs.tag }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
`cr upload --skip-existing` silently skips asset upload when a release already exists, leaving the GitHub release with no .tgz attached on re-runs after a partial failure. This was papered over by a recovery step using `gh release upload --clobber`, but that recovery step itself violates immutable releases once enabled (modifying an already-published release is not allowed).

This PR replaces `cr upload` and the recovery step with explicit GH CLI steps:

- Create or reuse a draft release idempotently (`gh release create`, skips gracefully if the release already exists)
- Always upload the chart asset with `--clobber `(safe on re-runs, replaces the recovery pattern with a proactive upload)
- Hard-fail if the asset is missing after upload (no silent failures)
- Publish the release (`gh release edit --draft=false`) before cr index, because `GET/repos/{owner}/{repo}/releases/tags/{tag}` only returns published releases and cr index would silently produce no index update against a draft

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2359 
Partially fixes: #2421 

**Special notes for your reviewer**:
Changes were tested against my personal fork repo (xref: [source code](https://github.com/rancher/turtles/compare/main...furkatgofurov7:turtles:main), with additional changes to make it fork-runnable), and a [test release](https://github.com/furkatgofurov7/turtles/releases/tag/v0.99.7-test) was successfully created and published (not marked as latest, but published with assets).

This PR needs a backport once merged.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
