### PR TITLE
fix: do not disable the import when the cluster record vanishes mid-import

### DIFF
--- a/docs/adr/0003-deletion-strategy.md
+++ b/docs/adr/0003-deletion-strategy.md
@@ -27,6 +27,14 @@ The deletion workflow is structured as follows:
 
 **Cluster Annotation:** When deleting a Rancher cluster, the operator will annotate the corresponding CAPI cluster with the `ClusterImportedAnnotation` (`imported=“true”`) annotation. This annotation will prevent automatic re-import of the CAPI cluster after corresponding Rancher cluster deletion. The underlying infrastructure provisioned by CAPI is left intact.
 
+Amendment (2026-08): the annotation is only applied when the import of the
+deleted Rancher cluster had completed at least once (its record reached the
+`AgentDeployed` or `Ready` condition). A record that disappears before the
+agent was ever deployed, for example when it is replaced while the import is
+still settling, does not mark the CAPI cluster as imported: the next reconcile
+re-creates the record and the import proceeds. Without this restriction such a
+cluster could never be imported again without manual intervention.
+
 From an end-user perspective:
 
 * If user manually deletes CAPI cluster. Rancher turtles uses [Kubernetes owner references](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/) to track relationships between objects. These references are used for Kubernetes garbage collection, which is the basis of Rancher cluster deletion in Rancher turtles.

--- a/internal/controllers/import_controller.go
+++ b/internal/controllers/import_controller.go
@@ -236,7 +236,7 @@ func (r *CAPIImportReconciler) reconcile(ctx context.Context, capiCluster *clust
 		// Patch CAPI Cluster with:
 		// 1. `imported=true` annotation to prevent further-reimports.
 		// 2. Removed capicluster.turtles.cattle.io finalizer to allow deletion.
-		if err := r.reconcileDelete(ctx, capiCluster); err != nil {
+		if err := r.reconcileDelete(ctx, capiCluster, rancherCluster); err != nil {
 			log.Error(err, "Removing CAPI Cluster failed, retrying")
 			return ctrl.Result{}, err
 		}
@@ -471,9 +471,22 @@ func (r *CAPIImportReconciler) rancherV3ClusterToCapiCluster(ctx context.Context
 	}
 }
 
-func (r *CAPIImportReconciler) reconcileDelete(ctx context.Context, capiCluster *clusterv1.Cluster) error {
+func (r *CAPIImportReconciler) reconcileDelete(ctx context.Context, capiCluster *clusterv1.Cluster, rancherCluster *managementv3.Cluster) error {
 	log := log.FromContext(ctx)
 	log.Info("Reconciling rancher cluster deletion")
+
+	// Only mark the CAPI cluster as imported when the import had actually
+	// completed for the record being deleted. A record that vanishes before
+	// the agent was ever deployed (for example when it is replaced while the
+	// import is still settling) would otherwise permanently disable the
+	// import: the annotation short-circuits every future reconcile, so no new
+	// record is ever created and the agent never gets deployed.
+	if !conditions.IsTrue(rancherCluster, managementv3.ClusterConditionAgentDeployed) &&
+		!conditions.IsTrue(rancherCluster, managementv3.ClusterConditionReady) {
+		log.Info("Rancher cluster is being removed before the import completed, allowing a re-import")
+
+		return nil
+	}
 
 	// If the Rancher Cluster was already imported, then annotate the CAPI cluster so that we don't auto-import again.
 	log.Info(fmt.Sprintf("Rancher cluster is being removed, annotating CAPI cluster %s with %s",

--- a/internal/controllers/import_controller_test.go
+++ b/internal/controllers/import_controller_test.go
@@ -277,6 +277,144 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		}).Should(Succeed())
 	})
 
+	It("should not mark the CAPI cluster imported when the rancher cluster is removed before the import completed", func() {
+		Expect(cl.Create(ctx, capiCluster)).To(Succeed())
+		setControlPlaneReady(capiCluster)
+		Expect(cl.Status().Update(ctx, capiCluster)).To(Succeed())
+
+		// First reconcile creates the rancher cluster record.
+		Eventually(func(g Gomega) {
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: capiCluster.Namespace,
+					Name:      capiCluster.Name,
+				},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
+			g.Expect(rancherClusters.Items).To(HaveLen(1))
+		}).Should(Succeed())
+
+		cluster := rancherClusters.Items[0]
+
+		// Hold the record with an extra finalizer and delete it before the
+		// import ever completed (no AgentDeployed or Ready condition), so the
+		// reconciler observes the record mid-deletion, the way a slow
+		// finalization on a loaded Rancher exposes it.
+		Eventually(func(g Gomega) {
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(&cluster), &cluster)).To(Succeed())
+			cluster.Finalizers = append(cluster.Finalizers, "test.turtles.cattle.io/hold")
+			g.Expect(cl.Update(ctx, &cluster)).To(Succeed())
+		}).Should(Succeed())
+		Expect(cl.Delete(ctx, &cluster)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			// The reconcile may transiently fail while the cache still serves
+			// the record without its deletion timestamp; only the end state
+			// matters here.
+			_, _ = r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: capiCluster.Namespace,
+					Name:      capiCluster.Name,
+				},
+			})
+
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(capiCluster), capiCluster)).To(Succeed())
+			g.Expect(turtlesannotations.HasClusterImportAnnotation(capiCluster)).To(BeFalse(),
+				"a record deleted before the import completed must not disable the import")
+
+			// The reconciler still releases its finalizer so the record can go away.
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(&cluster), &cluster)).To(Succeed())
+			g.Expect(cluster.Finalizers).ToNot(ContainElement(managementv3.CapiClusterFinalizer))
+		}).WithTimeout(30 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
+
+		// Release the hold so cleanup can proceed.
+		Eventually(func(g Gomega) {
+			if err := cl.Get(ctx, client.ObjectKeyFromObject(&cluster), &cluster); err != nil {
+				return
+			}
+			kept := []string{}
+			for _, f := range cluster.Finalizers {
+				if f != "test.turtles.cattle.io/hold" {
+					kept = append(kept, f)
+				}
+			}
+			cluster.Finalizers = kept
+			g.Expect(cl.Update(ctx, &cluster)).To(Succeed())
+		}).Should(Succeed())
+	})
+
+	It("should mark the CAPI cluster imported when an imported rancher cluster is removed", func() {
+		Expect(cl.Create(ctx, capiCluster)).To(Succeed())
+		setControlPlaneReady(capiCluster)
+		Expect(cl.Status().Update(ctx, capiCluster)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			_, err := r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: capiCluster.Namespace,
+					Name:      capiCluster.Name,
+				},
+			})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(cl.List(ctx, rancherClusters, selectors...)).ToNot(HaveOccurred())
+			g.Expect(rancherClusters.Items).To(HaveLen(1))
+		}).Should(Succeed())
+
+		cluster := rancherClusters.Items[0]
+
+		// Mark the record as having completed the import.
+		Eventually(func(g Gomega) {
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(&cluster), &cluster)).To(Succeed())
+			conditions.Set(&cluster, metav1.Condition{
+				Type:               managementv3.ClusterConditionAgentDeployed,
+				Status:             metav1.ConditionTrue,
+				Reason:             "AgentDeployed",
+				LastTransitionTime: metav1.Now(),
+			})
+			g.Expect(cl.Status().Update(ctx, &cluster)).To(Succeed())
+		}).Should(Succeed())
+
+		// Unimport: hold and delete the record, as the Rancher unimport flow does.
+		Eventually(func(g Gomega) {
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(&cluster), &cluster)).To(Succeed())
+			cluster.Finalizers = append(cluster.Finalizers, "test.turtles.cattle.io/hold")
+			g.Expect(cl.Update(ctx, &cluster)).To(Succeed())
+		}).Should(Succeed())
+		Expect(cl.Delete(ctx, &cluster)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			// The reconcile may transiently fail while the cache still serves
+			// the record without its deletion timestamp; only the end state
+			// matters here.
+			_, _ = r.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: capiCluster.Namespace,
+					Name:      capiCluster.Name,
+				},
+			})
+
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(capiCluster), capiCluster)).To(Succeed())
+			g.Expect(turtlesannotations.HasClusterImportAnnotation(capiCluster)).To(BeTrue(),
+				"unimporting a cluster whose import completed must keep preventing re-imports")
+		}).WithTimeout(30 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
+
+		// Release the hold so cleanup can proceed.
+		Eventually(func(g Gomega) {
+			if err := cl.Get(ctx, client.ObjectKeyFromObject(&cluster), &cluster); err != nil {
+				return
+			}
+			kept := []string{}
+			for _, f := range cluster.Finalizers {
+				if f != "test.turtles.cattle.io/hold" {
+					kept = append(kept, f)
+				}
+			}
+			cluster.Finalizers = kept
+			g.Expect(cl.Update(ctx, &cluster)).To(Succeed())
+		}).Should(Succeed())
+	})
+
 	It("should reconcile a CAPI cluster when rancher cluster doesn't exist and annotation is set on the namespace", func() {
 		Expect(cl.Create(ctx, capiCluster)).To(Succeed())
 		setControlPlaneReady(capiCluster)


### PR DESCRIPTION
<!-- kind/bug -->
**What this PR does / why we need it**:

`reconcileDelete` annotates the CAPI cluster with `imported=true` whenever the
`management.cattle.io/v3` cluster record is observed with a deletion timestamp,
regardless of whether the import ever completed. If a record is deleted while
the import is still settling and its finalization lasts long enough for a
reconcile to observe it, the annotation permanently disables the import: every
future reconcile is short-circuited, no new record is created and the agent is
never deployed. A deterministic reproduction with controller logs is in #2641.

With this change the annotation is only set when the record being removed had
reached the `AgentDeployed` or `Ready` condition. A record deleted mid-import
now results in a re-import on the next reconcile, while unimporting a cluster
whose import completed keeps preventing re-imports. ADR 0003 is amended
accordingly.

**Which issue(s) this PR fixes**:
Fixes #2641

**Special notes for your reviewer**:
- Behavior note: deleting a record whose import never completed used to stop
  the import for good; with this change Turtles recreates the record.
  Preventing the import for such a cluster can still be done by setting the
  `imported` annotation on the CAPI cluster manually.
- No e2e test: reproducing the race deterministically requires holding the
  record in deleting state at the exact reconcile window, which is what the
  added envtest cases do; a timing-based e2e would be flaky by construction.

**Checklist**:
- [x] squashed commits into logical changes
- [x] includes documentation
- [x] adds unit tests
