### PR TITLE
chore: enable aws credential translation by default

### DIFF
--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -33,17 +33,18 @@ features:
   no-cert-manager:
     # enabled: Turn on or off.
     enabled: true
-  # use-rancher-default-registry: Alpha feature to use Rancher's default registry for provider images.
-  use-rancher-default-registry:
+  # rancher-credential-translation: Beta feature to automatically translate Rancher  Cloud Credentials.
+  rancher-credential-translation:
     # enabled: Turn on or off.
     enabled: true
   # use-caapf: Alpha feature to make Turtles rely on CAAPF to install Fleet in CAPI workload clusters.
   use-caapf:
     # enabled: Turn on or off.
     enabled: false
-  rancher-credential-translation:
+  # use-rancher-default-registry: Alpha feature to use Rancher's default registry for provider images.
+  use-rancher-default-registry:
     # enabled: Turn on or off.
-    enabled: false
+    enabled: true
 # volumes: Volumes for controller pods.
 volumes:
   - name: clusterctl-config

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -51,9 +51,9 @@ func init() {
 // DefaultGates are the default settings for Turtles feature gates.
 var DefaultGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	AgentTLSMode:              {Default: true, PreRelease: featuregate.Beta},
-	UIPlugin:                  {Default: false, PreRelease: featuregate.Alpha},
 	NoCertManager:             {Default: true, PreRelease: featuregate.Beta},
-	UseRancherDefaultRegistry: {Default: true, PreRelease: featuregate.Beta},
+	RancherCCTranslation:      {Default: true, PreRelease: featuregate.Beta},
+	UIPlugin:                  {Default: false, PreRelease: featuregate.Alpha},
 	UseCAAPF:                  {Default: false, PreRelease: featuregate.Alpha},
-	RancherCCTranslation:      {Default: false, PreRelease: featuregate.Alpha},
+	UseRancherDefaultRegistry: {Default: true, PreRelease: featuregate.Beta},
 }

--- a/test/e2e/suites/rancher-managed-fleet/suite_test.go
+++ b/test/e2e/suites/rancher-managed-fleet/suite_test.go
@@ -99,13 +99,6 @@ var _ = SynchronizedBeforeSuite(
 			RancherPatches:        [][]byte{e2e.RancherSettingPatch},
 		})
 
-		By("Enable Rancher Cloud Credential translation")
-		testenv.SetTurtlesFeatureGate(ctx, testenv.SetTurtlesFeatureGateInput{
-			BootstrapClusterProxy: setupClusterResult.BootstrapClusterProxy,
-			FeatureName:           "rancher-credential-translation",
-			Enabled:               true,
-		})
-
 		By("Waiting for Rancher to be ready")
 		capiframework.WaitForDeploymentsAvailable(ctx, capiframework.WaitForDeploymentsAvailableInput{
 			Getter: setupClusterResult.BootstrapClusterProxy.GetClient(),


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Enable the cloud credential translation feature by default. This will align the value with Rancher's system chart's setting when installing Turtles.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This addresses https://github.com/rancher/turtles/issues/2702

**Special notes for your reviewer**:

Must be back-ported to `release/v0.27`.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
