### PR TITLE
test: refactor AWS/EC2/RKE2 test away from CAAPF

### DIFF
--- a/examples/applications/ccm/aws/helm-chart.yaml
+++ b/examples/applications/ccm/aws/helm-chart.yaml
@@ -56,5 +56,4 @@ spec:
           - key: clusterclass-name.fleet.addons.cluster.x-k8s.io
             operator: In
             values:
-              - aws-rke2-example
               - aws-kubeadm-example

--- a/examples/applications/csi/aws/helm-chart.yaml
+++ b/examples/applications/csi/aws/helm-chart.yaml
@@ -17,4 +17,3 @@ spec:
         operator: In
         values:
         - aws-kubeadm-example
-        - aws-rke2-example

--- a/test/e2e/data/cluster-templates/aws-ec2-rke2-topology.yaml
+++ b/test/e2e/data/cluster-templates/aws-ec2-rke2-topology.yaml
@@ -3,7 +3,6 @@ kind: Cluster
 metadata:
   labels:
     cloud-provider: aws
-    cni: calico
     csi: aws-ebs-csi-driver
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
@@ -28,7 +27,7 @@ spec:
       - name: amiID
         value: ${AWS_AMI_ID}
       - name: cni
-        value: none
+        value: calico
       - name: awsClusterIdentityName
         value: ${AWS_CLUSTER_IDENTITY_NAME}
     version: ${RKE2_KUBERNETES_VERSION}
@@ -37,3 +36,103 @@ spec:
         - class: default-worker
           name: md-0
           replicas: ${WORKER_MACHINE_COUNT}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta2
+kind: ClusterResourceSet
+metadata:
+  name: cloud-provider-aws
+  namespace: ${NAMESPACE}
+spec:
+  strategy: Reconcile
+  clusterSelector:
+    matchLabels:
+      cloud-provider: aws
+  resources:
+    - name: cloud-provider-aws
+      kind: ConfigMap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-provider-aws
+  namespace: ${NAMESPACE}
+data:
+  cloud-provider-aws.yaml: |-
+    apiVersion: helm.cattle.io/v1
+    kind: HelmChart
+    metadata:
+      name: aws-cloud-controller-manager
+      namespace: kube-system
+    spec:
+      chart: aws-cloud-controller-manager
+      repo: https://kubernetes.github.io/cloud-provider-aws
+      version: 0.0.11
+      targetNamespace: kube-system
+      bootstrap: true
+      valuesContent: |-
+        hostNetworking: "true"
+        args:
+          - --v=2
+          - --cloud-provider=aws
+          - --use-service-account-credentials=true
+          - --configure-cloud-routes=false
+        nodeSelector:
+          node-role.kubernetes.io/control-plane: "true"
+        clusterRoleRules:
+          - apiGroups:
+              - ""
+            resources:
+              - events
+              - nodes
+              - nodes/status
+              - services
+              - services/status
+              - serviceaccounts
+              - persistentvolumes
+              - configmaps
+              - serviceaccounts/token
+              - endpoints
+            verbs:
+              - "*"
+          - apiGroups:
+              - coordination.k8s.io
+            resources:
+              - leases
+            verbs:
+              - create
+              - get
+              - list
+              - watch
+              - update
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta2
+kind: ClusterResourceSet
+metadata:
+  name: aws-ebs-csi
+  namespace: ${NAMESPACE}
+spec:
+  strategy: Reconcile
+  clusterSelector:
+    matchLabels:
+      csi: aws-ebs-csi-driver
+  resources:
+    - name: aws-ebs-csi
+      kind: ConfigMap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-ebs-csi
+  namespace: ${NAMESPACE}
+data:
+  aws-ebs-csi.yaml: |-
+    apiVersion: helm.cattle.io/v1
+    kind: HelmChart
+    metadata:
+      name: aws-ebs-csi-driver
+      namespace: kube-system
+    spec:
+      chart: aws-ebs-csi-driver
+      repo: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+      version: 2.62.0
+      targetNamespace: kube-system

--- a/test/e2e/suites/import-gitops/import_gitops_test.go
+++ b/test/e2e/suites/import-gitops/import_gitops_test.go
@@ -21,13 +21,11 @@ package import_gitops
 
 import (
 	"fmt"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/rancher/turtles/test/e2e"
 	"github.com/rancher/turtles/test/e2e/specs"
 	turtlesframework "github.com/rancher/turtles/test/framework"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
@@ -200,94 +198,6 @@ var _ = Describe("[AWS] [EC2 Kubeadm] Create and delete CAPI cluster functionali
 				{
 					Name:            "aws-csi",
 					Paths:           []string{"examples/applications/csi/aws"},
-					ClusterProxy:    bootstrapClusterProxy,
-					TargetNamespace: topologyNamespace,
-				},
-			},
-		}
-	})
-})
-
-var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.FullTestLabel, e2e.Rke2TestLabel), func() {
-	var topologyNamespace, capiClusterNamespace, credentialName string
-
-	BeforeEach(func() {
-		komega.SetClient(bootstrapClusterProxy.GetClient())
-		komega.SetContext(ctx)
-
-		topologyNamespace = "creategitops-aws-rke2"
-		// AWSClusterStaticIdentity only allows provisioning clusters in "fleet-default"
-		capiClusterNamespace = "fleet-default"
-		credentialName = "rancher-cloud-credential-aws"
-
-		By("Creating Rancher AWS Cloud Credential which will be translated into `AWSClusterStaticIdentity`")
-		lookupResult := &turtlesframework.RancherLookupUserResult{}
-		turtlesframework.RancherLookupUser(ctx, turtlesframework.RancherLookupUserInput{
-			Username:     "admin",
-			ClusterProxy: bootstrapClusterProxy,
-		}, lookupResult)
-
-		turtlesframework.CreateSecret(ctx, turtlesframework.CreateSecretInput{
-			Creator:   bootstrapClusterProxy.GetClient(),
-			Name:      credentialName,
-			Namespace: "cattle-global-data",
-			Type:      corev1.SecretTypeOpaque,
-			Data: map[string]string{
-				"amazonec2credentialConfig-accessKey": os.Getenv("AWS_ACCESS_KEY_ID"),
-				"amazonec2credentialConfig-secretKey": os.Getenv("AWS_SECRET_ACCESS_KEY"),
-			},
-			Annotations: map[string]string{
-				"field.cattle.io/name":          credentialName,
-				"provisioning.cattle.io/driver": "aws",
-				"field.cattle.io/creatorId":     lookupResult.User,
-			},
-			Labels: map[string]string{
-				"cattle.io/creator": "norman",
-			},
-		})
-	})
-
-	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
-		return specs.CreateUsingGitOpsSpecInput{
-			E2EConfig:                 e2e.LoadE2EConfig(),
-			BootstrapClusterProxy:     bootstrapClusterProxy,
-			ClusterTemplate:           e2e.CAPIAwsEC2RKE2Topology,
-			ClusterName:               "cluster-aws-rke2",
-			Namespace:                 capiClusterNamespace,
-			ControlPlaneMachineCount:  ptr.To(3), // minimum 3 replicas for CSI controller
-			WorkerMachineCount:        ptr.To(1),
-			LabelNamespace:            true,
-			RancherServerURL:          hostName,
-			CAPIClusterCreateWaitName: "wait-capa-create-cluster",
-			DeleteClusterWaitName:     "wait-eks-delete",
-			TopologyNamespace:         topologyNamespace,
-			VerifyETCDSize:            true,
-			AdditionalTemplateVariables: map[string]string{
-				"AWS_CLUSTER_IDENTITY_NAME": credentialName,
-				"NAMESPACE":                 capiClusterNamespace,
-			},
-			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
-				{
-					Name:            "aws-cluster-class-rke2",
-					Paths:           []string{"examples/clusterclasses/aws/rke2"},
-					ClusterProxy:    bootstrapClusterProxy,
-					TargetNamespace: topologyNamespace,
-				},
-				{
-					Name:            "aws-ccm-ec2-rke2",
-					Paths:           []string{"examples/applications/ccm/aws"},
-					ClusterProxy:    bootstrapClusterProxy,
-					TargetNamespace: topologyNamespace,
-				},
-				{
-					Name:            "aws-csi-ec2-rke2",
-					Paths:           []string{"examples/applications/csi/aws"},
-					ClusterProxy:    bootstrapClusterProxy,
-					TargetNamespace: topologyNamespace,
-				},
-				{
-					Name:            "aws-cni",
-					Paths:           []string{"examples/applications/cni/aws/calico"},
 					ClusterProxy:    bootstrapClusterProxy,
 					TargetNamespace: topologyNamespace,
 				},

--- a/test/e2e/suites/rancher-managed-fleet/rancher_managed_fleet_test.go
+++ b/test/e2e/suites/rancher-managed-fleet/rancher_managed_fleet_test.go
@@ -20,10 +20,13 @@ limitations under the License.
 package rancher_managed_fleet
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/rancher/turtles/test/e2e"
 	"github.com/rancher/turtles/test/e2e/specs"
 	turtlesframework "github.com/rancher/turtles/test/framework"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
@@ -151,6 +154,78 @@ var _ = Describe("[RancherManagedFleet] [Docker] [Kubeadm]  Create and delete CA
 			},
 			AdditionalDownstreamTemplates: [][]byte{
 				e2e.CalicoManifest,
+			},
+		}
+	})
+})
+
+var _ = Describe("[AWS] [EC2 RKE2] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.FullTestLabel, e2e.Rke2TestLabel), func() {
+	var topologyNamespace, capiClusterNamespace, credentialName string
+
+	BeforeEach(func() {
+		komega.SetClient(bootstrapClusterProxy.GetClient())
+		komega.SetContext(ctx)
+
+		topologyNamespace = "creategitops-aws-rke2"
+		// AWSClusterStaticIdentity only allows provisioning clusters in "fleet-default"
+		capiClusterNamespace = "fleet-default"
+		credentialName = "rancher-cloud-credential-aws"
+
+		By("Creating Rancher AWS Cloud Credential which will be translated into `AWSClusterStaticIdentity`")
+		lookupResult := &turtlesframework.RancherLookupUserResult{}
+		turtlesframework.RancherLookupUser(ctx, turtlesframework.RancherLookupUserInput{
+			Username:     "admin",
+			ClusterProxy: bootstrapClusterProxy,
+		}, lookupResult)
+
+		turtlesframework.CreateSecret(ctx, turtlesframework.CreateSecretInput{
+			Creator:   bootstrapClusterProxy.GetClient(),
+			Name:      credentialName,
+			Namespace: "cattle-global-data",
+			Type:      corev1.SecretTypeOpaque,
+			Data: map[string]string{
+				"amazonec2credentialConfig-accessKey": os.Getenv("AWS_ACCESS_KEY_ID"),
+				"amazonec2credentialConfig-secretKey": os.Getenv("AWS_SECRET_ACCESS_KEY"),
+			},
+			Annotations: map[string]string{
+				"field.cattle.io/name":          credentialName,
+				"provisioning.cattle.io/driver": "aws",
+				"field.cattle.io/creatorId":     lookupResult.User,
+			},
+			Labels: map[string]string{
+				"cattle.io/creator": "norman",
+			},
+		})
+	})
+
+	specs.CreateUsingGitOpsSpec(ctx, func() specs.CreateUsingGitOpsSpecInput {
+		return specs.CreateUsingGitOpsSpecInput{
+			E2EConfig:                      e2e.LoadE2EConfig(),
+			BootstrapClusterProxy:          bootstrapClusterProxy,
+			ClusterTemplate:                e2e.CAPIAwsEC2RKE2Topology,
+			ClusterName:                    "cluster-aws-rke2",
+			Namespace:                      capiClusterNamespace,
+			ControlPlaneMachineCount:       ptr.To(3), // minimum 3 replicas for CSI controller
+			WorkerMachineCount:             ptr.To(1),
+			LabelNamespace:                 true,
+			RancherManagedFleet:            true,
+			ValidateFleetAgentWasInstalled: true,
+			RancherServerURL:               hostName,
+			CAPIClusterCreateWaitName:      "wait-capa-create-cluster",
+			DeleteClusterWaitName:          "wait-eks-delete",
+			TopologyNamespace:              topologyNamespace,
+			VerifyETCDSize:                 true,
+			AdditionalTemplateVariables: map[string]string{
+				"AWS_CLUSTER_IDENTITY_NAME": credentialName,
+				"NAMESPACE":                 capiClusterNamespace,
+			},
+			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
+				{
+					Name:            "aws-cluster-class-rke2",
+					Paths:           []string{"examples/clusterclasses/aws/rke2"},
+					ClusterProxy:    bootstrapClusterProxy,
+					TargetNamespace: topologyNamespace,
+				},
 			},
 		}
 	})

--- a/test/e2e/suites/rancher-managed-fleet/suite_test.go
+++ b/test/e2e/suites/rancher-managed-fleet/suite_test.go
@@ -99,6 +99,13 @@ var _ = SynchronizedBeforeSuite(
 			RancherPatches:        [][]byte{e2e.RancherSettingPatch},
 		})
 
+		By("Enable Rancher Cloud Credential translation")
+		testenv.SetTurtlesFeatureGate(ctx, testenv.SetTurtlesFeatureGateInput{
+			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
+			FeatureName:           "rancher-credential-translation",
+			Enabled:               true,
+		})
+
 		By("Waiting for Rancher to be ready")
 		capiframework.WaitForDeploymentsAvailable(ctx, capiframework.WaitForDeploymentsAvailableInput{
 			Getter: setupClusterResult.BootstrapClusterProxy.GetClient(),
@@ -120,7 +127,7 @@ var _ = SynchronizedBeforeSuite(
 		testenv.DeployRancherTurtlesProviders(ctx, testenv.DeployRancherTurtlesProvidersInput{
 			BootstrapClusterProxy:   setupClusterResult.BootstrapClusterProxy,
 			RancherTurtlesNamespace: e2e.RancherTurtlesNamespace,
-			ProviderList:            "docker,rke2,azure,kubeadm",
+			ProviderList:            "docker,rke2,aws,azure,kubeadm",
 		})
 
 		data, err := json.Marshal(e2e.Setup{


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR updates the AWS/EC2/RKE2 test to use CRS and the RKE2's ability to define a CNI in order to no longer rely on CAAPF. 

Long test run: https://github.com/rancher/turtles/actions/runs/27680377285/job/81866498200

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #2505 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
