### PR TITLE
e2e: fix Azure CCM node selector to work with RKE2

### DIFF
--- a/test/e2e/data/cluster-templates/azure-rke2-topology.yaml
+++ b/test/e2e/data/cluster-templates/azure-rke2-topology.yaml
@@ -73,6 +73,8 @@ data:
           clusterName: ${CLUSTER_NAME}
         cloudControllerManager:
           clusterCIDR: 192.168.0.0/16
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: "true"
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a regression introduced by https://github.com/rancher/turtles/pull/2512
In RKE2 the actual node label is `node-role.kubernetes.io/control-plane: "true"` so it must be configured accordingly.

This was accidentally removed from the previous HelmOp configuration: https://github.com/rancher/turtles/blob/release/v0.27/examples/applications/ccm/azure/helm-chart.yaml#L18C1-L23C20

Test run: https://github.com/rancher/turtles/actions/runs/29498387618

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
