### PR TITLE
ci: add verify-chart to ensure chart files are up to date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,6 +470,13 @@ verify-gen: generate  ## Verify go generated files are up to date
 		echo "generated files are out of date, run make generate"; exit 1; \
 	fi
 
+.PHONY: verify-chart
+verify-chart: build-chart 
+	@if !(git diff --quiet HEAD); then \
+		git diff; \
+		echo "chart files are out of date, run make generate"; exit 1; \
+	fi
+
 ## --------------------------------------
 ## Hack / Tools
 ## --------------------------------------

--- a/charts/rancher-turtles/templates/rancher-turtles-components.yaml
+++ b/charts/rancher-turtles/templates/rancher-turtles-components.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: capiproviders.turtles-capi.cattle.io
 spec:
   group: turtles-capi.cattle.io
@@ -3244,9 +3244,6 @@ spec:
             - message: 'CAPI Provider version should be in the semver format prefixed
                 with ''v''. Example: v1.9.3'
               rule: '!has(self.version) || self.version.matches(r"""^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$""")'
-            - message: Config secret namespace is always equal to the resource namespace
-                and should not be set.
-              rule: '!has(self.configSecret) || !has(self.configSecret.__namespace__)'
             - message: One of fetchConfig oci, url or selector should be set.
               rule: '!has(self.fetchConfig) || [has(self.fetchConfig.oci), has(self.fetchConfig.url),
                 has(self.fetchConfig.selector)].exists_one(e, e)'
@@ -3359,7 +3356,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: clusterctlconfigs.turtles-capi.cattle.io
 spec:
   group: turtles-capi.cattle.io
@@ -3576,6 +3573,7 @@ rules:
   - infrastructure.cluster.x-k8s.io
   resources:
   - '*'
+  - awsclusterstaticidentities
   verbs:
   - create
   - delete


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `verify-chart` to build and test if there are changes with the chart files.
Just noticed the chart was not updated after the controller-gen bump and the cloud credentials translation feature.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
