### PR TITLE
ci: add support for release/v0.27 in renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,9 @@
   "devbox": {
     "enabled": false
   },
+  "labels": ["area/dependency", "kind/chore"],
   "baseBranchPatterns": [
+    "release/v0.27",
     "release/v0.26",
     "release/v0.25"
   ],
@@ -16,6 +18,28 @@
       "matchPackageNames": ["rancher/turtles"],
       "matchDatasources": ["docker"],
       "enabled": false
+    },
+    {
+      "description": "release/v0.27: Align with core CAPI v1.13 dependencies",
+      "matchBaseBranches": ["release/v0.27"],
+      "matchPackageNames": [
+        "sigs.k8s.io/controller-runtime"
+      ],
+      "allowedVersions": "<0.24.0"
+    },
+    {
+      "description": "release/v0.27: Align with core CAPI v1.13 dependencies",
+      "matchBaseBranches": ["release/v0.27"],
+      "matchPackageNames": [
+        "k8s.io/**"
+      ],
+      "allowedVersions": "<0.36.0"
+    },
+    {
+      "description": "release/v0.27: Pin rancher/kuberlr-kubectl to version 8 (v8.x.x)",
+      "matchBaseBranches": ["release/v0.27"],
+      "matchPackageNames": ["rancher/kuberlr-kubectl"],
+      "allowedVersions": "<9.0.0"
     },
     {
       "description": "release/v0.26: Align with core CAPI v1.12 dependencies",


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This PR adds release/v0.27 to renovate.json so that we get dependency bumps for that release branch. Also adds kind and area labels to pass CI validation.

Relates to https://github.com/rancher/turtles/issues/2363

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
