### PR TITLE
e2e: retry applying downstream manifests

### DIFF
--- a/test/e2e/specs/import_gitops.go
+++ b/test/e2e/specs/import_gitops.go
@@ -283,11 +283,13 @@ func CreateUsingGitOpsSpec(ctx context.Context, inputGetter func() CreateUsingGi
 
 		By("Applying downstream manifests")
 		for _, template := range input.AdditionalDownstreamTemplates {
-			Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
-				Template:                      template,
-				AddtionalEnvironmentVariables: input.AdditionalTemplateVariables,
-				Proxy:                         input.BootstrapClusterProxy.GetWorkloadCluster(ctx, capiCluster.Namespace, capiCluster.Name),
-			})).To(Succeed())
+			Eventually(func() error {
+				return turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+					Template:                      template,
+					AddtionalEnvironmentVariables: input.AdditionalTemplateVariables,
+					Proxy:                         input.BootstrapClusterProxy.GetWorkloadCluster(ctx, capiCluster.Namespace, capiCluster.Name),
+				})
+			}).WithTimeout(5 * time.Minute).WithPolling(30 * time.Second).Should(Succeed())
 		}
 
 		// Validate Rancher importing


### PR DESCRIPTION
**What this PR does / why we need it**:

Seems that occasionally the downstream manifest application fails with:

```
[08](https://github.com/rancher/turtles/actions/runs/28486072599/job/84432940210#step:8:509)
  STEP: Applying downstream manifests @ 07/01/26 01:30:50.398
  2026-07-01T01:30:50Z	INFO	Running kubectl	{"command": "apply --kubeconfig /tmp/e2e-kubeconfig3990809428 -f -"}
  2026-07-01T01:31:11Z	INFO	Stderr:	{"stderr": "error: error validating \"STDIN\": error validating data: failed to download openapi: Get \"[https://136.69.115.155:443/openapi/v2?timeout=32s\](https://136.69.115.155/openapi/v2?timeout=32s\)": EOF; if you choose to ignore these errors, turn validation off with --validate=false\n"}
  [FAILED] in [It] - /home/runner/work/turtles/turtles/test/e2e/specs/import_gitops.go:290 @ 07/01/26 01:31:11.012
```

See: https://github.com/rancher/turtles/actions/runs/28486072599/job/84432940210

Test run: https://github.com/rancher/turtles/actions/runs/28514152773

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
