### PR TITLE
bump capg to v1.13.1

### DIFF
--- a/charts/rancher-turtles-providers/values.yaml
+++ b/charts/rancher-turtles-providers/values.yaml
@@ -368,7 +368,7 @@ images:
       tag: v2.18.0
   infrastructureGCP:
     repository: rancher/cluster-api-gcp-controller
-    tag: v1.13.0
+    tag: v1.13.1
   infrastructureVSphere:
     repository: rancher/cluster-api-vsphere-controller
     tag: v1.16.1

--- a/internal/controllers/clusterctl/config-prime.yaml
+++ b/internal/controllers/clusterctl/config-prime.yaml
@@ -22,7 +22,7 @@ data:
       url:          "https://github.com/rancher/cluster-api-provider-azure/releases/v1.26.0/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "gcp"
-      url:          "https://github.com/rancher/cluster-api-provider-gcp/releases/v1.13.0/infrastructure-components.yaml"
+      url:          "https://github.com/rancher/cluster-api-provider-gcp/releases/v1.13.1/infrastructure-components.yaml"
       type:         "InfrastructureProvider"
     - name:         "vsphere"
       url:          "https://github.com/rancher/cluster-api-provider-vsphere/releases/v1.16.1/infrastructure-components.yaml"

--- a/internal/controllers/clusterctl/config_test.go
+++ b/internal/controllers/clusterctl/config_test.go
@@ -66,7 +66,7 @@ data:
         url: https://github.com/rancher/cluster-api/releases/v1.13.3/core-components.yaml
       - name: gcp
         type: InfrastructureProvider
-        url: https://github.com/rancher/cluster-api-provider-gcp/releases/v1.13.0/infrastructure-components.yaml
+        url: https://github.com/rancher/cluster-api-provider-gcp/releases/v1.13.1/infrastructure-components.yaml
       - name: rke2
         type: ControlPlaneProvider
         url: https://github.com/rancher/cluster-api-provider-rke2/releases/v0.25.0/control-plane-components.yaml

--- a/test/e2e/data/applications/cloud-provider-gcp.yaml
+++ b/test/e2e/data/applications/cloud-provider-gcp.yaml
@@ -1,4 +1,4 @@
-# Source: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/refs/tags/v1.13.0/test/e2e/data/ccm/gce-cloud-controller-manager.yaml
+# Source: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-gcp/refs/tags/v1.13.1/test/e2e/data/ccm/gce-cloud-controller-manager.yaml
 #
 # Notes: 
 # 1. Patch the DeamonSet command with the ${CLUSTER_CIDR} variable instead of a static value.


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Bump CAPG to the latest patch 1.13.1, which includes a fix to an error when comparing `GCPManagedMachinePools` and `MachinePools` that blocks provisioning. 

Link to running long E2E: https://github.com/rancher/turtles/actions/runs/31502654444

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
