### PR TITLE
ci: make Azure cloud provider chart version configurable

### DIFF
--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -76,6 +76,8 @@ variables:
   AZURE_AKS_KUBERNETES_VERSION: "v1.36.0"
   # Name of the Kubernetes Secret used by ASO to authenticate with Azure (defaults to ASO's own default name)
   AZURE_ASO_CREDENTIAL_SECRET_NAME: "aso-credential-secret"
+  # The version of the Azure Cloud Provider chart. See: https://github.com/kubernetes-sigs/cloud-provider-azure/releases
+  AZURE_CLOUD_PROVIDER_VERSION: "1.36.0"
 
   # AWS Configuration
   #

--- a/test/e2e/data/cluster-templates/azure-rke2-topology.yaml
+++ b/test/e2e/data/cluster-templates/azure-rke2-topology.yaml
@@ -21,7 +21,6 @@ kind: Cluster
 metadata:
   labels:
     cluster-api.cattle.io/rancher-auto-import: "true"
-    cloud-provider: azure
   name: ${CLUSTER_NAME}
   namespace: ${NAMESPACE}
 spec:
@@ -67,7 +66,7 @@ data:
       repo: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
       chart: cloud-provider-azure
       bootstrap: true
-      version: "1.36.0"
+      version: "${AZURE_CLOUD_PROVIDER_VERSION}"
       targetNamespace: kube-system
       valuesContent: |-
         infra:
@@ -84,7 +83,7 @@ spec:
   strategy: Reconcile
   clusterSelector:
     matchLabels:
-      cloud-provider: azure
+      cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
   resources:
     - name: cloud-provider-azure
       kind: ConfigMap

--- a/test/e2e/suites/rancher-managed-fleet/rancher_managed_fleet_test.go
+++ b/test/e2e/suites/rancher-managed-fleet/rancher_managed_fleet_test.go
@@ -79,7 +79,7 @@ var _ = Describe("[RancherManagedFleet] [Docker] [RKE2] Create and delete CAPI c
 	})
 })
 
-var _ = Describe("[RancherManagedFleet] [Azure] [RKE2] Create and delete CAPI cluster from cluster class", Label(e2e.FullTestLabel, e2e.Rke2TestLabel), func() {
+var _ = Describe("[RancherManagedFleet] [Azure] [RKE2] Create and delete CAPI cluster from cluster class", Label(e2e.FullTestLabel, e2e.Rke2TestLabel, e2e.RancherManagedFleetLabel), func() {
 	var topologyNamespace string
 
 	BeforeEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Part of https://github.com/rancher/turtles/issues/2506

Test run: https://github.com/rancher/turtles/actions/runs/28094838415 (ignore unrelated GKE artifact collection failure)

This PR makes 3 changes:
1. Use a variable for the Azure cloud provider chart version, so that's easier to maintain and document. See https://github.com/rancher/turtles-product-docs/pull/234
2. Remove the `cloud-provider: azure` misleading label selector from ClusterResourceSet. Since it contains Cluster specific information (name and cidr), it's more appropriate to select by cluster name.
3. Add the ranchermanagedfleet label to the Azure/RKE2 e2e test. Was missing.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
