### PR TITLE
fix: allow VXLAN port for Calico

### DIFF
--- a/examples/clusterclasses/aws/rke2/clusterclass-ec2-rke2-example.yaml
+++ b/examples/clusterclasses/aws/rke2/clusterclass-ec2-rke2-example.yaml
@@ -209,6 +209,10 @@ spec:
               fromPort: -1
               protocol: "4"
               toPort: 65535
+            - description: Calico VXLAN
+              fromPort: 4789
+              protocol: udp
+              toPort: 4789
             - description: Calico Typha
               fromPort: 5473
               protocol: tcp


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

The RKE2-bundled Calico chart uses VXLAN by default which requires UDP port 4789 to be open.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
