### PR TITLE
e2e: bump GKE version to v1.35.5

### DIFF
--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -100,7 +100,7 @@ variables:
   # GCP Configuration
   # Images are self-built and need versioned kubernetes components. See docs/image-builder
   GCP_KUBERNETES_VERSION: "v1.36.1"
-  GCP_GKE_KUBERNETES_VERSION: "v1.35.3"
+  GCP_GKE_KUBERNETES_VERSION: "v1.35.5"
   GCP_MACHINE_TYPE: "n1-standard-2"
   GCP_REGION: "europe-west2"
   GCP_IMAGE_ID: "cluster-api-ubuntu-2404-v1-36-1-1779178908" # Private image. See docs/image-builder


### PR DESCRIPTION
**What this PR does / why we need it**:

`v1.35.3` is out the stable channel, making first provisioning fail.

test run: https://github.com/rancher/turtles/actions/runs/28506325791

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
