### PR TITLE
e2e: retry identity application when rancher-webhook not ready

### DIFF
--- a/test/testenv/providers.go
+++ b/test/testenv/providers.go
@@ -389,28 +389,32 @@ func applyProviderSecrets(ctx context.Context, input DeployRancherTurtlesProvide
 		switch name {
 		case providerAzure:
 			By("Applying Azure identity secret")
-			Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+			Eventually(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
 				Proxy:    input.BootstrapClusterProxy,
 				Template: e2e.AzureIdentitySecret,
-			})).To(Succeed(), "Failed to apply Azure identity secret")
+			})).WithPolling(10*time.Second).WithTimeout(5*time.Minute).
+				Should(Succeed(), "Failed to apply Azure identity secret")
 		case providerAWS:
 			By("Applying AWS provider secret")
-			Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+			Eventually(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
 				Proxy:    input.BootstrapClusterProxy,
 				Template: e2e.AWSIdentitySecret,
-			})).To(Succeed(), "Failed to apply AWS provider secret")
+			})).WithPolling(10*time.Second).WithTimeout(5*time.Minute).
+				Should(Succeed(), "Failed to apply AWS provider secret")
 		case providerGCP:
 			By("Applying GCP provider secret")
-			Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+			Eventually(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
 				Proxy:    input.BootstrapClusterProxy,
 				Template: e2e.GCPProviderSecret,
-			})).To(Succeed(), "Failed to apply GCP provider secret")
+			})).WithPolling(10*time.Second).WithTimeout(5*time.Minute).
+				Should(Succeed(), "Failed to apply GCP provider secret")
 		case providerVSphere:
 			By("Applying vSphere provider secret")
-			Expect(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
+			Eventually(turtlesframework.ApplyFromTemplate(ctx, turtlesframework.ApplyFromTemplateInput{
 				Proxy:    input.BootstrapClusterProxy,
 				Template: e2e.VSphereProviderSecret,
-			})).To(Succeed(), "Failed to apply vSphere provider secret")
+			})).WithPolling(10*time.Second).WithTimeout(5*time.Minute).
+				Should(Succeed(), "Failed to apply vSphere provider secret")
 		}
 	}
 }


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Small fix to address a flaky case where the identities are applied before the rancher-webhook is ready.
This only affects vSphere and AWS identities so far, but will most likely apply to others in the future.

Failure reference: https://github.com/rancher/turtles/actions/runs/31344286253

Error:

```txt
STEP: Applying vSphere provider secret @ 08/10/26 00:45:46.871
  2026-08-10T00:45:46Z	INFO	Running kubectl	{"command": "apply --kubeconfig /tmp/kubeconfig3278292687 -f -"}
  2026-08-10T00:45:48Z	INFO	Stderr:	{"stderr": "Error from server (InternalError): error when creating \"STDIN\": Internal error occurred: failed calling webhook \"rancher.cattle.io.secrets\": failed to call webhook: Post \"[https://rancher-webhook.cattle-system.svc:443/v1/webhook/validation/secrets?timeout=10s\](https://rancher-webhook.cattle-system.svc/v1/webhook/validation/secrets?timeout=10s\)": EOF\n"}
  [FAILED] in [SynchronizedBeforeSuite] - /home/runner/work/turtles/turtles/test/testenv/providers.go:413 @ 08/10/26 00:45:48.916
```

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
