### PR TITLE
e2e: enable Calico VXLAN encapsulation

### DIFF
--- a/test/e2e/data/applications/calico.yaml
+++ b/test/e2e/data/applications/calico.yaml
@@ -1,5 +1,17 @@
 ---
 # Source: https://raw.githubusercontent.com/projectcalico/calico/refs/tags/v3.31.5/manifests/calico.yaml
+# Notes:
+# 1. Disable IPIP and enable VXLAN:
+#   # Enable IPIP
+#   - name: CALICO_IPV4POOL_IPIP
+#     value: "Never"
+#   # Enable or Disable VXLAN on the default IP pool.
+#   - name: CALICO_IPV4POOL_VXLAN
+#     value: "Always"
+#   # Enable or Disable VXLAN on the default IPv6 IP pool.
+#   - name: CALICO_IPV6POOL_VXLAN
+#     value: "Always" 
+#
 # This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
 
 apiVersion: policy/v1
@@ -7208,13 +7220,13 @@ spec:
               value: "autodetect"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
-              value: "Always"
+              value: "Never"
             # Enable or Disable VXLAN on the default IP pool.
             - name: CALICO_IPV4POOL_VXLAN
-              value: "Never"
+              value: "Always"
             # Enable or Disable VXLAN on the default IPv6 IP pool.
             - name: CALICO_IPV6POOL_VXLAN
-              value: "Never"
+              value: "Always"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:


### PR DESCRIPTION
**What this PR does / why we need it**:

This enables Azure support, see: https://docs.tigera.io/calico/latest/reference/public-cloud/azure
Also aligns this Calico manifest with the previously used chart: https://github.com/rancher/turtles/blob/main/examples/applications/cni/calico/helm-chart.yaml#L21

Test run: https://github.com/rancher/turtles/actions/runs/28529932462
vSphere run: https://github.com/rancher/turtles/actions/runs/28524602902

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
