### PR TITLE
[release/v0.25] chore: bump Go version and providers chart

### DIFF
--- a/charts/rancher-turtles-providers/Chart.yaml
+++ b/charts/rancher-turtles-providers/Chart.yaml
@@ -3,8 +3,8 @@ name: rancher-turtles-providers
 description: This chart installs the Rancher Turtles certified providers.
 home: https://turtles.docs.rancher.com/turtles/stable/en/overview/certified.html
 icon: https://raw.githubusercontent.com/rancher/turtles/main/logos/capi.svg
-version: 0.25.7-rc.1
-appVersion: "0.25.7-rc.1"
+version: 0.25.7-rc.2
+appVersion: "0.25.7-rc.2"
 keywords:
 - rancher
 - cluster-api

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/examples
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/agnivade/levenshtein v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/test
 
-go 1.25.12
+go 1.25.13
 
 replace github.com/rancher/turtles => ../
 

--- a/tilt/project/Tiltfile
+++ b/tilt/project/Tiltfile
@@ -295,7 +295,7 @@ def get_port_forwards(debug):
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.25.12 as tilt-helper
+FROM golang:1.25.13 as tilt-helper
 # Support live reloading with Tilt
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/restart.sh  && \


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Bump Go version to `1.25.13` and providers chart version to `0.25.7-rc.2`

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
