### PR TITLE
Add clustername and releaseChannel variable name

### DIFF
--- a/examples/clusterclasses/gcp/gke/clusterclass-gke-example.yaml
+++ b/examples/clusterclasses/gcp/gke/clusterclass-gke-example.yaml
@@ -57,6 +57,12 @@ spec:
         openAPIV3Schema:
           description: "The GCP network name"
           type: string
+    - name: releaseChannel
+      required: false
+      schema:
+        openAPIV3Schema:
+          description: "Release channel to use for fetching Kubernetes version"
+          type: string
   patches:
     - name: project
       definitions:
@@ -82,6 +88,30 @@ spec:
               path: /spec/template/spec/project
               valueFrom:
                 variable: project
+    - name: clusterNameControlPlane
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: GCPManagedControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/clusterName
+              valueFrom:
+                variable: builtin.cluster.name
+    - name: releaseChannelControlPlane
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: GCPManagedControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/releaseChannel
+              valueFrom:
+                variable: releaseChannel
     - name: region
       definitions:
         - selector:

--- a/examples/clusterclasses/gcp/gke/clusterclass-gke-example.yaml
+++ b/examples/clusterclasses/gcp/gke/clusterclass-gke-example.yaml
@@ -61,7 +61,7 @@ spec:
       required: false
       schema:
         openAPIV3Schema:
-          description: "Release channel to use for fetching Kubernetes version"
+          description: "Release channel to use for fetching Kubernetes version (default: regular)"
           type: string
   patches:
     - name: project

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -98,7 +98,7 @@ variables:
   # GCP Configuration
   # Images are self-built and need versioned kubernetes components. See docs/image-builder
   GCP_KUBERNETES_VERSION: "v1.36.1"
-  GCP_GKE_KUBERNETES_VERSION: "v1.35.6"
+  GCP_GKE_KUBERNETES_VERSION: "v1.35.7"
   GCP_MACHINE_TYPE: "n1-standard-2"
   GCP_REGION: "europe-west2"
   GCP_IMAGE_ID: "cluster-api-ubuntu-2404-v1-36-1-1779178908" # Private image. See docs/image-builder

--- a/test/e2e/data/cluster-templates/gcp-gke-topology.yaml
+++ b/test/e2e/data/cluster-templates/gcp-gke-topology.yaml
@@ -22,6 +22,8 @@ spec:
         value: ${GCP_REGION}
       - name: networkName
         value: ${GCP_NETWORK_NAME}
+      - name: releaseChannel
+        value: regular
     workers:
       machinePools:
         - class: default-system

--- a/test/e2e/suites/rancher-managed-fleet/rancher_managed_fleet_test.go
+++ b/test/e2e/suites/rancher-managed-fleet/rancher_managed_fleet_test.go
@@ -528,7 +528,7 @@ var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster from cluster class"
 	})
 })
 
-var _ = Describe("[GCP] [GKE] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.FullTestLabel), func() {
+var _ = FDescribe("[GCP] [GKE] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.FullTestLabel), func() {
 	var topologyNamespace string
 
 	BeforeEach(func() {

--- a/test/e2e/suites/rancher-managed-fleet/rancher_managed_fleet_test.go
+++ b/test/e2e/suites/rancher-managed-fleet/rancher_managed_fleet_test.go
@@ -528,7 +528,7 @@ var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster from cluster class"
 	})
 })
 
-var _ = FDescribe("[GCP] [GKE] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.FullTestLabel), func() {
+var _ = Describe("[GCP] [GKE] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(e2e.FullTestLabel), func() {
 	var topologyNamespace string
 
 	BeforeEach(func() {


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
1. This PR adds `clusterName` variable to GKE Clusterclass example, so that it uses the cluster name defined in `cluster.clusters.cluster.x-k8s.io`.

    I had added a similar [change](https://github.com/rancher/turtles/pull/2231/changes) a few months ago in March, but that had to be [reverted](https://github.com/rancher/turtles/pull/2233) because the `clusterName` field was not exposed for use, the fix for it is now in v1.13.1, so the feature should work, [see](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/commit/435223c367fea73067a58f6113b903b99bed485a). 

2. It also adds `releaseChannel` variable to allow users to add the release name since lately I have been experiencing failure related to missing `releaseChannel` value in GKE.

3. Bump GKE K8s version to 1.35.7 (required because 1.35.6 is not available on _Regular_ channel and _No Channel_ option has been deprecated by google).

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests - [long e2e GKE focused run](https://github.com/rancher/turtles/actions/runs/33372021993/job/99425632237) :green_circle: 

This screenshots shows custom cluster name instead of the default `capg-XXX`, and _Regular_ release channel selection.
<img width="1328" height="1113" alt="Screenshot from 2026-08-31 14-16-05" src="https://github.com/user-attachments/assets/83c45b6e-b29c-4414-a69b-c5dfb7019f4d" />
