### PR TITLE
Add releaseChannel variable to GKE clusterclass, bump GKE to 1.35.7 and Rancher to 2.14.4-alpha1

### DIFF
--- a/examples/clusterclasses/gcp/gke/clusterclass-gke-example.yaml
+++ b/examples/clusterclasses/gcp/gke/clusterclass-gke-example.yaml
@@ -57,6 +57,12 @@ spec:
         openAPIV3Schema:
           description: "The GCP network name"
           type: string
+    - name: releaseChannel
+      required: false
+      schema:
+        openAPIV3Schema:
+          description: "Release channel to use for fetching Kubernetes version (default: regular)"
+          type: string
   patches:
     - name: project
       definitions:
@@ -118,6 +124,18 @@ spec:
               path: /spec/template/spec/network/name
               valueFrom:
                 variable: networkName
+    - name: releaseChannelControlPlane
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: GCPManagedControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/releaseChannel
+              valueFrom:
+                variable: releaseChannel
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: GCPManagedClusterTemplate

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -94,7 +94,7 @@ variables:
   # GCP Configuration
   # Images are self-built and need versioned kubernetes components. See docs/image-builder
   GCP_KUBERNETES_VERSION: "v1.34.1"
-  GCP_GKE_KUBERNETES_VERSION: "v1.35.0"
+  GCP_GKE_KUBERNETES_VERSION: "v1.35.7"
   GCP_MACHINE_TYPE: "n1-standard-2"
   GCP_REGION: "europe-west2"
   GCP_IMAGE_ID: "cluster-api-ubuntu-2404-v1-34-1-1762253907" # Private image. See docs/image-builder
@@ -106,7 +106,7 @@ variables:
   HELM_EXTRA_VALUES_FOLDER: "/tmp"
 
   # Rancher Configuration
-  RANCHER_VERSION: "v2.14.0-alpha13"
+  RANCHER_VERSION: "v2.14.4-alpha1"
   RANCHER_REPO_NAME: "rancher-alpha"
   RANCHER_PATH: "rancher-alpha/rancher"
   RANCHER_URL: "https://releases.rancher.com/server-charts/alpha"

--- a/test/e2e/data/cluster-templates/gcp-gke-topology.yaml
+++ b/test/e2e/data/cluster-templates/gcp-gke-topology.yaml
@@ -22,6 +22,8 @@ spec:
         value: ${GCP_REGION}
       - name: networkName
         value: ${GCP_NETWORK_NAME}
+      - name: releaseChannel
+        value: regular
     workers:
       machinePools:
         - class: default-system


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
This PR adds `releaseChannel` variable to GKE clusterclass to allow user to pass release channel which has recently become mandate, No Channel option has been deprecated.

This is a manual backport of #2766.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests - [Long E2E run focused on GKE](https://github.com/rancher/turtles/actions/runs/33721665912/job/100542358612) :green_circle: 
