### PR TITLE
e2e: prevent fleet-default namespace deletion

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -87,11 +87,16 @@ func DumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterPr
 			Namespace:    namespace.Name,
 		}, intervalsGetter(specName, "wait-delete-cluster")...)
 
-		turtlesframework.Byf("Deleting namespace used for hosting the %q test spec", specName)
-		framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{
-			Deleter: clusterProxy.GetClient(),
-			Name:    namespace.Name,
-		})
+		// Tests that use cloud credentials mapping will be constrained to the shared fleet-default namespace.
+		// Since all CAPI Clusters are imported into fleet-default namespace as well, we need to prevent deletion
+		// of this namespace to not disrupt other tests or other Rancher functionality.
+		if namespace.Name != "fleet-default" {
+			turtlesframework.Byf("Deleting namespace used for hosting the %q test spec", specName)
+			framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{
+				Deleter: clusterProxy.GetClient(),
+				Name:    namespace.Name,
+			})
+		}
 	}
 	cancelWatches()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

fixes https://github.com/rancher/turtles/issues/2710

Test run: https://github.com/rancher/turtles/actions/runs/30896516177

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
