### PR TITLE
ci: make vSphere CPI/CSI charts version configurable

### DIFF
--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -160,3 +160,7 @@ variables:
   DOCKER_REGISTRY_CONFIG: ""
 
   VSPHERE_TEMPLATE: "turtles-ci/ubuntu-2404-kube-v1.36.1"
+  # vSphere RKE2 CPI Chart version: curl -s https://rke2-charts.rancher.io/index.yaml | yq .entries.rancher-vsphere-cpi[0].version
+  VSPHERE_RKE2_CPI_CHART_VERSION: "1.14.000"
+  # vSphere RKE2 CSI Chart version: curl -s https://rke2-charts.rancher.io/index.yaml | yq .entries.rancher-vsphere-csi[0].version
+  VSPHERE_RKE2_CSI_CHART_VERSION: "3.7.0-rancher100"

--- a/test/e2e/data/cluster-templates/vsphere-rke2-topology.yaml
+++ b/test/e2e/data/cluster-templates/vsphere-rke2-topology.yaml
@@ -89,7 +89,7 @@ data:
       chart: rancher-vsphere-cpi
       bootstrap: true
       targetNamespace: kube-system
-      version: "1.14.000"
+      version: "${VSPHERE_RKE2_CPI_CHART_VERSION}"
       valuesContent: |-
         vCenter:
           host: "${VSPHERE_SERVER}"
@@ -183,7 +183,7 @@ data:
       bootstrap: true
       targetNamespace: vmware-system-csi
       createNamespace: true
-      version: "3.7.0-rancher100"
+      version: "${VSPHERE_RKE2_CSI_CHART_VERSION}"
       valuesContent: |-
         vCenter:
           configSecret:

--- a/test/e2e/suites/rancher-managed-fleet/rancher_managed_fleet_test.go
+++ b/test/e2e/suites/rancher-managed-fleet/rancher_managed_fleet_test.go
@@ -280,7 +280,7 @@ var _ = Describe("[RancherManagedFleet] [GCP] [Kubeadm] Create and delete CAPI c
 	})
 })
 
-var _ = Describe("[RancherManagedFleet] [vSphere] [RKE2] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.VsphereTestLabel, e2e.Rke2TestLabel), func() {
+var _ = Describe("[RancherManagedFleet] [vSphere] [RKE2] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.VsphereTestLabel, e2e.Rke2TestLabel, e2e.RancherManagedFleetLabel), func() {
 	var topologyNamespace string
 
 	BeforeEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the vSphere RKE2 CPI/CSI charts version configurable, so it's easier to maintain and document them.

Test run: https://github.com/rancher/turtles/actions/runs/28095825030

Part of https://github.com/rancher/turtles/issues/2531

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
