### PR TITLE
automatically label renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,10 @@
     "release/v0.26",
     "release/v0.25"
   ],
+  "labels": [
+        "kind/cleanup",
+        "area/dependency"
+    ],
   "packageRules": [
     {
       "description": "Disable rancher/turtles updates on dockerfiles. This avoids PRs that bump the version tag in Turtles Helm chart.",


### PR DESCRIPTION
**What this PR does / why we need it**:

Renovate PRs are only labeled with the default `dependencies`, which does not satisfy the repo's requirements and fails CI checks. This should (hopefully) automatically apply the required labels to the PRs that the Renovate bot creates.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
