### PR TITLE
ci: cleanup kind build node-image cache on dev-env

### DIFF
--- a/scripts/turtles-dev.sh
+++ b/scripts/turtles-dev.sh
@@ -87,6 +87,8 @@ cleanup() {
     echo "Cleaning up background processes..."
     [ -n "$NGROK_PID" ] && kill $NGROK_PID 2>/dev/null && echo "Stopped ngrok (PID: $NGROK_PID)"
     [ -f "$NGROK_CONFIG_FILE" ] && rm -f "$NGROK_CONFIG_FILE" && echo "Removed ngrok config file"
+    echo "Deleting kind build node-image cache..."
+    rm -rf /tmp/k8s-tar-extract-*
 }
 trap cleanup EXIT INT TERM
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The `kind build node-image` creates random cache folders like `/tmp/k8s-tar-extract-2874908621`. 
These can grow to 300MB or more each time the command is launched, so running the dev-env a bunch of times will fill /tmp completely making other steps fails (ex. kind load docker-image).

This PR ensures the caches are always cleared when terminating the dev env.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
