### PR TITLE
chore: bump capg to v1.13.0

### DIFF
--- a/charts/rancher-turtles-providers/values.yaml
+++ b/charts/rancher-turtles-providers/values.yaml
@@ -368,7 +368,7 @@ images:
       tag: v2.13.0
   infrastructureGCP:
     repository: rancher/cluster-api-gcp-controller
-    tag: v1.11.2
+    tag: v1.13.0
   infrastructureVSphere:
     repository: rancher/cluster-api-vsphere-controller
     tag: v1.16.1

--- a/internal/controllers/clusterctl/config-prime.yaml
+++ b/internal/controllers/clusterctl/config-prime.yaml
@@ -22,7 +22,7 @@ data:
       url:          "https://github.com/rancher/cluster-api-provider-azure/releases/v1.23.2/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "gcp"
-      url:          "https://github.com/rancher/cluster-api-provider-gcp/releases/v1.11.2/infrastructure-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-gcp/releases/v1.13.0/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "vsphere"
       url:          "https://github.com/rancher/cluster-api-provider-vsphere/releases/v1.16.1/infrastructure-components.yaml"

--- a/internal/controllers/clusterctl/config_test.go
+++ b/internal/controllers/clusterctl/config_test.go
@@ -66,7 +66,7 @@ data:
         url: https://github.com/rancher/cluster-api/releases/v1.13.3/core-components.yaml
       - name: gcp
         type: InfrastructureProvider
-        url: https://github.com/rancher/cluster-api-provider-gcp/releases/v1.11.1/infrastructure-components.yaml
+        url: https://github.com/rancher/cluster-api-provider-gcp/releases/v1.13.0/infrastructure-components.yaml
       - name: rke2
         type: ControlPlaneProvider
         url: https://github.com/rancher/cluster-api-provider-rke2/releases/v0.25.0/control-plane-components.yaml

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -206,6 +206,8 @@ const (
 	GCPProjectIDVar        = "GCP_PROJECT"
 
 	ClusterCIDRVar = "CLUSTER_CIDR"
+
+	GCPCCMVersionVar = "GCP_CCM_VERSION"
 )
 
 const (

--- a/test/e2e/data/applications/cloud-provider-gcp.yaml
+++ b/test/e2e/data/applications/cloud-provider-gcp.yaml
@@ -1,7 +1,8 @@
-# Source: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/refs/tags/v1.11.2/test/e2e/data/ccm/gce-cloud-controller-manager.yaml
+# Source: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/refs/tags/v1.13.0/test/e2e/data/ccm/gce-cloud-controller-manager.yaml
 #
 # Notes: 
 # 1. Patch the DeamonSet command with the ${CLUSTER_CIDR} variable instead of a static value.
+# 2. Patch the DeamonSet command with the ${GCP_CCM_VERSION} variable: recommend using the same as upstream (see above link).
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -46,7 +47,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
       - name: cloud-controller-manager
-        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master
+        image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:${GCP_CCM_VERSION}
         imagePullPolicy: IfNotPresent
         command:
         - /cloud-controller-manager

--- a/test/e2e/suites/rancher-managed-fleet/rancher_managed_fleet_test.go
+++ b/test/e2e/suites/rancher-managed-fleet/rancher_managed_fleet_test.go
@@ -307,6 +307,7 @@ var _ = Describe("[RancherManagedFleet] [GCP] [Kubeadm] Create and delete CAPI c
 			AdditionalTemplateVariables: map[string]string{
 				e2e.GCPImageIDFormattedVar: gcpImageFormatted,
 				e2e.ClusterCIDRVar:         "192.168.0.0/16",
+				e2e.GCPCCMVersionVar:       "v35.1.3",
 			},
 			AdditionalFleetGitRepos: []turtlesframework.FleetCreateGitRepoInput{
 				{


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

cluster-api-provider:v1.13.0 is the latest release of the Google provider, which uses CAPI v1.13.2.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Original issue: https://github.com/rancher/turtles/issues/2695

**Special notes for your reviewer**:

:white_check_mark: Link to successful E2E long: https://github.com/rancher/turtles/actions/runs/30823368376

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
