### PR TITLE
[release/v0.27] chore: bump Go and providers chart versions

### DIFF
--- a/charts/rancher-turtles-providers/Chart.yaml
+++ b/charts/rancher-turtles-providers/Chart.yaml
@@ -3,8 +3,8 @@ name: rancher-turtles-providers
 description: This chart installs the Rancher Turtles certified providers.
 home: https://turtles.docs.rancher.com/turtles/stable/en/overview/certified.html
 icon: https://raw.githubusercontent.com/rancher/turtles/main/logos/capi.svg
-version: 0.27.1
-appVersion: "0.27.1"
+version: 0.27.2-rc.0
+appVersion: "0.27.2-rc.0"
 keywords:
   - rancher
   - cluster-api

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/examples
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/agnivade/levenshtein v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles
 
-go 1.26.6
+go 1.26.8
 
 ignore (
 	./hack/tools/krew

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/turtles/test
 
-go 1.26.6
+go 1.26.8
 
 replace github.com/rancher/turtles => ../
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Bump Go version to `1.26.8` and providers chart to `0.27.2-rc.0` ahead of cutting a new RC.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
