### PR TITLE
fix: remove additional labels from config/default kustomization

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,11 +6,6 @@ namespace: cattle-turtles-system
 # "wordpress" becomes "alices-wordpress".
 namePrefix: rancher-turtles-
 
-labels:
-- includeSelectors: true
-  pairs:
-    turtles-capi.cattle.io: "turtles"
-
 resources:
 - ../rbac
 - ../manager


### PR DESCRIPTION
**What this PR does / why we need it**:

These labels are not necessary and make the Tilt deployment conflict with the Turtles chart (which does not contain them).


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
