### PR TITLE
ci: fix capiprovider webhook test flake

### DIFF
--- a/test/e2e/suites/capiprovider/capiprovider_test.go
+++ b/test/e2e/suites/capiprovider/capiprovider_test.go
@@ -250,7 +250,10 @@ var _ = Describe("no-cert-manager feature verification", Ordered, Label(e2e.Shor
 	})
 
 	It("Should apply dummy resource that uses webhooks", func() {
-		Expect(framework.Apply(ctx, bootstrapClusterProxy, e2e.CAPVDummyMachineTemplate)).Should(Succeed())
+		Eventually(func() error {
+			return framework.Apply(ctx, bootstrapClusterProxy, e2e.CAPVDummyMachineTemplate)
+		}, e2e.LoadE2EConfig().GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...).
+			Should(Succeed())
 		// Early cleanup since it's not used
 		Expect(framework.Delete(ctx, bootstrapClusterProxy, e2e.CAPVDummyMachineTemplate)).Should(Succeed())
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing a small flake that appeared since some newer version of CAPV.
Occasionally we try to apply a resource before the CAPV controller is able to serve webhook requests:

```
no-cert-manager feature verification Should apply dummy resource that uses webhooks [short]
/home/runner/_work/turtles/turtles/test/e2e/suites/capiprovider/capiprovider_test.go:252
  2026-06-25T08:56:22Z	INFO	Running kubectl	{"command": "apply --kubeconfig /tmp/e2e-kind4081111797 -f -"}
  2026-06-25T08:56:22Z	INFO	Stderr:	{"stderr": "Error from server (InternalError): error when creating \"STDIN\": Internal error occurred: failed calling webhook \"validation.vspheremachinetemplate.infrastructure.cluster.x-k8s.io\": failed to call webhook: Post \"[https://capv-webhook-service.capv-system.svc:443/validate-infrastructure-cluster-x-k8s-io-v1beta1-vspheremachinetemplate?timeout=10s\](https://capv-webhook-service.capv-system.svc/validate-infrastructure-cluster-x-k8s-io-v1beta1-vspheremachinetemplate?timeout=10s\)": dial tcp 10.96.40.163:443: connect: connection refused\n"}
```

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
