### PR TITLE
fix: remove empty roles placeholder from aggregated_role

### DIFF
--- a/charts/rancher-turtles/templates/rancher-turtles-components.yaml
+++ b/charts/rancher-turtles/templates/rancher-turtles-components.yaml
@@ -3515,7 +3515,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: rancher-turtles-aggregated-manager-role
-rules: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/rbac/aggregated_role.yaml
+++ b/config/rbac/aggregated_role.yaml
@@ -6,4 +6,3 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rancher-turtles/aggregate-to-manager: "true"
-rules: []


### PR DESCRIPTION
Fixes #2534 in Rancher 2.15 with Helm v4

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
We are unable to upgrade rancher-turtles chart in Rancher 2.15 with Helm v4 after enabling caapf feature due to a conflict with aggregation controller calculated rules with provided empty rules array from turtles chart.

See full problem description [here](https://github.com/rancher/turtles/issues/2534#issuecomment-4789516579)
<!-- Enter a description of the change and why this change is needed -->


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2534 

**Special notes for your reviewer**:
I have validated this solution as working in 2.15. The empty `rules: []` seems to be not compatible with Helm v4 SSA approach whereas it worked fine with Helm v3 which just merged the empty rules array with existing rules managed by aggregation controller.

We would need to backport this to release/v0.27

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
