### PR TITLE
feat(chart): expose core CAPI controller replicas via Helm values

### DIFF
--- a/charts/rancher-turtles/templates/core-provider.yaml
+++ b/charts/rancher-turtles/templates/core-provider.yaml
@@ -35,18 +35,34 @@ spec:
     {{- else if index .Values "cluster-api-operator" "cluster-api" "core" "fetchConfig" "selector" }}
     selector: {{ index .Values "cluster-api-operator" "cluster-api" "core" "fetchConfig" "selector" | toYaml | nindent 6 }}
     {{- end }}
-{{- if or (index .Values "cluster-api-operator" "cluster-api" "core" "imageUrl") .Values.imagePullSecrets }}
+{{- $core := index .Values "cluster-api-operator" "cluster-api" "core" }}
+{{- if or $core.imageUrl $core.replicas $core.nodeSelector $core.tolerations $core.affinity .Values.imagePullSecrets }}
   deployment:
+{{- if hasKey $core "replicas" }}
+    replicas: {{ $core.replicas }}
+{{- end }}
 {{- if .Values.imagePullSecrets }}
     imagePullSecrets:
 {{- range .Values.imagePullSecrets }}
       - name: {{ . }}
 {{- end }}
 {{- end }}
-{{- if index .Values "cluster-api-operator" "cluster-api" "core" "imageUrl" }}
+{{- if $core.nodeSelector }}
+    nodeSelector:
+{{ toYaml $core.nodeSelector | nindent 6 }}
+{{- end }}
+{{- if $core.tolerations }}
+    tolerations:
+{{ toYaml $core.tolerations | nindent 6 }}
+{{- end }}
+{{- if $core.affinity }}
+    affinity:
+{{ toYaml $core.affinity | nindent 6 }}
+{{- end }}
+{{- if $core.imageUrl }}
     containers:
       - name: manager
-        imageUrl: {{ index .Values "cluster-api-operator" "cluster-api" "core" "imageUrl" }}
+        imageUrl: {{ $core.imageUrl }}
 {{- end }}
 {{- end }}
 ---

--- a/charts/rancher-turtles/values.schema.json
+++ b/charts/rancher-turtles/values.schema.json
@@ -133,6 +133,20 @@
                 "imageUrl": {
                   "type": "string"
                 },
+                "replicas": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "nodeSelector": {
+                  "type": "object",
+                  "additionalProperties": { "type": "string" }
+                },
+                "tolerations": {
+                  "type": "array"
+                },
+                "affinity": {
+                  "type": "object"
+                },
                 "fetchConfig": {
                   "type": "object",
                   "properties": {

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -73,6 +73,13 @@ cluster-api-operator:
       enableAutomaticUpdate: false
       # imageUrl: Custom image URL.
       imageUrl: ""
+      # replicas: Number of capi-controller-manager pods (CAPIProvider.spec.deployment.replicas).
+      # Increase for HA when nodes may be drained or recycled by automation. Defaults to 1.
+      replicas: 1
+      # Optional scheduling settings passed to CAPIProvider.spec.deployment.
+      # nodeSelector: {}
+      # tolerations: []
+      # affinity: {}
       # fetchConfig: Config fetching settings.
       fetchConfig:
         # url: Config fetch URL.


### PR DESCRIPTION
## Summary

- Expose `cluster-api-operator.cluster-api.core.replicas` in the Turtles Helm chart so the core `CAPIProvider` sets `spec.deployment.replicas` for `capi-controller-manager`.
- Optionally pass through `nodeSelector`, `tolerations`, and `affinity` to `CAPIProvider.spec.deployment`.
- Default remains `replicas: 1` (no behavior change for existing installs beyond explicitly setting the existing API default).

Fixes #2812

## Test plan

- [ ] `helm template` with default values renders `deployment.replicas: 1` on the core `CAPIProvider`
- [ ] `helm template --set cluster-api-operator.cluster-api.core.replicas=2` renders `replicas: 2`
- [ ] Upgrade/install with `replicas=2` results in `capi-controller-manager` Deployment with 2 ready pods and a single leader