### PR TITLE
bump test gke version to 1.35.6

### DIFF
--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -98,7 +98,7 @@ variables:
   # GCP Configuration
   # Images are self-built and need versioned kubernetes components. See docs/image-builder
   GCP_KUBERNETES_VERSION: "v1.36.1"
-  GCP_GKE_KUBERNETES_VERSION: "v1.35.5"
+  GCP_GKE_KUBERNETES_VERSION: "v1.35.6"
   GCP_MACHINE_TYPE: "n1-standard-2"
   GCP_REGION: "europe-west2"
   GCP_IMAGE_ID: "cluster-api-ubuntu-2404-v1-36-1-1779178908" # Private image. See docs/image-builder


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

A quick investigation on recurrent GKE provisioning errors point to the Kubernetes version, which is no longer available. This should fix this failure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Google regularly removes specific Kubernetes versions from their release channels, which breaks our GKE validation. It may be interesting to think about a solution to automatically detect this scenario and raise a PR to bump the version.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
